### PR TITLE
refactor: rename header plugin

### DIFF
--- a/example/app/data/DemoDataSource/DemoPackage/recipe_links/attribute_selector_sidebar_blueprint.json
+++ b/example/app/data/DemoDataSource/DemoPackage/recipe_links/attribute_selector_sidebar_blueprint.json
@@ -10,7 +10,10 @@
       "childTabsOnRender": true,
       "asSidebar": true,
       "homeRecipe": "home",
-      "visibleAttributes": ["firstAttribute", "thirdAttribute"]
+      "visibleAttributes": [
+        "firstAttribute",
+        "thirdAttribute"
+      ]
     }
   },
   "uiRecipes": [
@@ -20,13 +23,16 @@
       "plugin": "UiPluginSelector",
       "config": {
         "type": "blueprints/Plugins/UiPluginSelectorConfig",
-        "recipes": ["Yaml", "Edit"]
+        "recipes": [
+          "Yaml",
+          "Edit"
+        ]
       }
     },
     {
       "name": "Yaml",
       "type": "CORE:UiRecipe",
-      "plugin": "yaml",
+      "plugin": "@development-framework/dm-core-plugins/yaml",
       "category": "container"
     },
     {

--- a/example/app/data/DemoDataSource/DemoPackage/recipe_links/attribute_selector_sidebar_blueprint.json
+++ b/example/app/data/DemoDataSource/DemoPackage/recipe_links/attribute_selector_sidebar_blueprint.json
@@ -33,7 +33,7 @@
       "type": "CORE:UiRecipe",
       "name": "Edit",
       "description": "Default edit",
-      "plugin": "form"
+      "plugin": "@development-framework/dm-core-plugins/form"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/DemoPackage/recipe_links/attribute_selector_sidebar_blueprint.json
+++ b/example/app/data/DemoDataSource/DemoPackage/recipe_links/attribute_selector_sidebar_blueprint.json
@@ -10,10 +10,7 @@
       "childTabsOnRender": true,
       "asSidebar": true,
       "homeRecipe": "home",
-      "visibleAttributes": [
-        "firstAttribute",
-        "thirdAttribute"
-      ]
+      "visibleAttributes": ["firstAttribute", "thirdAttribute"]
     }
   },
   "uiRecipes": [
@@ -23,10 +20,7 @@
       "plugin": "UiPluginSelector",
       "config": {
         "type": "blueprints/Plugins/UiPluginSelectorConfig",
-        "recipes": [
-          "Yaml",
-          "Edit"
-        ]
+        "recipes": ["Yaml", "Edit"]
       }
     },
     {

--- a/example/app/data/DemoDataSource/DemoPackage/recipe_links/attribute_selector_tabs_blueprint.json
+++ b/example/app/data/DemoDataSource/DemoPackage/recipe_links/attribute_selector_tabs_blueprint.json
@@ -19,13 +19,16 @@
       "plugin": "UiPluginSelector",
       "config": {
         "type": "blueprints/Plugins/UiPluginSelectorConfig",
-        "recipes": ["Yaml", "Edit"]
+        "recipes": [
+          "Yaml",
+          "Edit"
+        ]
       }
     },
     {
       "name": "Yaml",
       "type": "CORE:UiRecipe",
-      "plugin": "yaml",
+      "plugin": "@development-framework/dm-core-plugins/yaml",
       "category": "container"
     },
     {

--- a/example/app/data/DemoDataSource/DemoPackage/recipe_links/attribute_selector_tabs_blueprint.json
+++ b/example/app/data/DemoDataSource/DemoPackage/recipe_links/attribute_selector_tabs_blueprint.json
@@ -32,7 +32,7 @@
       "type": "CORE:UiRecipe",
       "name": "Edit",
       "description": "Default edit",
-      "plugin": "form"
+      "plugin": "@development-framework/dm-core-plugins/form"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/DemoPackage/recipe_links/attribute_selector_tabs_blueprint.json
+++ b/example/app/data/DemoDataSource/DemoPackage/recipe_links/attribute_selector_tabs_blueprint.json
@@ -19,10 +19,7 @@
       "plugin": "UiPluginSelector",
       "config": {
         "type": "blueprints/Plugins/UiPluginSelectorConfig",
-        "recipes": [
-          "Yaml",
-          "Edit"
-        ]
+        "recipes": ["Yaml", "Edit"]
       }
     },
     {

--- a/example/app/data/DemoDataSource/DemoPackage/recipe_links/dashboard.json
+++ b/example/app/data/DemoDataSource/DemoPackage/recipe_links/dashboard.json
@@ -35,7 +35,7 @@
             "scope": "aNestedObjectWithCustomUI",
             "recipe": {
               "type": "CORE:UiRecipe",
-              "plugin": "form",
+              "plugin": "@development-framework/dm-core-plugins/form",
               "name": "form",
               "config": {
                 "type": "blueprints/Plugins/Form/FormInput",
@@ -100,7 +100,7 @@
     {
       "name": "Edit",
       "type": "CORE:UiRecipe",
-      "plugin": "form"
+      "plugin": "@development-framework/dm-core-plugins/form"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/DemoPackage/recipe_links/dashboard.json
+++ b/example/app/data/DemoDataSource/DemoPackage/recipe_links/dashboard.json
@@ -95,7 +95,7 @@
     {
       "name": "Yaml",
       "type": "CORE:UiRecipe",
-      "plugin": "yaml"
+      "plugin": "@development-framework/dm-core-plugins/yaml"
     },
     {
       "name": "Edit",

--- a/example/app/data/DemoDataSource/DemoPackage/recipe_links/dummy_blueprint.json
+++ b/example/app/data/DemoDataSource/DemoPackage/recipe_links/dummy_blueprint.json
@@ -11,7 +11,7 @@
     {
       "name": "Yaml",
       "type": "CORE:UiRecipe",
-      "plugin": "yaml"
+      "plugin": "@development-framework/dm-core-plugins/yaml"
     },
     {
       "type": "CORE:UiRecipe",

--- a/example/app/data/DemoDataSource/DemoPackage/recipe_links/dummy_blueprint.json
+++ b/example/app/data/DemoDataSource/DemoPackage/recipe_links/dummy_blueprint.json
@@ -22,7 +22,7 @@
     {
       "name": "Diagram",
       "type": "CORE:UiRecipe",
-      "plugin": "blueprint-hierarchy"
+      "plugin": "@development-framework/dm-core-plugins/blueprint-hierarchy"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/DemoPackage/recipe_links/example_application.json
+++ b/example/app/data/DemoDataSource/DemoPackage/recipe_links/example_application.json
@@ -6,10 +6,7 @@
     "type": "CORE:UiRecipe",
     "plugin": "@development-framework/dm-core-plugins/header",
     "config": {
-      "uiRecipesList": [
-        "Yaml",
-        "Explorer"
-      ],
+      "uiRecipesList": ["Yaml", "Explorer"],
       "type": "blueprints/Plugins/HeaderPluginConfig",
       "hideAbout": false,
       "hideUserInfo": false
@@ -30,7 +27,7 @@
     {
       "name": "Explorer",
       "type": "CORE:UiRecipe",
-      "plugin": "explorer"
+      "plugin": "@development-framework/dm-core-plugins/explorer"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/DemoPackage/recipe_links/example_application.json
+++ b/example/app/data/DemoDataSource/DemoPackage/recipe_links/example_application.json
@@ -4,9 +4,12 @@
   "initialUiRecipe": {
     "name": "Header",
     "type": "CORE:UiRecipe",
-    "plugin": "header",
+    "plugin": "@development-framework/dm-core-plugins/header",
     "config": {
-      "uiRecipesList": ["Yaml", "Explorer"],
+      "uiRecipesList": [
+        "Yaml",
+        "Explorer"
+      ],
       "type": "blueprints/Plugins/HeaderPluginConfig",
       "hideAbout": false,
       "hideUserInfo": false

--- a/example/app/data/DemoDataSource/DemoPackage/recipe_links/example_application.json
+++ b/example/app/data/DemoDataSource/DemoPackage/recipe_links/example_application.json
@@ -6,7 +6,10 @@
     "type": "CORE:UiRecipe",
     "plugin": "@development-framework/dm-core-plugins/header",
     "config": {
-      "uiRecipesList": ["Yaml", "Explorer"],
+      "uiRecipesList": [
+        "Yaml",
+        "Explorer"
+      ],
       "type": "blueprints/Plugins/HeaderPluginConfig",
       "hideAbout": false,
       "hideUserInfo": false
@@ -16,7 +19,7 @@
     {
       "name": "Yaml",
       "type": "CORE:UiRecipe",
-      "plugin": "yaml"
+      "plugin": "@development-framework/dm-core-plugins/yaml"
     },
     {
       "type": "CORE:UiRecipe",

--- a/example/app/data/DemoDataSource/DemoPackage/recipe_links/example_application.json
+++ b/example/app/data/DemoDataSource/DemoPackage/recipe_links/example_application.json
@@ -6,10 +6,7 @@
     "type": "CORE:UiRecipe",
     "plugin": "@development-framework/dm-core-plugins/header",
     "config": {
-      "uiRecipesList": [
-        "Yaml",
-        "Explorer"
-      ],
+      "uiRecipesList": ["Yaml", "Explorer"],
       "type": "blueprints/Plugins/HeaderPluginConfig",
       "hideAbout": false,
       "hideUserInfo": false
@@ -25,7 +22,7 @@
       "type": "CORE:UiRecipe",
       "name": "Edit",
       "description": "Default edit",
-      "plugin": "form"
+      "plugin": "@development-framework/dm-core-plugins/form"
     },
     {
       "name": "Explorer",

--- a/example/app/data/DemoDataSource/DemoPackage/recipe_links/formBlueprint.json
+++ b/example/app/data/DemoDataSource/DemoPackage/recipe_links/formBlueprint.json
@@ -17,7 +17,10 @@
       "plugin": "UiPluginSelector",
       "config": {
         "type": "blueprints/Plugins/UiPluginSelectorConfig",
-        "recipes": ["Yaml", "Edit"]
+        "recipes": [
+          "Yaml",
+          "Edit"
+        ]
       }
     },
     {
@@ -73,16 +76,27 @@
             "type": "blueprints/Plugins/Form/fields/ArrayField",
             "name": "listOfObjects",
             "widget": "TableWidget",
-            "columns": ["name", "foo", "bar", "baz"]
+            "columns": [
+              "name",
+              "foo",
+              "bar",
+              "baz"
+            ]
           }
         ],
-        "order": ["name", "type", "description", "aBool", "*"]
+        "order": [
+          "name",
+          "type",
+          "description",
+          "aBool",
+          "*"
+        ]
       }
     },
     {
       "name": "Yaml",
       "type": "CORE:UiRecipe",
-      "plugin": "yaml"
+      "plugin": "@development-framework/dm-core-plugins/yaml"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/DemoPackage/recipe_links/formBlueprint.json
+++ b/example/app/data/DemoDataSource/DemoPackage/recipe_links/formBlueprint.json
@@ -17,10 +17,7 @@
       "plugin": "UiPluginSelector",
       "config": {
         "type": "blueprints/Plugins/UiPluginSelectorConfig",
-        "recipes": [
-          "Yaml",
-          "Edit"
-        ]
+        "recipes": ["Yaml", "Edit"]
       }
     },
     {
@@ -76,21 +73,10 @@
             "type": "blueprints/Plugins/Form/fields/ArrayField",
             "name": "listOfObjects",
             "widget": "TableWidget",
-            "columns": [
-              "name",
-              "foo",
-              "bar",
-              "baz"
-            ]
+            "columns": ["name", "foo", "bar", "baz"]
           }
         ],
-        "order": [
-          "name",
-          "type",
-          "description",
-          "aBool",
-          "*"
-        ]
+        "order": ["name", "type", "description", "aBool", "*"]
       }
     },
     {

--- a/example/app/data/DemoDataSource/DemoPackage/recipe_links/formBlueprint.json
+++ b/example/app/data/DemoDataSource/DemoPackage/recipe_links/formBlueprint.json
@@ -23,7 +23,7 @@
     {
       "name": "Edit",
       "type": "CORE:UiRecipe",
-      "plugin": "form",
+      "plugin": "@development-framework/dm-core-plugins/form",
       "category": "edit",
       "config": {
         "type": "blueprints/Plugins/Form/FormInput",

--- a/example/app/data/DemoDataSource/DemoPackage/recipe_links/nested.json
+++ b/example/app/data/DemoDataSource/DemoPackage/recipe_links/nested.json
@@ -17,13 +17,13 @@
     {
       "name": "Form",
       "type": "CORE:UiRecipe",
-      "plugin": "form",
+      "plugin": "@development-framework/dm-core-plugins/form",
       "category": "edit"
     },
     {
       "name": "aRecipeName",
       "type": "CORE:UiRecipe",
-      "plugin": "form",
+      "plugin": "@development-framework/dm-core-plugins/form",
       "category": "edit",
       "config": {
         "type": "blueprints/Plugins/Form/FormInput",

--- a/example/app/data/DemoDataSource/DemoPackage/recipe_links/nested.json
+++ b/example/app/data/DemoDataSource/DemoPackage/recipe_links/nested.json
@@ -11,7 +11,7 @@
     {
       "name": "custom",
       "type": "CORE:UiRecipe",
-      "plugin": "yaml",
+      "plugin": "@development-framework/dm-core-plugins/yaml",
       "category": "view"
     },
     {

--- a/example/app/data/DemoDataSource/DemoPackage/recipe_links/singleField.json
+++ b/example/app/data/DemoDataSource/DemoPackage/recipe_links/singleField.json
@@ -5,7 +5,7 @@
     {
       "name": "Yaml",
       "type": "CORE:UiRecipe",
-      "plugin": "yaml"
+      "plugin": "@development-framework/dm-core-plugins/yaml"
     },
     {
       "type": "CORE:UiRecipe",

--- a/example/app/data/DemoDataSource/DemoPackage/recipe_links/singleField.json
+++ b/example/app/data/DemoDataSource/DemoPackage/recipe_links/singleField.json
@@ -10,7 +10,7 @@
     {
       "type": "CORE:UiRecipe",
       "name": "Form",
-      "plugin": "form"
+      "plugin": "@development-framework/dm-core-plugins/form"
     }
   ]
 }

--- a/packages/dm-core-plugins/package.json
+++ b/packages/dm-core-plugins/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@development-framework/dm-core-plugins",
   "license": "MIT",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "main": "dist/index.js",
   "dependencies": {
     "@development-framework/dm-core": "^1.0.41",

--- a/packages/dm-core-plugins/src/index.tsx
+++ b/packages/dm-core-plugins/src/index.tsx
@@ -43,7 +43,7 @@ export const plugins: TPlugin[] = [
     component: JobInputEditPlugin,
   },
   {
-    pluginName: 'form',
+    pluginName: '@development-framework/dm-core-plugins/form',
     component: FormPlugin,
   },
   {

--- a/packages/dm-core-plugins/src/index.tsx
+++ b/packages/dm-core-plugins/src/index.tsx
@@ -39,7 +39,7 @@ export const plugins: TPlugin[] = [
     component: JobControlPlugin,
   },
   {
-    pluginName: 'jobInputEdit',
+    pluginName: '@development-framework/dm-core-plugins/jobInputEdit',
     component: JobInputEditPlugin,
   },
   {

--- a/packages/dm-core-plugins/src/index.tsx
+++ b/packages/dm-core-plugins/src/index.tsx
@@ -47,7 +47,7 @@ export const plugins: TPlugin[] = [
     component: FormPlugin,
   },
   {
-    pluginName: 'header',
+    pluginName: '@development-framework/dm-core-plugins/header',
     component: HeaderPlugin,
   },
   {

--- a/packages/dm-core-plugins/src/index.tsx
+++ b/packages/dm-core-plugins/src/index.tsx
@@ -35,7 +35,7 @@ export const plugins: TPlugin[] = [
     component: BlueprintHierarchyPlugin,
   },
   {
-    pluginName: 'jobControl',
+    pluginName: '@development-framework/dm-core-plugins/jobControl',
     component: JobControlPlugin,
   },
   {

--- a/packages/dm-core-plugins/src/index.tsx
+++ b/packages/dm-core-plugins/src/index.tsx
@@ -31,7 +31,7 @@ export const plugins: TPlugin[] = [
     component: AttributeSelectorPlugin,
   },
   {
-    pluginName: 'blueprint-hierarchy',
+    pluginName: '@development-framework/dm-core-plugins/blueprint-hierarchy',
     component: BlueprintHierarchyPlugin,
   },
   {

--- a/packages/dm-core-plugins/src/index.tsx
+++ b/packages/dm-core-plugins/src/index.tsx
@@ -19,7 +19,7 @@ export const plugins: TPlugin[] = [
     component: ExplorerPlugin,
   },
   {
-    pluginName: 'yaml',
+    pluginName: '@development-framework/dm-core-plugins/yaml',
     component: YamlPlugin,
   },
   {

--- a/packages/dm-core-plugins/src/index.tsx
+++ b/packages/dm-core-plugins/src/index.tsx
@@ -15,7 +15,7 @@ import { GridPlugin } from './grid/GridPlugin'
 
 export const plugins: TPlugin[] = [
   {
-    pluginName: 'explorer',
+    pluginName: '@development-framework/dm-core-plugins/explorer',
     component: ExplorerPlugin,
   },
   {


### PR DESCRIPTION
## What does this pull request change?
rename dm core plugins -> append prefix `@development-framework/dm-core-plugins/`to all plugins
## Why is this pull request needed?

## Issues related to this change
closes #96 
