### PR TITLE
refactor(dm-core): update builtin plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 dist
 yarn.lock
 package-lock.json
+yarn-error.log

--- a/packages/dm-core/package.json
+++ b/packages/dm-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@development-framework/dm-core",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "license": "MIT",
   "peerDependencies": {
     "react-router-dom": ">=5.1.2",

--- a/packages/dm-core/src/components/UiRecipesSelector.tsx
+++ b/packages/dm-core/src/components/UiRecipesSelector.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components'
 import { CircularProgress } from '@equinor/eds-core-react'
 import { useBlueprint } from '../hooks'
 import { UIPluginSelector } from './UiPluginSelector'
-import { UiRecipesSideBarSelector } from './UiRecipesSideBarSelector'
 import { UiPluginContext } from '../context/UiPluginContext'
 import { IUIPlugin } from '../types'
 
@@ -27,24 +26,13 @@ export function UIRecipesSelector(props: IUIPlugin): JSX.Element {
   useEffect(() => {
     // Make sure uiRecipes has been loaded
     if (isBlueprintLoading || isContextLoading) return
-    let component
 
     if (!initialUiRecipe) {
       setInitialPlugin({ component: UIPluginSelector })
       return
     }
 
-    switch (initialUiRecipe.plugin) {
-      case 'UiPluginSelector':
-        component = UIPluginSelector
-        break
-      case 'UiRecipesSideBarSelector':
-        component = UiRecipesSideBarSelector
-        break
-      default:
-        component = getUiPlugin(initialUiRecipe.plugin).component
-    }
-    setInitialPlugin({ component: component })
+    setInitialPlugin({ component: getUiPlugin(initialUiRecipe.plugin) })
   }, [initialUiRecipe, isBlueprintLoading, isContextLoading])
 
   if (isBlueprintLoading || isContextLoading)

--- a/packages/dm-core/src/components/UiRecipesSideBarSelector.tsx
+++ b/packages/dm-core/src/components/UiRecipesSideBarSelector.tsx
@@ -46,7 +46,7 @@ type TSelectablePlugins = {
 }
 
 export function UiRecipesSideBarSelector(props: IUIPlugin): JSX.Element {
-  const { idReference, categories, onSubmit, onOpen, type } = props
+  const { idReference, onSubmit, onOpen, type } = props
   const { loading: isContextLoading, getUiPlugin } = useContext(UiPluginContext)
   const { uiRecipes, isLoading: isBlueprintLoading } = useBlueprint(type)
   const [selectedRecipe, setSelectedRecipe] = useState<number>(0)
@@ -61,7 +61,7 @@ export function UiRecipesSideBarSelector(props: IUIPlugin): JSX.Element {
       (uiRecipe: any): TSelectablePlugins => ({
         name:
           uiRecipe?.label || uiRecipe?.name || uiRecipe?.plugin || 'No name',
-        component: getUiPlugin(uiRecipe?.plugin).component,
+        component: getUiPlugin(uiRecipe?.plugin),
         config: uiRecipe?.config,
       })
     )
@@ -110,7 +110,6 @@ export function UiRecipesSideBarSelector(props: IUIPlugin): JSX.Element {
           type={type}
           onSubmit={onSubmit}
           onOpen={onOpen}
-          categories={categories}
           config={selectableRecipes[selectedRecipe].config}
         />
       </ErrorBoundary>

--- a/packages/dm-core/src/types.ts
+++ b/packages/dm-core/src/types.ts
@@ -132,16 +132,21 @@ export type TValidEntity = {
 export interface IUIPlugin {
   type: string
   idReference: string
-  categories?: string[]
   onSubmit?: (data: any) => void
   onOpen?: (data: any) => void
   config?: any
-  readOnly?: boolean
+}
+
+export type TUiRecipe = {
+  type: string
+  name: string
+  plugin: string
+  roles?: string[]
 }
 
 export type TPlugin = {
   pluginName: string
-  pluginType: EPluginType
+  pluginType?: EPluginType
   component: (props: IUIPlugin) => JSX.Element
 }
 

--- a/packages/tabs/src/TabsContainer.tsx
+++ b/packages/tabs/src/TabsContainer.tsx
@@ -50,7 +50,6 @@ type TStringMap = {
 
 export const TabsContainer = (props: IUIPlugin) => {
   const { idReference, config, onSubmit } = props
-  const [dataSourceId, documentId] = idReference.split('/', 2)
   const [selectedTab, setSelectedTab] = useState<string>('home')
   const [formData, setFormData] = useState<TGenericObject>({})
   const [childTabs, setChildTabs] = useState<TStringMap>({})
@@ -61,7 +60,7 @@ export const TabsContainer = (props: IUIPlugin) => {
     setFormData({ ...entity })
   }, [entity])
 
-  if (!entity || Object.keys(formData).length === 0) return null
+  if (!entity || Object.keys(formData).length === 0) return <></>
 
   const handleOpen = (tabData: TChildTab) => {
     setChildTabs({ ...childTabs, [tabData.attribute]: tabData })
@@ -108,7 +107,7 @@ export const TabsContainer = (props: IUIPlugin) => {
         <HidableWrapper hidden={'home' !== selectedTab}>
           <UIPluginSelector
             key={'home'}
-            absoluteDottedId={`${dataSourceId}/${documentId}`}
+            idReference={idReference}
             type={formData.type}
             categories={config?.subCategories?.filter(
               (c: string) => c !== 'container'
@@ -132,7 +131,7 @@ export const TabsContainer = (props: IUIPlugin) => {
               hidden={childTab.attribute !== selectedTab}
             >
               <UIPluginSelector
-                absoluteDottedId={childTab.absoluteDottedId}
+                idReference={childTab.absoluteDottedId}
                 type={childTab.entity.type}
                 categories={childTab.categories}
                 onSubmit={(data: TChildTab) => {


### PR DESCRIPTION
## What does this pull request change?
- Remove the "category" prop from "IUIPlugin"
-  Adds a config type for "UiPluginSelector" - allowing to specify a list of recipes to present for selection
- UiPluginSelector now has the common "IUIPlugin"-interface
- UiPluginContext
  - Removed "getPagePlugin"
  - Adds builtin plugins to list of loaded plugins
  -  "getUiPlugin" now returns "() => JSX.Element" instead of an object

## Why is this pull request needed?
- Should be possible to use "Tabs" as an "initialRecipe"

## Issues related to this change
needed for #55 