### PR TITLE
fix: bug when saving optional value in form plugin

### DIFF
--- a/example/app/data/DemoDataSource/DemoPackage/blueprints/Product.json
+++ b/example/app/data/DemoDataSource/DemoPackage/blueprints/Product.json
@@ -12,6 +12,12 @@
       "type": "CORE:BlueprintAttribute",
       "name": "something",
       "optional": true
+    },
+    {
+      "attributeType": "number",
+      "type": "CORE:BlueprintAttribute",
+      "name": "price",
+      "optional": true
     }
   ]
 }

--- a/packages/dm-core-plugins/package.json
+++ b/packages/dm-core-plugins/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@development-framework/dm-core-plugins",
   "license": "MIT",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "main": "dist/index.js",
   "dependencies": {
     "@development-framework/dm-core": "^1.0.51",

--- a/packages/dm-core-plugins/src/form/Form.tsx
+++ b/packages/dm-core-plugins/src/form/Form.tsx
@@ -6,6 +6,7 @@ import { ObjectField } from './fields/ObjectField'
 import { TFormProps } from './types'
 import { RegistryProvider } from './RegistryContext'
 import styled from 'styled-components'
+import { TGenericObject } from '@development-framework/dm-core'
 
 const Wrapper = styled.div`
   max-width: 650px;
@@ -32,8 +33,18 @@ export const Form = (props: TFormProps) => {
   // Every react hook form controller needs to have a unique name
   const namePath: string = ''
 
+  const convertNullToUndefined = (obj: TGenericObject) => {
+    Object.keys(obj).forEach((key) => {
+      if (obj[key] === null) {
+        obj[key] = undefined
+      }
+    })
+    return obj
+  }
+
   const handleSubmit = methods.handleSubmit((data) => {
-    if (onSubmit !== undefined) onSubmit(data)
+    // since react-hook-form cannot handle undefined values, we have to convert null values to undefined before submitting.
+    if (onSubmit !== undefined) onSubmit(convertNullToUndefined(data))
   })
 
   return (

--- a/packages/dm-core-plugins/src/form/fields/NumberField.test.tsx
+++ b/packages/dm-core-plugins/src/form/fields/NumberField.test.tsx
@@ -169,5 +169,57 @@ describe('NumberField', () => {
         expect(onSubmit).toHaveBeenCalledTimes(0)
       })
     })
+
+    it('should handle an empty number change event', async () => {
+      mockBlueprintGet([
+        {
+          name: 'SingleField',
+          type: 'system/SIMOS/Blueprint',
+          attributes: [
+            {
+              name: 'foo',
+              type: 'system/SIMOS/BlueprintAttribute',
+              attributeType: 'number',
+              default: '432',
+              optional: true,
+            },
+          ],
+        },
+      ])
+      let value = 567
+
+      const formData = {
+        foo: value,
+      }
+
+      render(<Form type="SingleField" formData={formData} />, { wrapper })
+      await waitFor(() => {
+        expect(screen.getByTestId('form-textfield').getAttribute('value')).toBe(
+          String(value)
+        )
+      })
+
+      userEvent.type(
+        screen.getByTestId('form-textfield'),
+        '{backspace}{backspace}{backspace}{backspace}123'
+      )
+
+      await waitFor(() => {
+        expect(screen.getByTestId('form-textfield').getAttribute('value')).toBe(
+          '123'
+        )
+      })
+
+      userEvent.type(
+        screen.getByTestId('form-textfield'),
+        '{backspace}{backspace}{backspace}'
+      )
+
+      await waitFor(() => {
+        expect(screen.getByTestId('form-textfield').getAttribute('value')).toBe(
+          ''
+        )
+      })
+    })
   })
 })

--- a/packages/dm-core-plugins/src/form/fields/NumberField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/NumberField.tsx
@@ -47,19 +47,24 @@ export const NumberField = (props: TNumberFieldProps) => {
         required: !optional,
         pattern: { value: /^[0-9]+$/g, message: 'Only digits allowed' },
       }}
-      defaultValue={defaultValue || undefined}
+      defaultValue={defaultValue || null}
       render={({
         field: { ref, onChange, ...props },
         fieldState: { invalid, error },
       }) => {
         // Convert to number
-        const handleChange = (value: string) => {
-          onChange(asNumber(value))
+        const handleChange = (value: string | null) => {
+          if (value === null) {
+            onChange(null)
+          } else {
+            onChange(asNumber(value))
+          }
         }
         return (
           <Widget
             {...props}
             onChange={handleChange}
+            value={props.value ?? ''}
             type="number"
             id={namePath}
             label={displayLabel}

--- a/packages/dm-core-plugins/src/form/fields/StringField.test.tsx
+++ b/packages/dm-core-plugins/src/form/fields/StringField.test.tsx
@@ -240,18 +240,40 @@ describe('StringField', () => {
               type: 'system/SIMOS/BlueprintAttribute',
               attributeType: 'string',
               default: 'bare',
+              optional: true,
             },
           ],
         },
       ])
+      let value = 'beep'
       const formData = {
-        foo: 'beep',
+        foo: value,
       }
+
       render(<Form type="SingleField" formData={formData} />, { wrapper })
       await waitFor(() => {
-        fireEvent.change(screen.getByTestId('form-textfield'), {
-          target: { value: '' },
-        })
+        expect(screen.getByTestId('form-textfield').getAttribute('value')).toBe(
+          value
+        )
+      })
+
+      userEvent.type(
+        screen.getByTestId('form-textfield'),
+        '{backspace}{backspace}{backspace}{backspace}hei'
+      )
+
+      await waitFor(() => {
+        expect(screen.getByTestId('form-textfield').getAttribute('value')).toBe(
+          'hei'
+        )
+      })
+
+      userEvent.type(
+        screen.getByTestId('form-textfield'),
+        '{backspace}{backspace}{backspace}'
+      )
+
+      await waitFor(() => {
         expect(screen.getByTestId('form-textfield').getAttribute('value')).toBe(
           ''
         )

--- a/packages/dm-core-plugins/src/form/fields/StringField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/StringField.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
 import { TStringFieldProps } from '../types'
 import { useRegistryContext } from '../RegistryContext'
+import { asNumber } from './NumberField'
 
 const formatDate = (date: string) => {
   return new Date(date).toLocaleString(navigator.language)
@@ -23,7 +24,7 @@ export const StringField = (props: TStringFieldProps) => {
       rules={{
         required: !optional,
       }}
-      defaultValue={defaultValue || ''}
+      defaultValue={defaultValue ?? ''}
       render={({
         field: { ref, value, ...props },
         fieldState: { invalid, error },
@@ -38,7 +39,7 @@ export const StringField = (props: TStringFieldProps) => {
           <Widget
             readOnly={readOnly}
             {...props}
-            value={value}
+            value={value ?? ''}
             id={namePath}
             label={displayLabel}
             inputRef={ref}

--- a/packages/dm-core-plugins/src/form/widgets/TextWidget/TextWidget.tsx
+++ b/packages/dm-core-plugins/src/form/widgets/TextWidget/TextWidget.tsx
@@ -10,19 +10,22 @@ Icon.add({ error_filled })
 const TextWidget = (props: TWidget) => {
   const { label, onChange } = props
 
-  const _onChange = ({
-    target: { value },
-  }: React.ChangeEvent<HTMLInputElement>) => onChange(value === '' ? '' : value)
+  const onChangeHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = event.target
+    const formattedValue = value === '' ? null : value
+    onChange(formattedValue)
+  }
+
   return (
     <TextField
       id={props.id}
       readOnly={props.readOnly}
-      value={props.value}
+      defaultValue={props.value}
       onClick={props.onClick}
       inputRef={props.inputRef}
       variant={props.variant}
       helperText={props.helperText}
-      onChange={_onChange}
+      onChange={onChangeHandler}
       label={label}
       data-testid="form-textfield"
     />

--- a/packages/dm-core-plugins/src/form/widgets/TextareaWidget/TextareaWidget.tsx
+++ b/packages/dm-core-plugins/src/form/widgets/TextareaWidget/TextareaWidget.tsx
@@ -10,9 +10,11 @@ Icon.add({ error_filled })
 const TextareaWidget = (props: TWidget) => {
   const { label, onChange } = props
 
-  const _onChange = ({
-    target: { value },
-  }: React.ChangeEvent<HTMLInputElement>) => onChange(value === '' ? '' : value)
+  const onChangeHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = event.target
+    const formattedValue = value === '' ? null : value
+    onChange(formattedValue)
+  }
 
   return (
     // @ts-ignore
@@ -20,7 +22,7 @@ const TextareaWidget = (props: TWidget) => {
       {...props}
       multiline={true}
       rows={5}
-      onChange={_onChange}
+      onChange={onChangeHandler}
       label={label}
     />
   )


### PR DESCRIPTION
## What does this pull request change?
fix bug in form:

bug:
1) update an optional text field (for example `aOptionalNumber` in FormExample.json)
2) save
3) update the same text field:  delete the content of `aOptionalNumber` textfield
4) save

After these steps, the document in the database has an empty string stored in the `aOptionalNumber` attribute. 
There are 2 things wrong with this:
1) even though type is a number, the saved value is a string
2) the attribute should not even be saved in the document

The correct behavior is to remove the attribute from the document.
## Why is this pull request needed?

## Issues related to this change
closes #146 
