### PR TITLE
fix(explorer): use initialRecipe renderer

### DIFF
--- a/packages/explorer/package.json
+++ b/packages/explorer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@development-framework/explorer",
   "license": "MIT",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "dist/index.js",
   "dependencies": {
     "@equinor/eds-core-react": "^0.20.0",

--- a/packages/explorer/src/Editor.tsx
+++ b/packages/explorer/src/Editor.tsx
@@ -12,7 +12,7 @@ import {
   FSTreeContext,
   TreeNode,
   TreeView,
-  UIPluginSelector,
+  UIRecipesSelector,
 } from '@development-framework/dm-core'
 import { NodeRightClickMenu } from './components/context-menu/ContextMenu'
 
@@ -96,7 +96,7 @@ export default () => {
           registerComponents={(myLayout: any) => {
             myLayout.registerComponent(
               ELayoutComponents.blueprint,
-              wrapComponent(UIPluginSelector)
+              wrapComponent(UIRecipesSelector)
             )
             layout.operations.registerLayout({
               myLayout,


### PR DESCRIPTION
## What does this pull request change?

- use UIRecipeSelector instead of UIPluginSelector

## Why is this pull request needed?

Explorer should render initialRecipes

## Issues related to this change
closes #76 

