### PR TITLE
fix: make tree view and right window in explorer plugin scrollable

### DIFF
--- a/packages/dm-core-plugins/package.json
+++ b/packages/dm-core-plugins/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@development-framework/dm-core-plugins",
   "license": "MIT",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "main": "dist/index.js",
   "dependencies": {
     "@development-framework/dm-core": "^1.0.44",
@@ -55,7 +55,8 @@
     "prebuild": "rm -rf dist",
     "copy-explorer-css-file": "cp src/explorer/components/context-menu/react-contextmenu.css  dist/explorer/components/context-menu/react-contextmenu.css",
     "copy-yaml-css-file": "cp src/yaml/index.css ./dist/yaml",
-    "build": "tsc && yarn copy-explorer-css-file && yarn copy-yaml-css-file",
+    "copy-explorer-css-file": "cp src/explorer/style.css ./dist/explorer",
+    "build": "tsc && yarn copy-explorer-css-file && yarn copy-yaml-css-file && yarn copy-explorer-css-file",
     "postbuild": "rm -rf node_modules",
     "test": "jest test",
     "posttest": "npm remove --no-save --legacy-peer-deps react styled-components",

--- a/packages/dm-core-plugins/src/explorer/ExplorerPlugin.tsx
+++ b/packages/dm-core-plugins/src/explorer/ExplorerPlugin.tsx
@@ -26,7 +26,7 @@ export const TreeWrapper = styled.div`
   height: 100vh;
   border-right: black solid 1px;
   border-radius: 2px;
-  overflow: scroll;
+  overflow: auto;
 `
 
 function wrapComponent(Component: any) {

--- a/packages/dm-core-plugins/src/explorer/ExplorerPlugin.tsx
+++ b/packages/dm-core-plugins/src/explorer/ExplorerPlugin.tsx
@@ -15,7 +15,7 @@ import {
   UIRecipesSelector,
 } from '@development-framework/dm-core'
 import { NodeRightClickMenu } from './components/context-menu/ContextMenu'
-
+import './style.css'
 import { Progress } from '@equinor/eds-core-react'
 
 export const TreeWrapper = styled.div`
@@ -26,6 +26,7 @@ export const TreeWrapper = styled.div`
   height: 100vh;
   border-right: black solid 1px;
   border-radius: 2px;
+  overflow: scroll;
 `
 
 function wrapComponent(Component: any) {

--- a/packages/dm-core-plugins/src/explorer/style.css
+++ b/packages/dm-core-plugins/src/explorer/style.css
@@ -1,3 +1,3 @@
 body .lm_content {
-  overflow: scroll;
+  overflow: auto;
 }

--- a/packages/dm-core-plugins/src/explorer/style.css
+++ b/packages/dm-core-plugins/src/explorer/style.css
@@ -1,0 +1,3 @@
+body .lm_content {
+  overflow: scroll;
+}


### PR DESCRIPTION
## What does this pull request change?
make it possible to scroll in left and right side panels in the explorer plugin.



## Why is this pull request needed?

## Issues related to this change
closes #128

