### PR TITLE
fix: add type to document in useDocument

### DIFF
--- a/packages/dm-core/package.json
+++ b/packages/dm-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@development-framework/dm-core",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "license": "MIT",
   "peerDependencies": {
     "react-router-dom": ">=5.1.2",

--- a/packages/dm-core/src/hooks/useDocument.tsx
+++ b/packages/dm-core/src/hooks/useDocument.tsx
@@ -40,7 +40,7 @@ export function useDocument<T>(
   idReference: string,
   depth?: number | undefined
 ): [
-  any | null,
+  T | null,
   boolean,
   (newDocument: T, notify: boolean) => void,
   AxiosError<any> | null


### PR DESCRIPTION
## What does this pull request change?
add correct type to document returned from useDocument
## Why is this pull request needed?
add type hinting for developer
## Issues related to this change

part of #28 