### PR TITLE
Fix: replace deprecated output definition

### DIFF
--- a/.github/workflows/on-main-push.yaml
+++ b/.github/workflows/on-main-push.yaml
@@ -25,14 +25,14 @@ jobs:
       - name: Check if new version
         id: check-version
         run: |
-          echo '::set-output name=NEW_VERSION::false'
+          echo "NEW_VERSION=false" >> $GITHUB_OUTPUT
           cd packages/${{ matrix.package }}
           PACKAGE_VERSION=$(cat package.json | jq '.["version"]' | tr -d '"')
           PACKAGE_NAME=$(cat package.json | jq '.["name"]' | tr -d '"')
 
           VERSION_EXISTS=$(curl --HEAD --output /dev/null --silent -w "%{http_code}" https://registry.npmjs.org/$PACKAGE_NAME/$PACKAGE_VERSION)
           if [[ $VERSION_EXISTS == 404 ]]; then
-            echo '::set-output name=NEW_VERSION::true'
+            echo "NEW_VERSION=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Create package distribution and publish


### PR DESCRIPTION
## What does this pull request change?
The `set-output` command in the GitHub Actions workflows, [is about to become deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

## Why is this pull request needed?
To change from the 
```sh
echo "::set-output name=tag-ref::TAG_REF"
```
to the new
```sh
echo "tag-ref=$TAG_REF" >> $GITHUB_OUTPUT
```
stanza

## Issues related to this change

