### PR TITLE
fix: find recipe after loading finished

### DIFF
--- a/packages/dm-core/src/components/ViewCreator/ReferenceView.tsx
+++ b/packages/dm-core/src/components/ViewCreator/ReferenceView.tsx
@@ -17,6 +17,7 @@ export const ReferenceView = (props: TReferenceView) => {
   )
   if (isRecipeLoading) return <>Loading...</>
   if (error) return <>Error</>
+  if (recipe === undefined) return <>Recipe is undefined</>
   const UiPlugin = getUiPlugin(recipe.plugin)
   // TODO: Add override configuration functionality
   return (

--- a/packages/dm-core/src/hooks/useRecipe.tsx
+++ b/packages/dm-core/src/hooks/useRecipe.tsx
@@ -32,7 +32,7 @@ const findRecipe = (
 }
 
 interface IUseRecipe {
-  recipe: TUiRecipe
+  recipe: TUiRecipe | undefined
   isLoading: boolean
   error: Error | null
 }
@@ -64,7 +64,9 @@ export const useRecipe = (typeRef: string, recipeName?: string): IUseRecipe => {
   const { initialUiRecipe, uiRecipes, isLoading, error } = useBlueprint(typeRef)
 
   return {
-    recipe: findRecipe(initialUiRecipe, uiRecipes, recipeName),
+    recipe: isLoading
+      ? undefined
+      : findRecipe(initialUiRecipe, uiRecipes, recipeName),
     isLoading,
     error,
   }


### PR DESCRIPTION
## What does this pull request change?

* Find recipe only after loading is finished

## Why is this pull request needed?

* It will throw an error saying that the recipe is not found if it's try to find it to early

## Issues related to this change

