### PR TITLE
fix: build view-yaml bug

### DIFF
--- a/packages/yaml-view/package.json
+++ b/packages/yaml-view/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@development-framework/yaml-view",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "MIT",
   "files": [
     "dist",
@@ -27,8 +27,15 @@
     "@development-framework/dm-core": ">=1.0.5",
     "@types/styled-components": "^4.1.18"
   },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
+    "prebuild": "rm -rf dist && yarn install",
     "build": "tsc",
-    "postbuild": "cp src/index.css dist/index.css"
+    "postbuild": "cp package.json ./dist/ && cp src/index.css ./dist/ &&  rm -rf node_modules"
   }
 }

--- a/packages/yaml-view/tsconfig.json
+++ b/packages/yaml-view/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": ["dom", "dom.iterable", "commonjs"],
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
@@ -18,7 +18,7 @@
     "skipLibCheck": true,
     "jsx": "react",
     "esModuleInterop": true,
-    "module": "esnext",
+    "module": "commonjs",
     "moduleResolution": "node",
     "target": "es2022",
     "composite": false,

--- a/packages/yaml-view/tsconfig.json
+++ b/packages/yaml-view/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",
-    "lib": ["dom", "dom.iterable", "commonjs"],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,

--- a/packages/yaml-view/tsconfig.json
+++ b/packages/yaml-view/tsconfig.json
@@ -1,6 +1,29 @@
 {
-  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist"
-  }
+    "outDir": "dist",
+    "rootDir": "src",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": false,
+    "downlevelIteration": true,
+    "baseUrl": ".",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "allowJs": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "jsx": "react",
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "target": "es2022",
+    "composite": false,
+    "useUnknownInCatchVariables": false
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## What does this pull request change?
fix build error with view-yaml package
## Why is this pull request needed?
error with using the view-yaml when installing from npm/yarn - just get an error saying yaml plugin crashed. (found when trying to use the package in analysis portal)
## Issues related to this change

