### PR TITLE
fix: content of sidebar now fills available space

### DIFF
--- a/packages/dm-core-plugins/src/attribute-selector/AttributeSelectorPlugin.tsx
+++ b/packages/dm-core-plugins/src/attribute-selector/AttributeSelectorPlugin.tsx
@@ -90,6 +90,7 @@ export const AttributeSelectorPlugin = (props: IUIPlugin): JSX.Element => {
         style={{
           display: 'flex',
           flexDirection: config.asSidebar ? 'row' : 'column',
+          width: '100%',
         }}
       >
         {config.asSidebar ? <Sidebar /> : <Tabs />}

--- a/packages/dm-core-plugins/src/attribute-selector/Content.tsx
+++ b/packages/dm-core-plugins/src/attribute-selector/Content.tsx
@@ -11,6 +11,7 @@ import { TChildTab } from './AttributeSelectorPlugin'
 const HidableWrapper = styled.div<any>`
   display: ${(props: { hidden: boolean }) => (props.hidden && 'none') || 'flex'}
   align-self: normal;
+  width: 100%;
 `
 
 export const Content = (): JSX.Element => {
@@ -26,7 +27,7 @@ export const Content = (): JSX.Element => {
     config,
   } = useTabContext()
   return (
-    <>
+    <div style={{ width: '100%' }}>
       <HidableWrapper hidden={'home' !== selectedTab}>
         <UIPluginSelector
           idReference={idReference}
@@ -67,6 +68,6 @@ export const Content = (): JSX.Element => {
           </HidableWrapper>
         )
       })}
-    </>
+    </div>
   )
 }

--- a/packages/dm-core/package.json
+++ b/packages/dm-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@development-framework/dm-core",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "license": "MIT",
   "peerDependencies": {
     "react-router-dom": ">=5.1.2",


### PR DESCRIPTION
## What does this pull request change?
- set CSS prop "fill-available" on some wrappers

## Why is this pull request needed?
- some plugins were being squashed

Before:
![Screenshot_20230314_091639](https://user-images.githubusercontent.com/11062560/224938836-46b1104f-cc46-4404-b450-6a0ab77d6a08.png)

After:
![Screenshot_20230314_091703](https://user-images.githubusercontent.com/11062560/224938859-8c8a0500-9200-4fa0-b2fc-a443fdc28f7d.png)


## Issues related to this change
closes #148 

