### PR TITLE
fix: tab label priority. label -> name -> attribute

### DIFF
--- a/example/app/data/DemoDataSource/DemoPackage/entities/tabsStandardEntity.json
+++ b/example/app/data/DemoDataSource/DemoPackage/entities/tabsStandardEntity.json
@@ -12,7 +12,7 @@
   },
   "secondAttribute": {
     "type": "blueprints/TabsStandardBlueprint",
-    "name": "second attribute"
+    "name": ""
   },
   "thirdAttribute": {
     "type": "blueprints/TabsStandardBlueprint",
@@ -20,6 +20,7 @@
     "firstAttribute": {
       "type": "blueprints/TabsStandardBlueprint",
       "name": "first attribute",
+      "label": "First attribute label ½¡@£",
       "firstAttribute": {
         "type": "blueprints/TabsStandardBlueprint",
         "name": "first attribute",
@@ -28,11 +29,11 @@
     },
     "secondAttribute": {
       "type": "blueprints/TabsStandardBlueprint",
-      "name": "second attribute"
+      "name": "a"
     },
     "thirdAttribute": {
       "type": "blueprints/TabsStandardBlueprint",
-      "name": "third attribute",
+      "name": "_third-attribute_test_name------____",
       "aStringValue": "Hallo World!"
     }
   }

--- a/packages/dm-core-plugins/package.json
+++ b/packages/dm-core-plugins/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@development-framework/dm-core-plugins",
   "license": "MIT",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "dist/index.js",
   "dependencies": {
     "@development-framework/dm-core": "^1.0.39",

--- a/packages/dm-core-plugins/src/tabs/Sidebar.tsx
+++ b/packages/dm-core-plugins/src/tabs/Sidebar.tsx
@@ -1,8 +1,9 @@
-import * as React from 'react'
+import React from 'react'
 import { SideBar } from '@equinor/eds-core-react'
 import { home, subdirectory_arrow_right } from '@equinor/eds-icons'
 import { useTabContext } from './TabsContext'
 import { TChildTab } from './TabsContainer'
+import { prettifyName } from './utils'
 
 export const Sidebar = (): JSX.Element => {
   const { entity, selectedTab, setSelectedTab, childTabs } = useTabContext()
@@ -11,7 +12,9 @@ export const Sidebar = (): JSX.Element => {
       <SideBar.Content>
         <SideBar.Link
           icon={home}
-          label={entity.name}
+          label={
+            entity?.label ?? prettifyName(entity?.name || '') ?? selectedTab
+          }
           onClick={() => setSelectedTab('home')}
           active={selectedTab === 'home'}
         />
@@ -19,7 +22,11 @@ export const Sidebar = (): JSX.Element => {
           <SideBar.Link
             key={tabData.attribute}
             icon={subdirectory_arrow_right}
-            label={tabData.entity.name}
+            label={
+              tabData.entity?.label ||
+              prettifyName(tabData.entity?.name || '') ||
+              tabData.attribute
+            }
             onClick={() => setSelectedTab(tabData.attribute)}
             active={selectedTab === tabData.attribute}
           />

--- a/packages/dm-core-plugins/src/tabs/Tabs.tsx
+++ b/packages/dm-core-plugins/src/tabs/Tabs.tsx
@@ -4,6 +4,7 @@ import { home } from '@equinor/eds-icons'
 import styled from 'styled-components'
 import { TChildTab } from './TabsContainer'
 import { useTabContext } from './TabsContext'
+import { prettifyName } from './utils'
 
 interface ITabs {
   active: boolean
@@ -30,6 +31,8 @@ const BaseTab = styled(Tab as any)`
 
 const ChildTab = styled(Tab as any)`
   background-color: #d1d1d1;
+  display: flex;
+  align-items: self-end;
 `
 
 export const Tabs = (): JSX.Element => {
@@ -62,7 +65,9 @@ export const Tabs = (): JSX.Element => {
             onClick={() => setSelectedTab(tabData.attribute)}
             active={selectedTab === tabData.attribute}
           >
-            {tabData.entity.name}
+            {tabData.entity?.label ||
+              prettifyName(tabData.entity?.name || '') ||
+              tabData.attribute}
           </ChildTab>
         </Tooltip>
       ))}

--- a/packages/dm-core-plugins/src/tabs/utils.ts
+++ b/packages/dm-core-plugins/src/tabs/utils.ts
@@ -1,0 +1,5 @@
+export function prettifyName(uglyName: string): string {
+  if (!uglyName) return ''
+  let newName = uglyName.replace(/[-_]/g, ' ')
+  return newName[0].toUpperCase() + newName.slice(1)
+}


### PR DESCRIPTION
## What does this pull request change?
- "tabs" plugin label text now has fallback values if the entity does not have a "name"-attribute

## Why is this pull request needed?
see #101 

## Issues related to this change
closes #101 
