### PR TITLE
Feat/select recipes in header plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ yarn.lock
 package-lock.json
 yarn-error.log
 .tool-versions
+
+.venv

--- a/example/app/data/DemoDataSource/DemoPackage/HeaderPluginConfig.json
+++ b/example/app/data/DemoDataSource/DemoPackage/HeaderPluginConfig.json
@@ -1,0 +1,24 @@
+{
+  "type": "dmss://system/SIMOS/Blueprint",
+  "name": "HeaderPluginConfig",
+  "attributes": [
+    {
+      "attributeType": "boolean",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "name": "hideAbout",
+      "default": false
+    },
+    {
+      "attributeType": "boolean",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "name": "hideUserInfo",
+      "default": false
+    },
+    {
+      "attributeType": "string",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "dimensions": "*",
+      "name": "uiRecipesList"
+    }
+  ]
+}

--- a/example/app/data/DemoDataSource/DemoPackage/recipe_links/example_application.json
+++ b/example/app/data/DemoDataSource/DemoPackage/recipe_links/example_application.json
@@ -4,7 +4,13 @@
   "initialUiRecipe": {
     "name": "Header",
     "type": "CORE:UiRecipe",
-    "plugin": "header"
+    "plugin": "header",
+    "config": {
+      "uiRecipesList": ["Yaml", "Explorer"],
+      "type": "HeaderPluginConfig",
+      "hideAbout": false,
+      "hideUserInfo": false
+    }
   },
   "uiRecipes": [
     {
@@ -18,6 +24,11 @@
       "name": "Edit",
       "description": "Default edit",
       "plugin": "form"
+    },
+    {
+      "name": "Explorer",
+      "type": "CORE:UiRecipe",
+      "plugin": "explorer"
     }
   ]
 }

--- a/packages/header/README.md
+++ b/packages/header/README.md
@@ -1,6 +1,7 @@
 # Data Modelling Framework - UiPlugin - Header
 
-The `header` plugin is meant to be used as a web application header. Providing user information, application information, and an application recipe selector.
+The `header` plugin is meant to be used as a web application header. Providing user information, application
+information, and an application recipe selector. Below the header, another UI plugin is displayed.
 
 Add the package to your project with `npm add @development-framework/header`.
 
@@ -8,3 +9,12 @@ If you want to specify a config object in some UiRecipe-entity, the Blueprint is
 
 Copy it like so: `cp -R node_modules/@development-framework/header/dist/blueprint ./myApplicationBlueprints/`
 
+# Config
+
+The Header plugin can accept a config of type `HeaderPluginConfig` (see `blueprints/HeaderPluginConfig.json`).
+Explanation of the attributes:
+
+* `uiRecipesList`: Can be used to specify a list of UI recipes the user can select. By default, the fist UI recipe in
+  the list is displayed. If the list is empty, all UI recipes will be included.
+* `hideAbout`: Is a boolean value that determines if the About button in the header is activated
+* `hideUserInfo`: Is a boolean value that determines if the User info button in the header is activated

--- a/packages/header/blueprints/HeaderPluginConfig.json
+++ b/packages/header/blueprints/HeaderPluginConfig.json
@@ -1,0 +1,24 @@
+{
+  "type": "dmss://system/SIMOS/Blueprint",
+  "name": "HeaderPluginConfig",
+  "attributes": [
+    {
+      "attributeType": "boolean",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "name": "hideAbout",
+      "default": false
+    },
+    {
+      "attributeType": "boolean",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "name": "hideUserInfo",
+      "default": false
+    },
+    {
+      "attributeType": "string",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "dimensions": "*",
+      "name": "uiRecipesList"
+    }
+  ]
+}

--- a/packages/header/package.json
+++ b/packages/header/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@development-framework/header",
   "license": "MIT",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "dependencies": {
     "@development-framework/dm-core": ">=1.0.35",
     "@equinor/eds-core-react": "^0.28.0",

--- a/packages/header/package.json
+++ b/packages/header/package.json
@@ -3,7 +3,6 @@
   "license": "MIT",
   "version": "1.0.1",
   "dependencies": {
-    "@development-framework/dm-core": ">=1.0.35",
     "@equinor/eds-core-react": "^0.28.0",
     "@equinor/eds-icons": "^0.18.0",
     "@equinor/eds-tokens": "^0.9.0"
@@ -11,10 +10,11 @@
   "devDependencies": {
     "@types/react": "^17.0.39",
     "@types/styled-components": "^5.1.26",
+    "@development-framework/dm-core": ">=1.0.37",
     "typescript": "^4.9.5"
   },
   "peerDependencies": {
-    "@development-framework/dm-core": ">=1.0.35",
+    "@development-framework/dm-core": ">=1.0.38",
     "react": ">=17.0.2"
   },
   "files": [

--- a/packages/header/src/Header.tsx
+++ b/packages/header/src/Header.tsx
@@ -1,21 +1,14 @@
-import {
-  Button,
-  Dialog,
-  DmssAPI,
-  IUIPlugin,
-  Loading,
-  useDocument,
-} from '@development-framework/dm-core'
-import React, { useContext, useState } from 'react'
+import { IUIPlugin, Loading, useDocument } from '@development-framework/dm-core'
+import React, { useState } from 'react'
 import styled from 'styled-components'
-import { Icon, Radio, TopBar } from '@equinor/eds-core-react'
+import { Icon, TopBar } from '@equinor/eds-core-react'
 
 // @ts-ignore
 import { NotificationManager } from 'react-notifications'
-import { AxiosResponse } from 'axios'
-import { AuthContext } from 'react-oauth2-code-pkce'
-import { useLocalStorage } from './useLocalStorage'
 import { account_circle, grid_on, info_circle } from '@equinor/eds-icons'
+import { UserInfoDialog } from './components/UserInfoDialog'
+import { AboutDialog } from './components/AboutDialog'
+import { TApplication } from './types'
 
 const Icons = styled.div`
   display: flex;
@@ -66,50 +59,20 @@ const ClickableIcon = styled.div`
   }
 `
 
-const UserInfoLabel = styled.b`
-  margin-left: 5px;
-`
-
-const Row = styled.div`
-  display: flex;
-  flex-direction: row;
-`
-
-const UnstyledList = styled.ul`
-  margin: 0;
-  padding: 0;
-  list-style-type: none;
-  display: inline-flex;
-`
-
 type THeaderPluginConfig = {
   hideUserInfo: boolean
   hideAbout: boolean
-}
-
-type TApplication = {
-  name: string
-  dataSources: string[]
-  label: string
-  description: string
-  roles: string[]
-  adminRole: string
 }
 
 export default (props: IUIPlugin): JSX.Element => {
   const { idReference, config: passedConfig } = props
   const config: THeaderPluginConfig = passedConfig
   const [entity, isLoading] = useDocument<TApplication>(idReference)
-  const { tokenData, token, logOut } = useContext(AuthContext)
+
   const [aboutOpen, setAboutOpen] = useState(false)
   const [visibleUserInfo, setVisibleUserInfo] = useState<boolean>(false)
   const [appSelectorOpen, setAppSelectorOpen] = useState<boolean>(false)
   const [apiKey, setAPIKey] = useState<string | null>(null)
-  const dmssApi = new DmssAPI(token)
-  const [checked, updateChecked] = useLocalStorage<string | null>(
-    'impersonateRoles',
-    null
-  )
 
   if (isLoading || !entity) {
     return <Loading />
@@ -152,82 +115,16 @@ export default (props: IUIPlugin): JSX.Element => {
         </Icons>
       </TopBar.Actions>
       <TopBar.CustomContent>
-        <Dialog
+        <AboutDialog
           isOpen={aboutOpen}
-          closeScrim={() => setAboutOpen(false)}
-          header={`About ${entity.label}`}
-          width={'40vw'}
-        >
-          <p style={{ padding: '0 15px' }}>{entity.description}</p>
-        </Dialog>
-        <Dialog
+          setIsOpen={setAboutOpen}
+          applicationEntity={entity}
+        />
+        <UserInfoDialog
           isOpen={visibleUserInfo}
-          header={'User info'}
-          closeScrim={() => setVisibleUserInfo(false)}
-          width={'720px'}
-        >
-          <div style={{ margin: '20px' }}>
-            <Row>
-              Name:<UserInfoLabel>{tokenData?.name}</UserInfoLabel>
-            </Row>
-            <Row>
-              Username:
-              <UserInfoLabel>{tokenData?.preferred_username}</UserInfoLabel>
-            </Row>
-            <Row>
-              Roles:{' '}
-              <UserInfoLabel>{JSON.stringify(tokenData?.roles)}</UserInfoLabel>
-            </Row>
-            <div style={{ display: 'flex', justifyContent: 'space-around' }}>
-              <Button
-                onClick={() => {
-                  navigator.clipboard.writeText(token)
-                  NotificationManager.success('Copied token to clipboard')
-                }}
-              >
-                Copy token to clipboard
-              </Button>
-              <Button
-                onClick={() =>
-                  dmssApi
-                    .tokenCreate()
-                    .then((response: AxiosResponse<string>) =>
-                      setAPIKey(response.data)
-                    )
-                    .catch((error: any) => {
-                      console.error(error)
-                      NotificationManager.error(
-                        'Failed to create personal access token'
-                      )
-                    })
-                }
-              >
-                Create API-Key
-              </Button>
-              <Button onClick={() => logOut()}>Log out</Button>
-            </div>
-            {apiKey && <pre>{apiKey}</pre>}
-
-            {tokenData?.roles.includes(entity.adminRole) && (
-              <>
-                <p>Impersonate a role (UI only)</p>
-                <UnstyledList>
-                  {entity.roles.map((role: string) => (
-                    <li key={role}>
-                      <Radio
-                        label={role}
-                        name="impersonate-role"
-                        value={role}
-                        checked={checked === role}
-                        onChange={(e: any) => updateChecked(e.target.value)}
-                      />
-                    </li>
-                  ))}
-                </UnstyledList>
-              </>
-            )}
-          </div>
-        </Dialog>
+          setIsOpen={setVisibleUserInfo}
+          applicationEntity={entity}
+        />
       </TopBar.CustomContent>
     </TopBar>
   )

--- a/packages/header/src/components/AboutDialog.tsx
+++ b/packages/header/src/components/AboutDialog.tsx
@@ -1,0 +1,24 @@
+import { Dialog } from '@development-framework/dm-core'
+import React from 'react'
+import { TApplication } from '../types'
+
+type AboutDialogProps = {
+  isOpen: boolean
+  setIsOpen: (newValue: boolean) => void
+  applicationEntity: TApplication
+}
+
+export const AboutDialog = (props: AboutDialogProps) => {
+  const { isOpen, setIsOpen, applicationEntity } = props
+
+  return (
+    <Dialog
+      isOpen={isOpen}
+      closeScrim={() => setIsOpen(false)}
+      header={`About ${applicationEntity.label}`}
+      width={'40vw'}
+    >
+      <p style={{ padding: '0 15px' }}>{applicationEntity.description}</p>
+    </Dialog>
+  )
+}

--- a/packages/header/src/components/PluginSelector.tsx
+++ b/packages/header/src/components/PluginSelector.tsx
@@ -1,0 +1,67 @@
+import React from 'react'
+import styled from 'styled-components'
+import { TUiRecipe } from '@development-framework/dm-core'
+
+const AppSelectorWrapper = styled.div`
+  position: absolute;
+  top: 60px;
+  left: 0;
+  min-width: 300px;
+  max-width: 300px;
+  background: #ffffff;
+  border: 1px solid gray;
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: row;
+  padding: 10px;
+  width: min-content;
+`
+
+const AppBox = styled.div`
+  border: 3px solid grey;
+  padding: 8px;
+  margin: 5px;
+  height: 80px;
+  width: 80px;
+  background: #b3dae0;
+  color: black;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+
+  &:hover {
+    background: #4f878d;
+  }
+`
+
+type PluginSelectorProps = {
+  selectableUiRecipeNames: string[]
+  setSelectedUiPlugin: (uiPluginName: string) => void
+  availableUiRecipes: TUiRecipe[]
+}
+export const PluginSelector = (props: PluginSelectorProps) => {
+  const {
+    selectableUiRecipeNames,
+    setSelectedUiPlugin,
+    availableUiRecipes,
+  } = props
+
+  return (
+    <AppSelectorWrapper>
+      {selectableUiRecipeNames.map((recipeName: string) => (
+        <AppBox
+          onClick={() => {
+            availableUiRecipes.map((recipe) => {
+              if (recipe.name === recipeName) {
+                setSelectedUiPlugin(recipe.plugin)
+              }
+            })
+          }}
+        >
+          {recipeName}
+        </AppBox>
+      ))}
+    </AppSelectorWrapper>
+  )
+}

--- a/packages/header/src/components/UserInfoDialog.tsx
+++ b/packages/header/src/components/UserInfoDialog.tsx
@@ -1,0 +1,122 @@
+import { Icon, Radio, TopBar } from '@equinor/eds-core-react'
+import {
+  Button,
+  Dialog,
+  DmssAPI,
+  IUIPlugin,
+  Loading,
+  useDocument,
+} from '@development-framework/dm-core'
+import styled from 'styled-components'
+import React, { useContext, useState } from 'react'
+import { AuthContext } from 'react-oauth2-code-pkce'
+// @ts-ignore
+import { NotificationManager } from 'react-notifications'
+import { AxiosResponse } from 'axios'
+import { useLocalStorage } from '../useLocalStorage'
+import { TApplication } from '../types'
+
+const UnstyledList = styled.ul`
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+  display: inline-flex;
+`
+
+const Row = styled.div`
+  display: flex;
+  flex-direction: row;
+`
+
+const UserInfoLabel = styled.b`
+  margin-left: 5px;
+`
+
+type UserInfoDialogProps = {
+  isOpen: boolean
+  setIsOpen: (newValue: boolean) => void
+  applicationEntity: TApplication
+}
+
+export const UserInfoDialog = (props: UserInfoDialogProps) => {
+  const { isOpen, setIsOpen, applicationEntity } = props
+
+  const [apiKey, setAPIKey] = useState<string | null>(null)
+  const { tokenData, token, logOut } = useContext(AuthContext)
+  const dmssApi = new DmssAPI(token)
+  const [checked, updateChecked] = useLocalStorage<string | null>(
+    'impersonateRoles',
+    null
+  )
+
+  return (
+    <Dialog
+      isOpen={isOpen}
+      header={'User info'}
+      closeScrim={() => setIsOpen(false)}
+      width={'720px'}
+    >
+      <div style={{ margin: '20px' }}>
+        <Row>
+          Name:<UserInfoLabel>{tokenData?.name}</UserInfoLabel>
+        </Row>
+        <Row>
+          Username:
+          <UserInfoLabel>{tokenData?.preferred_username}</UserInfoLabel>
+        </Row>
+        <Row>
+          Roles:{' '}
+          <UserInfoLabel>{JSON.stringify(tokenData?.roles)}</UserInfoLabel>
+        </Row>
+        <div style={{ display: 'flex', justifyContent: 'space-around' }}>
+          <Button
+            onClick={() => {
+              navigator.clipboard.writeText(token)
+              NotificationManager.success('Copied token to clipboard')
+            }}
+          >
+            Copy token to clipboard
+          </Button>
+          <Button
+            onClick={() =>
+              dmssApi
+                .tokenCreate()
+                .then((response: AxiosResponse<string>) =>
+                  setAPIKey(response.data)
+                )
+                .catch((error: any) => {
+                  console.error(error)
+                  NotificationManager.error(
+                    'Failed to create personal access token'
+                  )
+                })
+            }
+          >
+            Create API-Key
+          </Button>
+          <Button onClick={() => logOut()}>Log out</Button>
+        </div>
+        {apiKey && <pre>{apiKey}</pre>}
+
+        {tokenData?.roles.includes(applicationEntity.adminRole) && (
+          <>
+            <p>Impersonate a role (UI only)</p>
+            <UnstyledList>
+              {applicationEntity.roles.map((role: string) => (
+                <li key={role}>
+                  <Radio
+                    label={role}
+                    name="impersonate-role"
+                    value={role}
+                    checked={checked === role}
+                    onChange={(e: any) => updateChecked(e.target.value)}
+                  />
+                </li>
+              ))}
+            </UnstyledList>
+          </>
+        )}
+      </div>
+    </Dialog>
+  )
+}

--- a/packages/header/src/components/UserInfoDialog.tsx
+++ b/packages/header/src/components/UserInfoDialog.tsx
@@ -40,7 +40,6 @@ type UserInfoDialogProps = {
 
 export const UserInfoDialog = (props: UserInfoDialogProps) => {
   const { isOpen, setIsOpen, applicationEntity } = props
-
   const [apiKey, setAPIKey] = useState<string | null>(null)
   const { tokenData, token, logOut } = useContext(AuthContext)
   const dmssApi = new DmssAPI(token)
@@ -65,7 +64,7 @@ export const UserInfoDialog = (props: UserInfoDialogProps) => {
           <UserInfoLabel>{tokenData?.preferred_username}</UserInfoLabel>
         </Row>
         <Row>
-          Roles:{' '}
+          Roles:
           <UserInfoLabel>{JSON.stringify(tokenData?.roles)}</UserInfoLabel>
         </Row>
         <div style={{ display: 'flex', justifyContent: 'space-around' }}>
@@ -102,17 +101,18 @@ export const UserInfoDialog = (props: UserInfoDialogProps) => {
           <>
             <p>Impersonate a role (UI only)</p>
             <UnstyledList>
-              {applicationEntity.roles.map((role: string) => (
-                <li key={role}>
-                  <Radio
-                    label={role}
-                    name="impersonate-role"
-                    value={role}
-                    checked={checked === role}
-                    onChange={(e: any) => updateChecked(e.target.value)}
-                  />
-                </li>
-              ))}
+              {applicationEntity.roles &&
+                applicationEntity.roles.map((role: string) => (
+                  <li key={role}>
+                    <Radio
+                      label={role}
+                      name="impersonate-role"
+                      value={role}
+                      checked={checked === role}
+                      onChange={(e: any) => updateChecked(e.target.value)}
+                    />
+                  </li>
+                ))}
             </UnstyledList>
           </>
         )}

--- a/packages/header/src/types.ts
+++ b/packages/header/src/types.ts
@@ -1,8 +1,9 @@
 export type TApplication = {
   name: string
-  dataSources: string[]
-  label: string
-  description: string
-  roles: string[]
-  adminRole: string
+  type: string
+  dataSources?: string[]
+  label?: string
+  description?: string
+  roles?: string[]
+  adminRole?: string
 }

--- a/packages/header/src/types.ts
+++ b/packages/header/src/types.ts
@@ -1,0 +1,8 @@
+export type TApplication = {
+  name: string
+  dataSources: string[]
+  label: string
+  description: string
+  roles: string[]
+  adminRole: string
+}

--- a/packages/header/tsconfig.json
+++ b/packages/header/tsconfig.json
@@ -16,7 +16,7 @@
     "allowJs": true,
     "strict": true,
     "skipLibCheck": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "esModuleInterop": true,
     "module": "commonjs",
     "moduleResolution": "node",


### PR DESCRIPTION
## What does this pull request change?

Add functionality to select a UI plugin in the header
![image](https://user-images.githubusercontent.com/69512295/217567609-1a337a58-a782-4fd6-b698-d4e4f3827bbd.png)

Also, refactor the Header.tsx file - split up into components for `AboutDialog` and `UserInfoDialog` 

## Why is this pull request needed?

## Issues related to this change
closes #77 
