### PR TITLE
refactor: Standardize build scripts

### DIFF
--- a/packages/blueprint/package.json
+++ b/packages/blueprint/package.json
@@ -19,8 +19,8 @@
     "styled-components": ">=5.3.6"
   },
   "scripts": {
-    "prebuild": "rm -rf dist && yarn install",
+    "prebuild": "rm -rf dist",
     "build": "tsc",
-    "postbuild": "cp package.json ./dist/ && rm -rf node_modules"
+    "postbuild": "rm -rf node_modules"
   }
 }

--- a/packages/default-pdf/package.json
+++ b/packages/default-pdf/package.json
@@ -15,6 +15,8 @@
     "styled-components": ">=5.3.6"
   },
   "scripts": {
-    "build": "tsc"
+    "prebuild": "rm -rf dist",
+    "build": "tsc",
+    "postbuild": "rm -rf node_modules"
   }
 }

--- a/packages/default-preview/package.json
+++ b/packages/default-preview/package.json
@@ -14,6 +14,8 @@
     "@development-framework/dm-core": ">=1.0.25"
   },
   "scripts": {
-    "build": "tsc"
+    "prebuild": "rm -rf dist",
+    "build": "tsc",
+    "postbuild": "rm -rf node_modules"
   }
 }

--- a/packages/dm-core/package.json
+++ b/packages/dm-core/package.json
@@ -47,9 +47,9 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "prebuild": "rm -rf dist && yarn install",
+    "prebuild": "rm -rf dist",
     "build": "tsc",
-    "postbuild": "cp package.json ./dist/ && rm -rf node_modules",
+    "postbuild": "rm -rf node_modules",
     "test": "jest test"
   }
 }

--- a/packages/explorer/package.json
+++ b/packages/explorer/package.json
@@ -28,9 +28,9 @@
     "styled-components": ">=5.3.6"
   },
   "scripts": {
-    "prebuild": "rm -rf dist && yarn install",
+    "prebuild": "rm -rf dist",
     "copy-css-file": "cp src/components/context-menu/react-contextmenu.css  dist/components/context-menu/react-contextmenu.css",
     "build": "tsc && yarn copy-css-file",
-    "postbuild": "cp package.json ./dist/ && rm -rf node_modules"
+    "postbuild": "rm -rf node_modules"
   }
 }

--- a/packages/form/README.md
+++ b/packages/form/README.md
@@ -8,7 +8,7 @@ Add the package to your project with `npm add @development-framework/form`.
 
 If you want to specify a config object in some UiRecipe-entity, the Blueprint is included in the npm package.
 
-Copy it like so: `cp -R node_modules/@development-framework/form/dist/blueprint ./myApplicationBlueprints/`
+Copy it like so: `cp -R node_modules/@development-framework/form/blueprints ./myApplicationBlueprints/`
 
 Alternative is to just import it directly without copying: `dm pkg import node_modules/@development-framework/form/dist/blueprints/ DemoDataSource``
 

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -4,14 +4,15 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
+    "blueprints",
     "dist",
     "src",
     "tsconfig.json"
   ],
   "scripts": {
-    "prebuild": "rm -rf dist && yarn install",
+    "prebuild": "rm -rf dist",
     "build": "tsc",
-    "postbuild": "cp package.json ./dist/ &&  rm -rf node_modules",
+    "postbuild": "rm -rf node_modules",
     "test": "jest test",
     "test-watch": "jest test --watchAll"
   },

--- a/packages/header/package.json
+++ b/packages/header/package.json
@@ -25,8 +25,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "prebuild": "rm -rf dist && yarn install",
+    "prebuild": "rm -rf dist",
     "build": "tsc",
-    "postbuild": "cp -R package.json README.md ./dist/ && rm -rf node_modules"
+    "postbuild": "rm -rf node_modules"
   }
 }

--- a/packages/job/package.json
+++ b/packages/job/package.json
@@ -14,6 +14,8 @@
     "@development-framework/dm-core": ">=1.0.25"
   },
   "scripts": {
-    "build": "tsc"
+    "prebuild": "rm -rf dist",
+    "build": "tsc",
+    "postbuild": "rm -rf node_modules"
   }
 }

--- a/packages/mermaid/package.json
+++ b/packages/mermaid/package.json
@@ -15,6 +15,8 @@
     "react": ">=17.0.2"
   },
   "scripts": {
-    "build": "tsc"
+    "prebuild": "rm -rf dist",
+    "build": "tsc",
+    "postbuild": "rm -rf node_modules"
   }
 }

--- a/packages/tabs/README.md
+++ b/packages/tabs/README.md
@@ -6,5 +6,5 @@ Add the package to your project with `npm add @development-framework/tabs`.
 
 If you want to specify a config object in some UiRecipe-entity, the Blueprint is included in the npm package.
 
-Copy it like so: `cp -R node_modules/@development-framework/tabs/dist/blueprint ./myApplicationBlueprints/`
+Copy it like so: `cp -R node_modules/@development-framework/tabs/blueprints ./myApplicationBlueprints/`
 

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -18,6 +18,7 @@
     "@development-framework/dm-core": ">=1.0.35"
   },
   "files": [
+    "blueprints",
     "dist",
     "src",
     "tsconfig.json"
@@ -25,8 +26,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "prebuild": "rm -rf dist && yarn install",
+    "prebuild": "rm -rf dist",
     "build": "tsc",
-    "postbuild": "cp -R blueprints package.json README.md ./dist/ && rm -rf node_modules"
+    "postbuild": "rm -rf node_modules"
   }
 }

--- a/packages/yaml-view/package.json
+++ b/packages/yaml-view/package.json
@@ -2,11 +2,6 @@
   "name": "@development-framework/yaml-view",
   "version": "1.0.4",
   "license": "MIT",
-  "files": [
-    "dist",
-    "package.json",
-    "README.md"
-  ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
@@ -28,8 +23,8 @@
     "@types/styled-components": "^4.1.18"
   },
   "scripts": {
-    "prebuild": "rm -rf dist && yarn install",
-    "build": "tsc",
-    "postbuild": "cp package.json ./dist/ && cp src/index.css ./dist/ &&  rm -rf node_modules"
+    "prebuild": "rm -rf dist",
+    "build": "tsc && cp src/index.css ./dist/",
+    "postbuild": "rm -rf node_modules"
   }
 }


### PR DESCRIPTION
## What does this pull request change?

Standardizes the build scripts between packages
Ensures blueprints are uploaded to npm

## Why is this pull request needed?

## Issues related to this change

