### PR TITLE
fix: add protocol to type returned from JobHandlerPicker

### DIFF
--- a/packages/dm-core/package.json
+++ b/packages/dm-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@development-framework/dm-core",
-  "version": "1.0.39",
+  "version": "1.0.40",
   "license": "MIT",
   "peerDependencies": {
     "react-router-dom": ">=5.1.2",

--- a/packages/dm-core/src/components/Pickers/JobHandlerPicker.tsx
+++ b/packages/dm-core/src/components/Pickers/JobHandlerPicker.tsx
@@ -12,6 +12,7 @@ export const JobHandlerPicker = (props: {
   const blueprintName = formData.split('/').pop()
   const { token } = useContext(AuthContext)
   const dmssApi = new DmssAPI(token)
+  const protocolPrefix = 'dmss://'
   const [searchResult] = useSearch<any>(
     {
       type: 'dmss://system/SIMOS/Blueprint',
@@ -26,7 +27,7 @@ export const JobHandlerPicker = (props: {
         absoluteId: `WorkflowDS/${blueprintId}`,
       })
       .then((response: any) => {
-        onChange(response.data)
+        onChange(`${protocolPrefix}${response.data}`)
       })
       .catch((error: any) => console.error(error))
   }


### PR DESCRIPTION
## What does this pull request change?
fix bug in JobHandlerPicker.

JobHandlerPicker is used in Analysis platform
![image](https://user-images.githubusercontent.com/69512295/222149747-30b35da4-0727-4f9f-b371-f36c016b8fd5.png)


the blueprintResolve endpoint in dmss return only a path
![image](https://user-images.githubusercontent.com/69512295/222150029-2e3fdcaa-0172-4699-96f4-4264070ef160.png)

 the protocol should be added since JobHandlerPicker returns a type
## Why is this pull request needed?
bug
## Issues related to this change
make analysis platform work again
closes #106 