### PR TITLE
refactor: tabs 2.0

### DIFF
--- a/example/app/data/DemoDataSource/DemoPackage/BlueprintWithComplexChildren.json
+++ b/example/app/data/DemoDataSource/DemoPackage/BlueprintWithComplexChildren.json
@@ -1,0 +1,34 @@
+{
+  "type": "CORE:Blueprint",
+  "name": "BlueprintWithComplexChildren",
+  "attributes": [
+    {
+      "attributeType": "BlueprintWithComplexChildren",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "name": "firstAttribute",
+      "contained": true,
+      "optional": true
+    },
+    {
+      "attributeType": "BlueprintWithComplexChildren",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "name": "secondAttribute",
+      "contained": true,
+      "optional": true
+    },
+    {
+      "attributeType": "BlueprintWithComplexChildren",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "name": "thirdAttribute",
+      "contained": true,
+      "optional": true
+    },
+    {
+      "attributeType": "string",
+      "type": "string",
+      "name": "aStringValue",
+      "contained": true,
+      "optional": true
+    }
+  ]
+}

--- a/example/app/data/DemoDataSource/DemoPackage/TabsPluginConfig.json
+++ b/example/app/data/DemoDataSource/DemoPackage/TabsPluginConfig.json
@@ -1,0 +1,22 @@
+{
+  "type": "dmss://system/SIMOS/Blueprint",
+  "name": "TabsPluginConfig",
+  "attributes": [
+    {
+      "attributeType": "boolean",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "name": "addChildTabsOnRender",
+      "contained": true,
+      "optional": true,
+      "default": false
+    },
+    {
+      "attributeType": "string",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "name": "homeRecipe",
+      "contained": true,
+      "optional": true,
+      "default": false
+    }
+  ]
+}

--- a/example/app/data/DemoDataSource/DemoPackage/UiPluginSelectorConfig.json
+++ b/example/app/data/DemoDataSource/DemoPackage/UiPluginSelectorConfig.json
@@ -1,0 +1,15 @@
+{
+  "type": "dmss://system/SIMOS/Blueprint",
+  "name": "UiPluginSelectorConfig",
+  "attributes": [
+    {
+      "attributeType": "string",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "name": "recipes",
+      "dimensions": "*",
+      "contained": true,
+      "optional": true,
+      "default": false
+    }
+  ]
+}

--- a/example/app/data/DemoDataSource/DemoPackage/complexEntity.json
+++ b/example/app/data/DemoDataSource/DemoPackage/complexEntity.json
@@ -1,0 +1,31 @@
+{
+  "_id": "g6282220-4a90-4d02-8f34-b82255fc91d5",
+  "type": "BlueprintWithComplexChildren",
+  "name": "complexEntity",
+  "firstAttribute": {
+    "type": "BlueprintWithComplexChildren",
+    "firstAttribute": {
+      "type": "BlueprintWithComplexChildren"
+    }
+  },
+  "secondAttribute": {
+    "type": "BlueprintWithComplexChildren"
+  },
+  "thirdAttribute": {
+    "type": "BlueprintWithComplexChildren",
+    "firstAttribute": {
+      "type": "BlueprintWithComplexChildren",
+      "firstAttribute": {
+        "type": "BlueprintWithComplexChildren",
+        "aStringValue": "Something here"
+      }
+    },
+    "secondAttribute": {
+      "type": "BlueprintWithComplexChildren"
+    },
+    "thirdAttribute": {
+      "type": "BlueprintWithComplexChildren",
+      "aStringValue": "Hallo World!"
+    }
+  }
+}

--- a/example/app/data/DemoDataSource/DemoPackage/recipe_links/complex_blueprint.json
+++ b/example/app/data/DemoDataSource/DemoPackage/recipe_links/complex_blueprint.json
@@ -1,0 +1,37 @@
+{
+  "type": "CORE:RecipeLink",
+  "_blueprintPath_": "BlueprintWithComplexChildren",
+  "initialUiRecipe": {
+    "name": "Tabs",
+    "type": "CORE:UiRecipe",
+    "plugin": "tabs",
+    "config": {
+      "type": "TabsPluginConfig",
+      "childTabsOnRender": true,
+      "homeRecipe": "home"
+    }
+  },
+  "uiRecipes": [
+    {
+      "type": "CORE:UiRecipe",
+      "name": "home",
+      "plugin": "UiPluginSelector",
+      "config": {
+        "type": "UiPluginSelectorConfig",
+        "recipes": ["Yaml", "Edit"]
+      }
+    },
+    {
+      "name": "Yaml",
+      "type": "CORE:UiRecipe",
+      "plugin": "yaml-view",
+      "category": "container"
+    },
+    {
+      "type": "CORE:UiRecipe",
+      "name": "Edit",
+      "description": "Default edit",
+      "plugin": "form"
+    }
+  ]
+}

--- a/example/package.json
+++ b/example/package.json
@@ -7,6 +7,7 @@
     "@development-framework/blueprint": "link:../packages/blueprint",
     "@development-framework/yaml-view": "link:../packages/yaml-view",
     "@development-framework/default-pdf": "link:../packages/default-pdf",
+    "@development-framework/tabs": "^1.0.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "5.3.4",

--- a/example/src/plugins.js
+++ b/example/src/plugins.js
@@ -2,4 +2,5 @@ export default [
   import('@development-framework/yaml-view'),
   import('@development-framework/blueprint'),
   import('@development-framework/default-pdf'),
+  import('@development-framework/tabs'),
 ]

--- a/packages/tabs/README.md
+++ b/packages/tabs/README.md
@@ -1,0 +1,10 @@
+# Data Modelling Framework - UiPlugin - TabsView
+
+The `tabs` plugin allows you to browse deeply nested, complex objects in a practical manner by opening complex children in a new tab.
+
+Add the package to your project with `npm add @development-framework/tabs`.
+
+If you want to specify a config object in some UiRecipe-entity, the Blueprint is included in the npm package.
+
+Copy it like so: `cp -R node_modules/@development-framework/tabs/dist/blueprint ./myApplicationBlueprints/`
+

--- a/packages/tabs/blueprints/TabsPluginConfig.json
+++ b/packages/tabs/blueprints/TabsPluginConfig.json
@@ -1,0 +1,21 @@
+{
+  "type": "dmss://system/SIMOS/Blueprint",
+  "name": "TabsPluginConfig",
+  "attributes": [
+    {
+      "attributeType": "boolean",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "name": "childTabsOnRender",
+      "contained": true,
+      "optional": true,
+      "default": false
+    },
+    {
+      "attributeType": "string",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "name": "homeRecipe",
+      "contained": true,
+      "optional": true
+    }
+  ]
+}

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -1,21 +1,21 @@
 {
   "name": "@development-framework/tabs",
   "license": "MIT",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "dependencies": {
     "@equinor/eds-core-react": "^0.20.0",
     "@equinor/eds-icons": "^0.12.0",
-    "@equinor/eds-tokens": "^0.7.0"
+    "@equinor/eds-tokens": "^0.7.0",
+    "@development-framework/dm-core": ">=1.0.35"
   },
   "devDependencies": {
     "@types/react": "^17.0.39",
     "@types/styled-components": "^4.1.18",
-    "typescript": "^4.5.5",
-    "@development-framework/dm-core": ">=1.0.25"
+    "typescript": "^4.5.5"
   },
   "peerDependencies": {
-    "@development-framework/dm-core": ">=1.0.25",
-    "react": ">=17.0.2"
+    "react": ">=17.0.2",
+    "@development-framework/dm-core": ">=1.0.35"
   },
   "files": [
     "dist",
@@ -27,6 +27,6 @@
   "scripts": {
     "prebuild": "rm -rf dist && yarn install",
     "build": "tsc",
-    "postbuild": "cp package.json ./dist/ && rm -rf node_modules"
+    "postbuild": "cp -R blueprints package.json ./dist/ && rm -rf node_modules"
   }
 }


### PR DESCRIPTION
## What does this pull request change?
- Tabs plugin now uses the "UiRecipeSelector", allowing it to render "initialRecipes"
-  Adds a "TabsPluginConfig"-blueprint. Allow for configuring auto rendering of tabs and specifying plugin for 'home tab'
- Adds a complex test entity in the example project

## Why is this pull request needed?
- Should be possible to use "Tabs" as an "initialRecipe"

## Issues related to this change
closes #56 
