### PR TITLE
feature(ViewCreator): update to handle views with no recipe

### DIFF
--- a/packages/dm-core/package.json
+++ b/packages/dm-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@development-framework/dm-core",
-  "version": "1.0.45",
+  "version": "1.0.46",
   "license": "MIT",
   "peerDependencies": {
     "react-router-dom": ">=5.1.2",

--- a/packages/dm-core/src/components/EntityView.tsx
+++ b/packages/dm-core/src/components/EntityView.tsx
@@ -12,11 +12,15 @@ const Wrapper = styled.div`
   width: 100%;
 `
 
-type IEntityView = IUIPlugin & { recipeName?: string }
+type IEntityView = IUIPlugin & { recipeName?: string; noInit?: boolean }
 
 export const EntityView = (props: IEntityView): JSX.Element => {
-  const { idReference, type, onSubmit, onOpen, recipeName } = props
-  const { recipe, isLoading, error, getUiPlugin } = useRecipe(type, recipeName)
+  const { idReference, type, onSubmit, onOpen, recipeName, noInit } = props
+  const { recipe, isLoading, error, getUiPlugin } = useRecipe(
+    type,
+    recipeName,
+    noInit
+  )
 
   if (isLoading)
     return (

--- a/packages/dm-core/src/components/RecipeSelector.tsx
+++ b/packages/dm-core/src/components/RecipeSelector.tsx
@@ -70,11 +70,11 @@ export function RecipeSelector(
       )[] = []
       uiRecipes.forEach((recipe: TUiRecipe) => {
         if (recipe.plugin !== 'recipe-selector')
-          // Avoid recursion
+          // Avoid recursive loop
           newSelectableViews.push({
             type: 'InlineRecipeViewConfig',
             recipe: recipe,
-            scope: '',
+            scope: 'self',
           })
       })
       setSelectableViews(newSelectableViews)

--- a/packages/dm-core/src/components/ViewCreator/ViewCreator.tsx
+++ b/packages/dm-core/src/components/ViewCreator/ViewCreator.tsx
@@ -1,20 +1,26 @@
 import {
   isInlineRecipeViewConfig,
   isReferenceViewConfig,
+  isViewConfig,
+  IUIPlugin,
+  TInlineRecipeViewConfig,
+  TReferenceViewConfig,
   TViewConfig,
 } from '../../types'
-import { EntityView, Loading, useDocument, TGenericObject } from '../../index'
+import { EntityView, Loading, TGenericObject, useDocument } from '../../index'
 import React from 'react'
 import { InlineRecipeView } from './InlineRecipeView'
 import { getTarget, getType } from './utils'
 
-type TViewCreator = {
-  idReference: string
-  viewConfig: TViewConfig
+type TViewCreator = Omit<IUIPlugin, 'type'> & {
+  viewConfig: TViewConfig | TInlineRecipeViewConfig | TReferenceViewConfig
 }
 
 const getScopeDepth = (scope: string): number => {
   if (scope) {
+    if (scope === 'self') {
+      return 1
+    }
     return scope.split('.').length
   }
   return 1
@@ -32,7 +38,6 @@ const getScopeDepth = (scope: string): number => {
  * ```
  * <ViewCreator
  *    idReference={idReference}
- *    document={document}
  *    viewConfig={viewConfig} />
  * ```
  *
@@ -68,6 +73,15 @@ export const ViewCreator = (props: TViewCreator): JSX.Element => {
         type={type}
         idReference={absoluteDottedId}
         recipeName={viewConfig.recipe}
+      />
+    )
+  if (isViewConfig(viewConfig))
+    return (
+      <EntityView
+        idReference={absoluteDottedId}
+        type={type}
+        // Don't use initialUiRecipes when rendering 'self'
+        noInit={idReference === absoluteDottedId}
       />
     )
 

--- a/packages/dm-core/src/components/ViewCreator/utils.ts
+++ b/packages/dm-core/src/components/ViewCreator/utils.ts
@@ -2,7 +2,8 @@ import { TViewConfig } from '../../types'
 import { TGenericObject } from '../../index'
 
 export const getTarget = (idReference: string, viewConfig: TViewConfig) => {
-  if (viewConfig?.scope) return `${idReference}.${viewConfig.scope}`
+  if (viewConfig?.scope && viewConfig.scope !== 'self')
+    return `${idReference}.${viewConfig.scope}`
   return idReference
 }
 

--- a/packages/dm-core/src/hooks/useDocument.test.tsx
+++ b/packages/dm-core/src/hooks/useDocument.test.tsx
@@ -37,7 +37,7 @@ describe('useDocumentHook', () => {
       await waitFor(() => {
         expect(result.current[0]).toEqual(null)
         expect(result.current[1]).toEqual(false)
-        expect(result.current[3]).toEqual('error')
+        expect(result.current[3]).toEqual({ message: 'Unknown error' })
         expect(mock).toHaveBeenCalledTimes(1)
       })
     })

--- a/packages/dm-core/src/hooks/useDocument.tsx
+++ b/packages/dm-core/src/hooks/useDocument.tsx
@@ -4,6 +4,7 @@ import { DmssAPI } from '../services/api/DmssAPI'
 //@ts-ignore
 import { NotificationManager } from 'react-notifications'
 import { AuthContext } from 'react-oauth2-code-pkce'
+import { ErrorResponse } from '../services'
 
 /**
  * A hook for asynchronously working with documents.
@@ -43,11 +44,11 @@ export function useDocument<T>(
   T | null,
   boolean,
   (newDocument: T, notify: boolean) => void,
-  AxiosError<any> | null
+  ErrorResponse | null
 ] {
   const [document, setDocument] = useState<T | null>(null)
   const [isLoading, setLoading] = useState<boolean>(true)
-  const [error, setError] = useState<AxiosError<any> | null>(null)
+  const [error, setError] = useState<ErrorResponse | null>(null)
   const { token } = useContext(AuthContext)
   const dmssAPI = new DmssAPI(token)
 
@@ -66,7 +67,9 @@ export function useDocument<T>(
         setDocument(data)
         setError(null)
       })
-      .catch((error: AxiosError) => setError(error))
+      .catch((error: AxiosError<ErrorResponse>) =>
+        setError(error.response?.data || { message: 'Unknown error' })
+      )
       .finally(() => setLoading(false))
   }, [idReference])
 
@@ -91,7 +94,7 @@ export function useDocument<T>(
             'Failed to update document',
             0
           )
-        setError(error)
+        setError(error.response?.data)
       })
       .finally(() => setLoading(false))
   }

--- a/packages/dm-core/src/hooks/useRecipe.tsx
+++ b/packages/dm-core/src/hooks/useRecipe.tsx
@@ -10,7 +10,8 @@ import {
 const findRecipe = (
   initialUiRecipe: TUiRecipe | undefined,
   recipes: TUiRecipe[],
-  recipeName?: string
+  recipeName?: string,
+  noInit: boolean = false
 ): TUiRecipe => {
   // If recipe is defined, find and return the ui recipe from available recipes.
   if (recipeName) {
@@ -22,8 +23,8 @@ const findRecipe = (
     }
     return recipe
   }
-  // If not recipe is defined, use initialize recipe, or the first from recipes list or lastly fallback.
-  if (initialUiRecipe && Object.keys(initialUiRecipe).length > 0) {
+  // If no recipe is defined, use initialize recipe, or the first from recipes list or lastly fallback.
+  if (!noInit && initialUiRecipe && Object.keys(initialUiRecipe).length > 0) {
     return initialUiRecipe
   }
   if (recipes.length > 0) {
@@ -65,9 +66,14 @@ interface IUseRecipe {
  *
  * @param typeRef - The reference to the blueprint to retrieve a recipe for
  * @param recipeName - Name of recipe to find (optional)
+ * @param noInit - Do not return any initialRecipes
  * @returns A list containing the blueprint document, a boolean representing the loading state, and an Error, if any.
  */
-export const useRecipe = (typeRef: string, recipeName?: string): IUseRecipe => {
+export const useRecipe = (
+  typeRef: string,
+  recipeName?: string,
+  noInit: boolean = false
+): IUseRecipe => {
   const {
     initialUiRecipe,
     uiRecipes,
@@ -81,7 +87,7 @@ export const useRecipe = (typeRef: string, recipeName?: string): IUseRecipe => {
   return {
     recipe: isBlueprintLoading
       ? undefined
-      : findRecipe(initialUiRecipe, uiRecipes, recipeName),
+      : findRecipe(initialUiRecipe, uiRecipes, recipeName, noInit),
     isLoading: isBlueprintLoading && isPluginContextLoading,
     error,
     getUiPlugin,

--- a/packages/dm-core/src/types.ts
+++ b/packages/dm-core/src/types.ts
@@ -108,14 +108,20 @@ export type TInlineRecipeViewConfig = TViewConfig & {
   recipe: TUiRecipe
 }
 
+export function isViewConfig(
+  viewConfig: TViewConfig | TInlineRecipeViewConfig | TReferenceViewConfig
+): viewConfig is TViewConfig {
+  return viewConfig.type.split(/:|\//).at(-1) === 'ViewConfig'
+}
+
 export function isReferenceViewConfig(
-  viewConfig: TViewConfig
+  viewConfig: TViewConfig | TInlineRecipeViewConfig | TReferenceViewConfig
 ): viewConfig is TReferenceViewConfig {
   return viewConfig.type.split(/:|\//).at(-1) === 'ReferenceViewConfig'
 }
 
 export function isInlineRecipeViewConfig(
-  viewConfig: TViewConfig
+  viewConfig: TViewConfig | TInlineRecipeViewConfig | TReferenceViewConfig
 ): viewConfig is TInlineRecipeViewConfig {
   return viewConfig.type.split(/:|\//).at(-1) === 'InlineRecipeViewConfig'
 }


### PR DESCRIPTION
## What does this pull request change?
- Added option for "useRecipe" to not use "initialRecipes" (needed to avoid recursion on generated fall back ViewConfigs)
- Support for ViewConfigs with no recipe (needed for generated ViewConfigs based on attribute only)
- Partial support for special scope keyword 'self'
 

## Why is this pull request needed?

- A more standardized way of configuring plugins designed to accomodate multiple views 

## Issues related to this change
needed for #151 
