### PR TITLE
fix(core): create blueprint with name

### DIFF
--- a/packages/dm-core/package.json
+++ b/packages/dm-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@development-framework/dm-core",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "license": "MIT",
   "peerDependencies": {
     "react-router-dom": ">=5.1.2",

--- a/packages/dm-core/src/domain/Tree.tsx
+++ b/packages/dm-core/src/domain/Tree.tsx
@@ -283,7 +283,7 @@ export class TreeNode {
     const response = await this.tree.dmssApi.instantiateEntity({
       basicEntity: { name: name, type: type },
     })
-    const newEntity = response.data
+    const newEntity = { ...response.data, name: name }
     const createResponse: AxiosResponse<any> = await this.tree.dmssApi.documentAdd(
       {
         absoluteRef: `${this.nodeId}${packageContent}`,


### PR DESCRIPTION
## What does this pull request change?
- Add the user provided name of the blueprint before saving it

## Why is this pull request needed?
The "Create blueprint" dialog asks to provide a name. So it should be put in the new blueprint entity.

## Issues related to this change
closes #74 
