### PR TITLE
feat: add option to hide attributes in attribute selector plugin

### DIFF
--- a/example/app/data/DemoDataSource/DemoPackage/blueprints/Plugins/AttributeSelectorPluginConfig.json
+++ b/example/app/data/DemoDataSource/DemoPackage/blueprints/Plugins/AttributeSelectorPluginConfig.json
@@ -7,7 +7,7 @@
       "type": "CORE:BlueprintAttribute",
       "name": "childTabsOnRender",
       "optional": true,
-      "default": false
+      "default": true
     },
     {
       "attributeType": "string",
@@ -21,7 +21,8 @@
       "type": "CORE:BlueprintAttribute",
       "name": "visibleAttributes",
       "optional": true,
-      "dimensions": "*"
+      "dimensions": "*",
+      "default": []
     },
     {
       "attributeType": "boolean",

--- a/example/app/data/DemoDataSource/DemoPackage/blueprints/Plugins/AttributeSelectorPluginConfig.json
+++ b/example/app/data/DemoDataSource/DemoPackage/blueprints/Plugins/AttributeSelectorPluginConfig.json
@@ -17,6 +17,13 @@
       "default": "home"
     },
     {
+      "attributeType": "string",
+      "type": "CORE:BlueprintAttribute",
+      "name": "visibleAttributes",
+      "optional": true,
+      "dimensions": "*"
+    },
+    {
       "attributeType": "boolean",
       "type": "CORE:BlueprintAttribute",
       "name": "asSidebar",

--- a/example/app/data/DemoDataSource/DemoPackage/recipe_links/attribute_selector_sidebar_blueprint.json
+++ b/example/app/data/DemoDataSource/DemoPackage/recipe_links/attribute_selector_sidebar_blueprint.json
@@ -9,7 +9,8 @@
       "type": "blueprints/Plugins/AttributeSelectorPluginConfig",
       "childTabsOnRender": true,
       "asSidebar": true,
-      "homeRecipe": "home"
+      "homeRecipe": "home",
+      "visibleAttributes": ["firstAttribute", "thirdAttribute"]
     }
   },
   "uiRecipes": [

--- a/example/app/data/DemoDataSource/DemoPackage/recipe_links/attribute_selector_tabs_blueprint.json
+++ b/example/app/data/DemoDataSource/DemoPackage/recipe_links/attribute_selector_tabs_blueprint.json
@@ -16,7 +16,7 @@
     {
       "type": "CORE:UiRecipe",
       "name": "home",
-      "plugin": "blueprints/Plugins/UiPluginSelector",
+      "plugin": "UiPluginSelector",
       "config": {
         "type": "blueprints/Plugins/UiPluginSelectorConfig",
         "recipes": ["Yaml", "Edit"]

--- a/packages/dm-core-plugins/blueprints/tabs/AttributeSelectorPluginConfig.json
+++ b/packages/dm-core-plugins/blueprints/tabs/AttributeSelectorPluginConfig.json
@@ -17,6 +17,13 @@
       "default": "home"
     },
     {
+      "attributeType": "string",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "name": "visibleAttributes",
+      "optional": true,
+      "dimensions": "*"
+    },
+    {
       "attributeType": "boolean",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
       "name": "asSidebar",

--- a/packages/dm-core-plugins/blueprints/tabs/AttributeSelectorPluginConfig.json
+++ b/packages/dm-core-plugins/blueprints/tabs/AttributeSelectorPluginConfig.json
@@ -7,7 +7,7 @@
       "type": "dmss://system/SIMOS/BlueprintAttribute",
       "name": "childTabsOnRender",
       "optional": true,
-      "default": false
+      "default": true
     },
     {
       "attributeType": "string",

--- a/packages/dm-core-plugins/blueprints/tabs/AttributeSelectorPluginConfig.json
+++ b/packages/dm-core-plugins/blueprints/tabs/AttributeSelectorPluginConfig.json
@@ -21,7 +21,8 @@
       "type": "dmss://system/SIMOS/BlueprintAttribute",
       "name": "visibleAttributes",
       "optional": true,
-      "dimensions": "*"
+      "dimensions": "*",
+      "default": []
     },
     {
       "attributeType": "boolean",

--- a/packages/dm-core-plugins/src/attribute-selector/AttributeSelectorPlugin.tsx
+++ b/packages/dm-core-plugins/src/attribute-selector/AttributeSelectorPlugin.tsx
@@ -48,12 +48,11 @@ export const AttributeSelectorPlugin = (props: IUIPlugin): JSX.Element => {
     if (config.childTabsOnRender) {
       const newChildTabs: TStringMap = {}
       Object.entries(entity).forEach(([key, attributeData]: [string, any]) => {
-        if (
-          (config?.visibleAttributes === undefined ||
-            config?.visibleAttributes.length === 0 ||
-            config?.visibleAttributes.includes(key)) &&
-          typeof attributeData == 'object'
-        ) {
+        const filteredOutInConfig =
+          config?.visibleAttributes !== undefined &&
+          config?.visibleAttributes.length > 0 &&
+          !config?.visibleAttributes.includes(key)
+        if (!filteredOutInConfig && typeof attributeData == 'object') {
           newChildTabs[key] = {
             attribute: key,
             entity: attributeData,

--- a/packages/dm-core-plugins/src/attribute-selector/AttributeSelectorPlugin.tsx
+++ b/packages/dm-core-plugins/src/attribute-selector/AttributeSelectorPlugin.tsx
@@ -32,7 +32,7 @@ export type TAttributeSelectorPluginConfig = {
 export const AttributeSelectorPlugin = (props: IUIPlugin): JSX.Element => {
   const { idReference, config: passedConfig, onSubmit } = props
   const config: TAttributeSelectorPluginConfig = {
-    childTabsOnRender: passedConfig?.childTabsOnRender ?? false,
+    childTabsOnRender: passedConfig?.childTabsOnRender ?? true,
     homeRecipe: passedConfig?.homeRecipe ?? 'home',
     asSidebar: passedConfig?.asSidebar ?? false,
     visibleAttributes: passedConfig?.visibleAttributes ?? [],
@@ -48,7 +48,12 @@ export const AttributeSelectorPlugin = (props: IUIPlugin): JSX.Element => {
     if (config.childTabsOnRender) {
       const newChildTabs: TStringMap = {}
       Object.entries(entity).forEach(([key, attributeData]: [string, any]) => {
-        if (typeof attributeData == 'object') {
+        if (
+          (config?.visibleAttributes === undefined ||
+            config?.visibleAttributes.length === 0 ||
+            config?.visibleAttributes.includes(key)) &&
+          typeof attributeData == 'object'
+        ) {
           newChildTabs[key] = {
             attribute: key,
             entity: attributeData,

--- a/packages/dm-core-plugins/src/attribute-selector/AttributeSelectorPlugin.tsx
+++ b/packages/dm-core-plugins/src/attribute-selector/AttributeSelectorPlugin.tsx
@@ -26,6 +26,7 @@ export type TAttributeSelectorPluginConfig = {
   childTabsOnRender?: boolean
   homeRecipe?: string
   asSidebar?: boolean
+  visibleAttributes?: string[]
 }
 
 export const AttributeSelectorPlugin = (props: IUIPlugin): JSX.Element => {
@@ -34,6 +35,7 @@ export const AttributeSelectorPlugin = (props: IUIPlugin): JSX.Element => {
     childTabsOnRender: passedConfig?.childTabsOnRender ?? false,
     homeRecipe: passedConfig?.homeRecipe ?? 'home',
     asSidebar: passedConfig?.asSidebar ?? false,
+    visibleAttributes: passedConfig?.visibleAttributes ?? [],
   }
   const [selectedTab, setSelectedTab] = useState<string>('home')
   const [formData, setFormData] = useState<TGenericObject>({})

--- a/packages/dm-core-plugins/src/attribute-selector/README.md
+++ b/packages/dm-core-plugins/src/attribute-selector/README.md
@@ -5,4 +5,13 @@ in a new tab.
 
 If you want to specify a config object in some UiRecipe-entity, the Blueprint is included in the npm package.
 
+
+The attribute-selector UI plugin can accept a config of type `AttributeSelectorPluginConfig` with the following attributes:
+
+* `childTabsOnRender` (optional): ??
+* `visibleAttributes` (optional): Can be used to control what attributes to be selectable. If the list is empty, all attributes of the entity can be selected.
+* `homeRecipe` (optional): What UI recipe to view when selecting an attribute.
+* `asSidebar` (optional): Specify if attributes should be displayed in a sidebar view. The alternative is a tab view.
+
+
 Copy it like so: `cp -R node_modules/@development-framework/dm-core-plugins/blueprints/tabs ./myApplicationBlueprints/`

--- a/packages/dm-core-plugins/src/attribute-selector/README.md
+++ b/packages/dm-core-plugins/src/attribute-selector/README.md
@@ -8,7 +8,7 @@ If you want to specify a config object in some UiRecipe-entity, the Blueprint is
 
 The attribute-selector UI plugin can accept a config of type `AttributeSelectorPluginConfig` with the following attributes:
 
-* `childTabsOnRender` (optional): ??
+* `childTabsOnRender` (optional): If false the tab/sidebar will only show the home button until "onOpen()" is called on an attribute. Defaults to true.
 * `visibleAttributes` (optional): Can be used to control what attributes to be selectable. If the list is empty, all attributes of the entity can be selected.
 * `homeRecipe` (optional): What UI recipe to view when selecting an attribute.
 * `asSidebar` (optional): Specify if attributes should be displayed in a sidebar view. The alternative is a tab view.

--- a/packages/dm-core-plugins/src/attribute-selector/Sidebar.tsx
+++ b/packages/dm-core-plugins/src/attribute-selector/Sidebar.tsx
@@ -6,7 +6,14 @@ import { TChildTab } from './AttributeSelectorPlugin'
 import { prettifyName } from './utils'
 
 export const Sidebar = (): JSX.Element => {
-  const { entity, selectedTab, setSelectedTab, childTabs } = useTabContext()
+  const {
+    entity,
+    selectedTab,
+    setSelectedTab,
+    childTabs,
+    config,
+  } = useTabContext()
+
   return (
     <SideBar open style={{ height: 'auto' }}>
       <SideBar.Content>
@@ -18,19 +25,27 @@ export const Sidebar = (): JSX.Element => {
           onClick={() => setSelectedTab('home')}
           active={selectedTab === 'home'}
         />
-        {Object.values(childTabs).map((tabData: TChildTab) => (
-          <SideBar.Link
-            key={tabData.attribute}
-            icon={subdirectory_arrow_right}
-            label={
-              tabData.entity?.label ||
-              prettifyName(tabData.entity?.name || '') ||
-              tabData.attribute
-            }
-            onClick={() => setSelectedTab(tabData.attribute)}
-            active={selectedTab === tabData.attribute}
-          />
-        ))}
+        {Object.values(childTabs).map((tabData: TChildTab) => {
+          if (
+            config?.visibleAttributes === undefined ||
+            config?.visibleAttributes.length === 0 ||
+            config?.visibleAttributes.includes(tabData.attribute)
+          ) {
+            return (
+              <SideBar.Link
+                key={tabData.attribute}
+                icon={subdirectory_arrow_right}
+                label={
+                  tabData.entity?.label ||
+                  prettifyName(tabData.entity?.name || '') ||
+                  tabData.attribute
+                }
+                onClick={() => setSelectedTab(tabData.attribute)}
+                active={selectedTab === tabData.attribute}
+              />
+            )
+          }
+        })}
       </SideBar.Content>
       <SideBar.Footer>
         <SideBar.Toggle />

--- a/packages/dm-core-plugins/src/attribute-selector/Sidebar.tsx
+++ b/packages/dm-core-plugins/src/attribute-selector/Sidebar.tsx
@@ -19,21 +19,19 @@ export const Sidebar = (): JSX.Element => {
           onClick={() => setSelectedTab('home')}
           active={selectedTab === 'home'}
         />
-        {Object.values(childTabs).map((tabData: TChildTab) => {
-          return (
-            <SideBar.Link
-              key={tabData.attribute}
-              icon={subdirectory_arrow_right}
-              label={
-                tabData.entity?.label ||
-                prettifyName(tabData.entity?.name || '') ||
-                tabData.attribute
-              }
-              onClick={() => setSelectedTab(tabData.attribute)}
-              active={selectedTab === tabData.attribute}
-            />
-          )
-        })}
+        {Object.values(childTabs).map((tabData: TChildTab) => (
+          <SideBar.Link
+            key={tabData.attribute}
+            icon={subdirectory_arrow_right}
+            label={
+              tabData.entity?.label ||
+              prettifyName(tabData.entity?.name || '') ||
+              tabData.attribute
+            }
+            onClick={() => setSelectedTab(tabData.attribute)}
+            active={selectedTab === tabData.attribute}
+          />
+        ))}
       </SideBar.Content>
       <SideBar.Footer>
         <SideBar.Toggle />

--- a/packages/dm-core-plugins/src/attribute-selector/Sidebar.tsx
+++ b/packages/dm-core-plugins/src/attribute-selector/Sidebar.tsx
@@ -6,13 +6,7 @@ import { TChildTab } from './AttributeSelectorPlugin'
 import { prettifyName } from './utils'
 
 export const Sidebar = (): JSX.Element => {
-  const {
-    entity,
-    selectedTab,
-    setSelectedTab,
-    childTabs,
-    config,
-  } = useTabContext()
+  const { entity, selectedTab, setSelectedTab, childTabs } = useTabContext()
 
   return (
     <SideBar open style={{ height: 'auto' }}>
@@ -26,25 +20,19 @@ export const Sidebar = (): JSX.Element => {
           active={selectedTab === 'home'}
         />
         {Object.values(childTabs).map((tabData: TChildTab) => {
-          if (
-            config?.visibleAttributes === undefined ||
-            config?.visibleAttributes.length === 0 ||
-            config?.visibleAttributes.includes(tabData.attribute)
-          ) {
-            return (
-              <SideBar.Link
-                key={tabData.attribute}
-                icon={subdirectory_arrow_right}
-                label={
-                  tabData.entity?.label ||
-                  prettifyName(tabData.entity?.name || '') ||
-                  tabData.attribute
-                }
-                onClick={() => setSelectedTab(tabData.attribute)}
-                active={selectedTab === tabData.attribute}
-              />
-            )
-          }
+          return (
+            <SideBar.Link
+              key={tabData.attribute}
+              icon={subdirectory_arrow_right}
+              label={
+                tabData.entity?.label ||
+                prettifyName(tabData.entity?.name || '') ||
+                tabData.attribute
+              }
+              onClick={() => setSelectedTab(tabData.attribute)}
+              active={selectedTab === tabData.attribute}
+            />
+          )
         })}
       </SideBar.Content>
       <SideBar.Footer>

--- a/packages/dm-core-plugins/src/attribute-selector/Tabs.tsx
+++ b/packages/dm-core-plugins/src/attribute-selector/Tabs.tsx
@@ -38,13 +38,7 @@ const ChildTab = styled(Tab as any)`
 `
 
 export const Tabs = (): JSX.Element => {
-  const {
-    entity,
-    selectedTab,
-    setSelectedTab,
-    childTabs,
-    config,
-  } = useTabContext()
+  const { entity, selectedTab, setSelectedTab, childTabs } = useTabContext()
   return (
     <div
       style={{
@@ -62,31 +56,23 @@ export const Tabs = (): JSX.Element => {
           <Icon data={home} size={24} />
         </BaseTab>
       </Tooltip>
-      {Object.values(childTabs).map((tabData: TChildTab) => {
-        if (
-          config?.visibleAttributes === undefined ||
-          config?.visibleAttributes.length === 0 ||
-          config?.visibleAttributes.includes(tabData.attribute)
-        ) {
-          return (
-            <Tooltip
-              key={tabData.attribute}
-              enterDelay={600}
-              title={tabData.entity.type}
-              placement="top-start"
-            >
-              <ChildTab
-                onClick={() => setSelectedTab(tabData.attribute)}
-                active={selectedTab === tabData.attribute}
-              >
-                {tabData.entity?.label ||
-                  prettifyName(tabData.entity?.name || '') ||
-                  tabData.attribute}
-              </ChildTab>
-            </Tooltip>
-          )
-        }
-      })}
+      {Object.values(childTabs).map((tabData: TChildTab) => (
+        <Tooltip
+          key={tabData.attribute}
+          enterDelay={600}
+          title={tabData.entity.type}
+          placement="top-start"
+        >
+          <ChildTab
+            onClick={() => setSelectedTab(tabData.attribute)}
+            active={selectedTab === tabData.attribute}
+          >
+            {tabData.entity?.label ||
+              prettifyName(tabData.entity?.name || '') ||
+              tabData.attribute}
+          </ChildTab>
+        </Tooltip>
+      ))}
     </div>
   )
 }

--- a/packages/dm-core-plugins/src/attribute-selector/Tabs.tsx
+++ b/packages/dm-core-plugins/src/attribute-selector/Tabs.tsx
@@ -38,7 +38,13 @@ const ChildTab = styled(Tab as any)`
 `
 
 export const Tabs = (): JSX.Element => {
-  const { entity, selectedTab, setSelectedTab, childTabs } = useTabContext()
+  const {
+    entity,
+    selectedTab,
+    setSelectedTab,
+    childTabs,
+    config,
+  } = useTabContext()
   return (
     <div
       style={{
@@ -56,23 +62,31 @@ export const Tabs = (): JSX.Element => {
           <Icon data={home} size={24} />
         </BaseTab>
       </Tooltip>
-      {Object.values(childTabs).map((tabData: TChildTab) => (
-        <Tooltip
-          key={tabData.attribute}
-          enterDelay={600}
-          title={tabData.entity.type}
-          placement="top-start"
-        >
-          <ChildTab
-            onClick={() => setSelectedTab(tabData.attribute)}
-            active={selectedTab === tabData.attribute}
-          >
-            {tabData.entity?.label ||
-              prettifyName(tabData.entity?.name || '') ||
-              tabData.attribute}
-          </ChildTab>
-        </Tooltip>
-      ))}
+      {Object.values(childTabs).map((tabData: TChildTab) => {
+        if (
+          config?.visibleAttributes === undefined ||
+          config?.visibleAttributes.length === 0 ||
+          config?.visibleAttributes.includes(tabData.attribute)
+        ) {
+          return (
+            <Tooltip
+              key={tabData.attribute}
+              enterDelay={600}
+              title={tabData.entity.type}
+              placement="top-start"
+            >
+              <ChildTab
+                onClick={() => setSelectedTab(tabData.attribute)}
+                active={selectedTab === tabData.attribute}
+              >
+                {tabData.entity?.label ||
+                  prettifyName(tabData.entity?.name || '') ||
+                  tabData.attribute}
+              </ChildTab>
+            </Tooltip>
+          )
+        }
+      })}
     </div>
   )
 }


### PR DESCRIPTION
## What does this pull request change?
add option to hide attributes in the attribute selector plugin.  This can be controlled by the config (see packages/dm-core-plugins/blueprints/tabs/AttributeSelectorPluginConfig.json)
## Why is this pull request needed?

## Issues related to this change
closes #119 
