### PR TITLE
fix: use dmssAPI instead of dmtAPI in create new entity button

### DIFF
--- a/packages/dmt-core/package.json
+++ b/packages/dmt-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@development-framework/dm-core",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "license": "MIT",
   "peerDependencies": {
     "react-router-dom": ">=5.1.2",

--- a/packages/dmt-core/src/components/NewEntityButton.tsx
+++ b/packages/dmt-core/src/components/NewEntityButton.tsx
@@ -14,7 +14,7 @@ import styled from 'styled-components'
 import { AuthContext } from 'react-oauth2-code-pkce'
 import { TReference } from '../types'
 import { INPUT_FIELD_WIDTH } from '../utils/variables'
-import { DmtAPI } from '../services'
+import DmssAPI from '../services/api/DmssAPI'
 
 const DialogWrapper = styled.div`
   display: flex;
@@ -44,7 +44,7 @@ export function NewEntityButton(props: {
   const [typeToCreate, setTypeToCreate] = useState<string>(type || '')
   const [loading, setLoading] = useState<boolean>(false)
   const { token } = useContext(AuthContext)
-  const dmtAPI = new DmtAPI(token)
+  const dmssAPI = new DmssAPI(token)
 
   useEffect(() => setTypeToCreate(type || ''), [type])
   useEffect(() => {
@@ -164,7 +164,7 @@ export function NewEntityButton(props: {
                       setLoading(false)
                     })
                 } else {
-                  dmtAPI
+                  dmssAPI
                     .instantiateEntity({
                       basicEntity: {
                         name: newName as string,


### PR DESCRIPTION
## What does this pull request change?
use dmssAPI in create newEntityButton instead of dmtAPI, since dmtAPI has been removed
## Why is this pull request needed?
add required functionality to the newEntityButton to make Analysis platform wok
## Issues related to this change


