### PR TITLE
fix: allow no config for header plugin

### DIFF
--- a/packages/dm-core-plugins/package.json
+++ b/packages/dm-core-plugins/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@development-framework/dm-core-plugins",
   "license": "MIT",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "main": "dist/index.js",
   "dependencies": {
     "@development-framework/dm-core": "^1.0.41",

--- a/packages/dm-core-plugins/src/header/HeaderPlugin.tsx
+++ b/packages/dm-core-plugins/src/header/HeaderPlugin.tsx
@@ -41,6 +41,12 @@ type THeaderPluginConfig = {
   hideAbout: boolean
 }
 
+const defaultHeaderPluginConfig = {
+  uiRecipesList: [],
+  hideUserInfo: false,
+  hideAbout: false,
+}
+
 type TRecipeConfigAndPlugin = {
   config?: TGenericObject
   component: (props: IUIPlugin) => JSX.Element
@@ -48,7 +54,10 @@ type TRecipeConfigAndPlugin = {
 
 export default (props: IUIPlugin): JSX.Element => {
   const { idReference, config: passedConfig, type } = props
-  const config = passedConfig as THeaderPluginConfig
+  const config: THeaderPluginConfig = {
+    ...defaultHeaderPluginConfig,
+    ...passedConfig,
+  }
   const [entity, isApplicationLoading] = useDocument<TApplication>(idReference)
   const { uiRecipes, isLoading: isBlueprintLoading } = useBlueprint(type)
   const [aboutOpen, setAboutOpen] = useState(false)

--- a/packages/dm-core-plugins/src/header/README.md
+++ b/packages/dm-core-plugins/src/header/README.md
@@ -13,6 +13,9 @@ The Header plugin can accept a config of type `HeaderPluginConfig` (see `bluepri
 Explanation of the attributes:
 
 * `uiRecipesList`: Can be used to specify a list of UI recipes the user can select. By default, the fist UI recipe in
-  the list is displayed. If the list is empty, all UI recipes will be included.
-* `hideAbout`: Is a boolean value that determines if the About button in the header is activated
-* `hideUserInfo`: Is a boolean value that determines if the User info button in the header is activated
+  the list is displayed. If the list is empty, all UI recipes will be included. If not
+  specified, defaults to empty list.
+* `hideAbout`: Is a boolean value that determines if the About button in the header is activated. If not specified,
+  defaults to false.
+* `hideUserInfo`: Is a boolean value that determines if the User info button in the header is activated. If not
+  specified, defaults to false.


### PR DESCRIPTION
## What does this pull request change?
allow no config for header plugin
## Why is this pull request needed?

## Issues related to this change
closes #97 
