### PR TITLE
fix: handle entity name when using DMSS' instantiateEntity endpoint in newEntityButton

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -9,7 +9,7 @@ import {
   UIPluginSelector,
   NewEntityButton,
 } from '@development-framework/dm-core'
-import { useContext } from 'react'
+import { useContext, useState } from 'react'
 import { Jobs } from './test_components/Jobs'
 
 function App() {
@@ -18,6 +18,7 @@ function App() {
   const { treeNodes, loading } = useContext(FSTreeContext)
 
   const dataSources = useDataSources(dmssAPI)
+  const [createdEntity, setCreatedEntity] = useState({})
 
   return (
     <div
@@ -64,10 +65,16 @@ function App() {
               idReference: `DemoDataSource/${createdEntity._id}`,
             })
             .then((response) => {
-              console.log('got data', response.data)
+              setCreatedEntity(response.data)
             })
         }
       />
+      {Object.entries(createdEntity).length !== 0 && (
+        <>
+          <h2>Created entity:</h2>
+          <JsonView data={createdEntity} />
+        </>
+      )}
     </div>
   )
 }

--- a/packages/dm-core/package.json
+++ b/packages/dm-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@development-framework/dm-core",
-  "version": "1.0.30",
+  "version": "1.0.31",
   "license": "MIT",
   "peerDependencies": {
     "react-router-dom": ">=5.1.2",

--- a/packages/dm-core/src/components/NewEntityButton.tsx
+++ b/packages/dm-core/src/components/NewEntityButton.tsx
@@ -165,14 +165,16 @@ export function NewEntityButton(props: {
                   dmssAPI
                     .instantiateEntity({
                       basicEntity: {
-                        name: newName as string,
                         type: typeToCreate,
                       },
                     })
-                    .then((newEntity) => {
-                      addEntityToPath({ ...newEntity.data }).then(() =>
-                        setShowScrim(false)
-                      )
+                    .then((response) => {
+                      const newEntity = response.data
+                      // instantiateEntity from DMSS will not populate the name, therefore the name has to be added manually.
+                      addEntityToPath({
+                        ...newEntity,
+                        name: newName as string,
+                      }).then(() => setShowScrim(false))
                     })
                     .finally(() => {
                       setLoading(false)


### PR DESCRIPTION

## What does this pull request change?
update NewEntityButton to manually add the name from user in the created entity.
The DMSS endpoint for instantiating an entity does not include a name in the returned entity.

## Why is this pull request needed?

## Issues related to this change

