### PR TITLE
fix(form): fix a bug where form continued with bad state

### DIFF
--- a/packages/dm-core-plugins/package.json
+++ b/packages/dm-core-plugins/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@development-framework/dm-core-plugins",
   "license": "MIT",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "main": "dist/index.js",
   "dependencies": {
     "@development-framework/dm-core": "^1.0.41",

--- a/packages/dm-core-plugins/src/form/FormPlugin.tsx
+++ b/packages/dm-core-plugins/src/form/FormPlugin.tsx
@@ -21,9 +21,10 @@ const ErrorHelperText = styled.div`
 const widgets = {
   TypeWidget: (props: TWidget) => {
     const { id, namePath, label, value } = props
-    const { blueprint, isLoading } = useBlueprint(value)
+    const { blueprint, isLoading, error } = useBlueprint(value)
 
     if (isLoading) return <Loading />
+    if (error) throw new Error(`Failed to fetch blueprint for '${value}'`)
     if (blueprint === undefined) return <div>Could not find the blueprint</div>
 
     const datasourceId = value.split('/')[0]

--- a/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
@@ -474,6 +474,7 @@ export const ObjectTypeSelector = (props: TObjectFieldProps): JSX.Element => {
   const { blueprint, uiRecipes, isLoading, error } = useBlueprint(type)
 
   if (isLoading) return <Loading />
+  if (error) throw new Error(`Failed to fetch blueprint for '${type}'`)
   if (blueprint === undefined) return <div>Could not find the blueprint</div>
 
   // The root object uses the ui recipe config that is passed into the ui plugin,

--- a/packages/dm-core/package.json
+++ b/packages/dm-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@development-framework/dm-core",
-  "version": "1.0.42",
+  "version": "1.0.43",
   "license": "MIT",
   "peerDependencies": {
     "react-router-dom": ">=5.1.2",

--- a/packages/dm-core/src/components/UiPluginSelector.tsx
+++ b/packages/dm-core/src/components/UiPluginSelector.tsx
@@ -215,12 +215,8 @@ export function UIPluginSelector(props: IUIPlugin): JSX.Element {
       )}
       {/*@ts-ignore*/}
       <ErrorBoundary
-        fallBack={() => (
-          <h4 style={{ color: 'red' }}>
-            The UiPlugin <i>{selectablePlugins[selectedPlugin].name}</i>{' '}
-            crashed...
-          </h4>
-        )}
+        key={selectablePlugins[selectedPlugin].name}
+        message={`Plugin '${selectablePlugins[selectedPlugin].name}' crashed...`}
       >
         <UiPlugin
           idReference={idReference}

--- a/packages/dm-core/src/components/UiRecipesSideBarSelector.tsx
+++ b/packages/dm-core/src/components/UiRecipesSideBarSelector.tsx
@@ -98,12 +98,7 @@ export function UiRecipesSideBarSelector(props: IUIPlugin): JSX.Element {
       </RecipeSidebarWrapper>
       {/*@ts-ignore*/}
       <ErrorBoundary
-        fallBack={() => (
-          <h4 style={{ color: 'red' }}>
-            The UiPlugin <i>{selectableRecipes[selectedRecipe].name}</i>{' '}
-            crashed...
-          </h4>
-        )}
+        message={`Plugin '${selectableRecipes[selectedRecipe].name}' crashed...`}
       >
         <UiPlugin
           idReference={idReference}

--- a/packages/dm-core/src/hooks/useBlueprint.tsx
+++ b/packages/dm-core/src/hooks/useBlueprint.tsx
@@ -2,13 +2,14 @@ import { useContext, useEffect, useState } from 'react'
 import { DmssAPI } from '../services/api/DmssAPI'
 import { AuthContext } from 'react-oauth2-code-pkce'
 import { ApplicationContext } from '../context/ApplicationContext'
-
+import { ErrorResponse } from '../services'
+import { AxiosError } from 'axios'
 interface IUseBlueprint {
   blueprint: any
   initialUiRecipe: any
   uiRecipes: any[]
   isLoading: boolean
-  error: Error | null
+  error: ErrorResponse | null
 }
 /**
  * Hook to fetch a Blueprint from the DMSS API
@@ -37,7 +38,7 @@ export const useBlueprint = (typeRef: string): IUseBlueprint => {
   const [uiRecipes, setUiRecipes] = useState<any[]>([])
   const [initialUiRecipe, setInitialUiRecipe] = useState<any>()
   const [isLoading, setLoading] = useState<boolean>(true)
-  const [error, setError] = useState<Error | null>(null)
+  const [error, setError] = useState<ErrorResponse | null>(null)
   const { token } = useContext(AuthContext)
   const { name } = useContext(ApplicationContext)
   const dmssAPI = new DmssAPI(token)
@@ -51,7 +52,9 @@ export const useBlueprint = (typeRef: string): IUseBlueprint => {
         setUiRecipes(response.data.uiRecipes)
         setError(null)
       })
-      .catch((error: Error) => setError(error))
+      .catch((error: AxiosError<ErrorResponse>) =>
+        setError(error.response?.data || null)
+      )
       .finally(() => setLoading(false))
   }, [typeRef])
 

--- a/packages/dm-core/src/hooks/useRecipe.tsx
+++ b/packages/dm-core/src/hooks/useRecipe.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useBlueprint, TUiRecipe } from '../index'
+import { useBlueprint, TUiRecipe, ErrorResponse } from '../index'
 
 const findRecipe = (
   initialUiRecipe: TUiRecipe | undefined,
@@ -34,7 +34,7 @@ const findRecipe = (
 interface IUseRecipe {
   recipe: TUiRecipe | undefined
   isLoading: boolean
-  error: Error | null
+  error: ErrorResponse | null
 }
 
 /**

--- a/packages/dm-core/src/utils/ErrorBoundary.tsx
+++ b/packages/dm-core/src/utils/ErrorBoundary.tsx
@@ -1,27 +1,44 @@
 import React, { ReactNode } from 'react'
+import styled from 'styled-components'
 
-export class ErrorBoundary extends React.Component<any, { hasError: boolean }> {
-  fallBack: () => ReactNode = () => (
-    <h4 style={{ color: 'red' }}>This component crashed...</h4>
+export const ErrorGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  border: 1px solid rgba(213, 18, 18, 0.71);
+  border-radius: 5px;
+  padding: 20px 20px;
+  background-color: #f6dfdf;
+`
+export class ErrorBoundary extends React.Component<
+  any,
+  { hasError: boolean; error: Error }
+> {
+  fallBack: (error: Error) => ReactNode = (error: Error) => (
+    <ErrorGroup>
+      <h4 style={{ color: 'red' }}>{this.message}</h4>
+      <pre>{error.message}</pre>
+    </ErrorGroup>
   )
+  message = 'unknown'
 
-  constructor(props: { fallBack: () => ReactNode }) {
+  constructor(props: { message: string }) {
     super(props)
-    this.fallBack = props.fallBack
-    this.state = { hasError: false }
+    this.message = props.message
+    this.state = { hasError: false, error: new Error('None') }
   }
 
-  static getDerivedStateFromError() {
+  static getDerivedStateFromError(error: Error) {
     // Update state so the next render will show the fallback UI.
     return {
       hasError: true,
+      error: error,
     }
   }
 
   render() {
     if (this.state.hasError) {
       // You can render any custom fallback UI
-      return this.fallBack()
+      return this.fallBack(this.state.error)
     }
     return this.props.children
   }


### PR DESCRIPTION
## What does this pull request change?
- "form" will throw error on failed blueprint fetches
- update ErrorBoundary to display error and plugin name


![Screenshot_20230317_121053](https://user-images.githubusercontent.com/11062560/225889039-f0628e37-d8b2-48ca-a41d-7611a2d2a660.png)



## Why is this pull request needed?

- "form" would silently continue even if it failed to fetch a blueprint. Making it hard to detect errors/bad config

## Issues related to this change
none
