### PR TITLE
Feat/option to specify url for dmss api

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -8,9 +8,14 @@ import {
 function App() {
   const dmssAPI = new DmssAPI('', 'http://localhost:8000')
 
-  dmssAPI.dataSourceGetAll().then((res) => {
-    console.log('data sources found: ', res)
-  })
+  dmssAPI
+    .dataSourceGetAll()
+    .then((res) => {
+      console.log('data sources found: ', res)
+    })
+    .catch((err) => {
+      console.error(err.message)
+    })
 
   return (
     <div

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -2,15 +2,15 @@ import {
   AccessControlList,
   BlueprintPicker,
   JsonView,
-    DmssAPI
+  DmssAPI,
 } from '@development-framework/dm-core'
 
 function App() {
-  const dmssAPI = new DmssAPI("", "http://localhost:8000")
+  const dmssAPI = new DmssAPI('', 'http://localhost:8000')
 
-    dmssAPI.dataSourceGetAll().then(res => {
-        console.log("data sources found: ", res)
-    })
+  dmssAPI.dataSourceGetAll().then((res) => {
+    console.log('data sources found: ', res)
+  })
 
   return (
     <div

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -2,9 +2,16 @@ import {
   AccessControlList,
   BlueprintPicker,
   JsonView,
+    DmssAPI
 } from '@development-framework/dm-core'
 
 function App() {
+  const dmssAPI = new DmssAPI("", "http://localhost:8000")
+
+    dmssAPI.dataSourceGetAll().then(res => {
+        console.log("data sources found: ", res)
+    })
+
   return (
     <div
       style={{

--- a/packages/dmt-core/src/services/api/DmssAPI.ts
+++ b/packages/dmt-core/src/services/api/DmssAPI.ts
@@ -4,7 +4,7 @@ export class DmssAPI extends DefaultApi {
   constructor(token: string, dmssBasePath?: string) {
     /*
       dmssBasePath is an optional parameter where you can specify the url for DMSS. Example: http://localhost:8000
-      (Note: a forward slash should not be included at the end of the url.
+      (Note: a forward slash should not be included at the end of the url)
     */
     const DMSSConfiguration = new Configuration({
       basePath: dmssBasePath || '/api/dmss',

--- a/packages/dmt-core/src/services/api/DmssAPI.ts
+++ b/packages/dmt-core/src/services/api/DmssAPI.ts
@@ -1,9 +1,13 @@
 import { Configuration, DefaultApi } from './configs/gen'
 
 export class DmssAPI extends DefaultApi {
-  constructor(token: string) {
+  constructor(token: string, dmssBasePath?: string) {
+    /*
+      dmssBasePath is an optional parameter where you can specify the url for DMSS. Example: http://localhost:8000
+      (Note: a forward slash should not be included at the end of the url.
+    */
     const DMSSConfiguration = new Configuration({
-      basePath: '/api/dmss',
+      basePath: dmssBasePath || '/api/dmss',
       accessToken: token,
     })
     super(DMSSConfiguration)


### PR DESCRIPTION
## What does this pull request change?
Add option to specify url for DMSS 
## Why is this pull request needed?
When not running in docker, the old DMSS url used did not work. We need to be able to specify url for DMSS.
## Issues related to this change
~closes https://github.com/orgs/equinor/projects/189/views/2~
- Closes equinor/data-modelling-tool#1411
