### PR TITLE
fix(attribute-selector): pass "onOpen" to views

### DIFF
--- a/example/app/data/DemoDataSource/DemoPackage/recipe_links/order.json
+++ b/example/app/data/DemoDataSource/DemoPackage/recipe_links/order.json
@@ -7,30 +7,19 @@
     "plugin": "@development-framework/dm-core-plugins/attribute-selector",
     "config": {
       "type": "PLUGINS:dm-core-plugins/attribute-selector/AttributeSelectorConfig",
-      "childTabsOnRender": true,
-      "items": [
-        {
-          "type": "PLUGINS:dm-core-plugins/attribute-selector/AttributeSelectorItem",
-          "label": "Items",
-          "view": {
-            "type": "CORE:ReferenceViewConfig",
-            "recipe": "List",
-            "scope": "items"
-          }
-        }
-      ]
+      "childTabsOnRender": true
     }
   },
   "uiRecipes": [
     {
-      "name": "Yaml",
-      "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/yaml"
-    },
-    {
       "name": "Form",
       "type": "CORE:UiRecipe",
       "plugin": "@development-framework/dm-core-plugins/form"
+    },
+    {
+      "name": "Yaml",
+      "type": "CORE:UiRecipe",
+      "plugin": "@development-framework/dm-core-plugins/yaml"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/DemoPackage/recipe_links/orderItem.json
+++ b/example/app/data/DemoDataSource/DemoPackage/recipe_links/orderItem.json
@@ -101,6 +101,12 @@
       "name": "Form",
       "type": "CORE:UiRecipe",
       "plugin": "@development-framework/dm-core-plugins/form"
+    },
+    {
+      "name": "List",
+      "type": "CORE:UiRecipe",
+      "plugin": "@development-framework/dm-core-plugins/generic-list",
+      "dimensions": "*"
     }
   ]
 }

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -33,6 +33,7 @@ function App() {
       <EntityView
         type={'dmss://DemoDataSource/DemoPackage/blueprints/OrderItem'}
         idReference={'DemoDataSource/orderExample.items'}
+        dimensions={'*'}
       />
       <h3>An application with the "header"-plugin</h3>
       <EntityView

--- a/packages/dm-core-plugins/src/attribute-selector/Content.tsx
+++ b/packages/dm-core-plugins/src/attribute-selector/Content.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react'
 import styled from 'styled-components'
-import { TGenericObject, ViewCreator } from '@development-framework/dm-core'
+import {
+  TGenericObject,
+  TViewConfig,
+  ViewCreator,
+} from '@development-framework/dm-core'
 import { TItemData } from './types'
 
 const HidableWrapper = styled.div<any>`
@@ -10,37 +14,34 @@ const HidableWrapper = styled.div<any>`
 `
 
 export const Content = (props: {
-  selectedView: number
+  selectedView: string
   items: TItemData[]
-  setFormData: Function
+  setFormData: (v: TGenericObject) => void
+  onOpen: (id: string, v: TViewConfig) => void
   formData: TGenericObject
 }): JSX.Element => {
-  const { selectedView, items, setFormData, formData } = props
+  const { selectedView, items, setFormData, formData, onOpen } = props
 
   return (
     <div style={{ width: '100%' }}>
-      {items.map((config: TItemData, index) => {
-        if (config.view.scope === undefined) {
-          return <div></div>
-        } else {
-          return (
-            <HidableWrapper key={index} hidden={index !== selectedView}>
-              <ViewCreator
-                idReference={config.rootEntityId}
-                viewConfig={config.view}
-                type={config.view.type}
-                // TODO: Fix this
-                // onSubmit={(data: TGenericObject) => {
-                //   setFormData({
-                //     ...formData,
-                //     [config.view?.scope]: data,
-                //   })
-                // }}
-              />
-            </HidableWrapper>
-          )
-        }
-      })}
+      {items.map((config: TItemData) => (
+        <HidableWrapper
+          key={config.viewId}
+          hidden={config.viewId !== selectedView}
+        >
+          <ViewCreator
+            idReference={config.rootEntityId}
+            viewConfig={config.view}
+            onOpen={onOpen}
+            onSubmit={(data: TGenericObject) => {
+              setFormData({
+                ...formData,
+                [config.viewId]: data,
+              })
+            }}
+          />
+        </HidableWrapper>
+      ))}
     </div>
   )
 }

--- a/packages/dm-core-plugins/src/attribute-selector/Sidebar.tsx
+++ b/packages/dm-core-plugins/src/attribute-selector/Sidebar.tsx
@@ -5,8 +5,8 @@ import { TItemData } from './types'
 import { availableIcons } from './Icon'
 
 export const Sidebar = (props: {
-  selectedView: number
-  setSelectedView: Function
+  selectedView: string
+  setSelectedView: (k: string) => void
   items: TItemData[]
 }): JSX.Element => {
   const { selectedView, setSelectedView, items } = props
@@ -14,17 +14,17 @@ export const Sidebar = (props: {
   return (
     <SideBar open style={{ height: 'auto' }}>
       <SideBar.Content>
-        {items.map((config: TItemData, index) => (
+        {items.map((config: TItemData) => (
           <SideBar.Link
-            key={index}
+            key={config.viewId}
             icon={
               config.view.eds_icon
                 ? availableIcons[config.view.eds_icon]
                 : subdirectory_arrow_right
             }
-            label={config.label ?? config.view.scope ?? 'self'}
-            onClick={() => setSelectedView(index)}
-            active={selectedView === index}
+            label={config.label}
+            onClick={() => setSelectedView(config.viewId)}
+            active={selectedView === config.viewId}
           />
         ))}
       </SideBar.Content>

--- a/packages/dm-core-plugins/src/attribute-selector/Tabs.tsx
+++ b/packages/dm-core-plugins/src/attribute-selector/Tabs.tsx
@@ -35,19 +35,19 @@ const TabsWrapper = styled.div`
 `
 
 export const Tabs = (props: {
-  selectedView: number
+  selectedView: string
   setSelectedView: Function
   items: TItemData[]
 }): JSX.Element => {
   const { selectedView, setSelectedView, items } = props
   return (
     <TabsWrapper>
-      {items.map((config: TItemData, index) => {
+      {items.map((config: TItemData) => {
         return (
           <Tab
-            key={index}
-            onClick={() => setSelectedView(index)}
-            active={selectedView === index}
+            key={config.viewId}
+            onClick={() => setSelectedView(config.viewId)}
+            active={selectedView === config.viewId}
           >
             {config.view.eds_icon && (
               <Icon
@@ -56,7 +56,7 @@ export const Tabs = (props: {
                 title={config.view.eds_icon}
               />
             )}
-            {config.label ?? config.view.scope ?? 'self'}
+            {config.label}
           </Tab>
         )
       })}

--- a/packages/dm-core-plugins/src/attribute-selector/types.tsx
+++ b/packages/dm-core-plugins/src/attribute-selector/types.tsx
@@ -10,7 +10,10 @@ export type TAttributeSelectorItem = {
   label?: string
 }
 export type TItemData = TAttributeSelectorItem & {
+  viewId: string
+  label: string
   rootEntityId: string
+  // onSubmit is not yet supported
   onSubmit?: (data: TItemData) => void
 }
 

--- a/packages/dm-core-plugins/src/blueprint/BlueprintPlugin.tsx
+++ b/packages/dm-core-plugins/src/blueprint/BlueprintPlugin.tsx
@@ -211,7 +211,7 @@ const BlueprintAttribute = (props: {
 
 export const BlueprintPlugin = (props: IUIPlugin) => {
   const { idReference } = props
-  const [document, _loading, updateDocument] =
+  const [document, _loading, updateDocument, error] =
     useDocument<TBlueprint>(idReference)
   const [formData, setFormData] = useState<any>({ ...document }) //TODO remove any type (requires TBlueprint to be updated)
 
@@ -223,6 +223,7 @@ export const BlueprintPlugin = (props: IUIPlugin) => {
     setFormData(document)
   }, [document])
 
+  if (error) throw new Error(JSON.stringify(error, null, 2))
   if (!document || _loading) return <Loading />
 
   return (

--- a/packages/dm-core-plugins/src/form/Form.tsx
+++ b/packages/dm-core-plugins/src/form/Form.tsx
@@ -14,16 +14,8 @@ const Wrapper = styled.div`
 `
 
 export const Form = (props: TFormProps) => {
-  const {
-    type,
-    formData,
-    widgets,
-    config,
-    onSubmit,
-    dataSourceId,
-    documentId,
-    onOpen,
-  } = props
+  const { type, formData, widgets, config, onSubmit, idReference, onOpen } =
+    props
 
   const methods = useForm({
     // Set initial state.
@@ -31,7 +23,8 @@ export const Form = (props: TFormProps) => {
   })
 
   // Every react hook form controller needs to have a unique name
-  const namePath: string = ''
+  const attributePath = idReference?.split('.', 2).slice(-1)[0] ?? ''
+  const namePath: string = attributePath === idReference ? '' : attributePath
 
   const convertNullToUndefined = (obj: TGenericObject) => {
     Object.keys(obj).forEach((key) => {
@@ -53,8 +46,7 @@ export const Form = (props: TFormProps) => {
         <RegistryProvider
           onOpen={onOpen}
           widgets={widgets}
-          dataSourceId={dataSourceId}
-          documentId={documentId}
+          idReference={idReference}
         >
           <form onSubmit={handleSubmit}>
             {type && (

--- a/packages/dm-core-plugins/src/form/FormPlugin.tsx
+++ b/packages/dm-core-plugins/src/form/FormPlugin.tsx
@@ -84,13 +84,10 @@ export const FormPlugin = (props: IUIPlugin) => {
     updateDocument(formData, true)
   }
 
-  const dataSourceId = idReference.split('/')[0]
-
   return (
     <Form
       onOpen={onOpen}
-      documentId={idReference}
-      dataSourceId={dataSourceId}
+      idReference={idReference}
       widgets={widgets}
       type={document.type}
       config={config}

--- a/packages/dm-core-plugins/src/form/RegistryContext.tsx
+++ b/packages/dm-core-plugins/src/form/RegistryContext.tsx
@@ -15,7 +15,7 @@ export const useRegistryContext = () => {
 }
 
 export const RegistryProvider = (props: any) => {
-  const { widgets, children, dataSourceId, documentId, onOpen } = props
+  const { widgets, children, idReference, onOpen } = props
 
   const allWidgets = { ...widgets, ...defaultWidgets }
 
@@ -27,8 +27,7 @@ export const RegistryProvider = (props: any) => {
 
   const value = {
     getWidget,
-    dataSourceId,
-    documentId,
+    idReference,
     onOpen,
   }
 

--- a/packages/dm-core-plugins/src/form/components/OpenObjectButton.tsx
+++ b/packages/dm-core-plugins/src/form/components/OpenObjectButton.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { Button } from '@equinor/eds-core-react'
+import { useRegistryContext } from '../RegistryContext'
+
+export const OpenObjectButton = ({ namePath }: { namePath: string }) => {
+  const { onOpen } = useRegistryContext()
+
+  return (
+    <Button
+      variant="outlined"
+      onClick={() =>
+        onOpen(namePath, {
+          type: 'ViewConfig',
+          scope: namePath,
+        })
+      }
+    >
+      Open
+    </Button>
+  )
+}

--- a/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
@@ -5,11 +5,10 @@ import { Button, Typography } from '@equinor/eds-core-react'
 import { AxiosError } from 'axios'
 import { useFieldArray, useFormContext } from 'react-hook-form'
 import styled from 'styled-components'
-import DynamicTable from '../components/DynamicTable'
 import { useRegistryContext } from '../RegistryContext'
 import { isPrimitive } from '../utils'
 import { AttributeField } from './AttributeField'
-import { OpenObject } from './ObjectField'
+import { OpenObjectButton } from '../components/OpenObjectButton'
 
 const Wrapper = styled.div`
   margin-bottom: 20px;
@@ -29,19 +28,14 @@ const Stretch = styled.div`
 
 const Sticky = styled.div``
 
-const FixedContainer = styled.div`
-  max-height: 400px;
-  overflow: auto;
-`
-
 const isPrimitiveType = (value: string): boolean => {
   return ['string', 'number', 'integer', 'number', 'boolean'].includes(value)
 }
 
 export default function Fields(props: any) {
-  const { namePath, displayLabel, type, uiAttribute } = props
+  const { namePath, displayLabel, type } = props
 
-  const { documentId, dataSourceId, onOpen } = useRegistryContext()
+  const { idReference, onOpen } = useRegistryContext()
   const dmssAPI = useDMSS()
   const { control } = useFormContext()
 
@@ -60,7 +54,7 @@ export default function Fields(props: any) {
         const data = JSON.stringify([...fields, newEntity.data])
         dmssAPI
           .documentUpdate({
-            idReference: `${documentId}.${namePath}`,
+            idReference: `${idReference}.${namePath}`,
             data: data,
             updateUncontained: false,
           })
@@ -74,53 +68,10 @@ export default function Fields(props: any) {
   }
 
   if (onOpen && !isPrimitiveType(type)) {
-    const rows: Array<any> = []
-    const columns =
-      uiAttribute && uiAttribute.columns
-        ? [...uiAttribute.columns, 'actions']
-        : ['name', 'actions']
-    fields.map((item: any, index: number) => {
-      const row: any = {}
-      columns.forEach((column: any) => (row[column] = item[column]))
-
-      row['actions'] = (
-        <div>
-          <OpenObject
-            type={type}
-            namePath={`${namePath}.${index}`}
-            contained={true}
-            dataSourceId={dataSourceId}
-            documentId={documentId}
-            entity={item}
-          />
-          <Button
-            variant="outlined"
-            type="button"
-            onClick={() => remove(index)}
-          >
-            Remove
-          </Button>
-        </div>
-      )
-
-      rows.push(row)
-    })
-
     return (
       <Wrapper>
         <Typography bold={true}>{displayLabel}</Typography>
-        <FixedContainer>
-          <DynamicTable columns={columns} rows={rows} />
-        </FixedContainer>
-        <Button
-          variant="outlined"
-          data-testid={`add-${namePath}`}
-          onClick={() => {
-            handleAddObject()
-          }}
-        >
-          Add
-        </Button>
+        <OpenObjectButton namePath={namePath} />
       </Wrapper>
     )
   }
@@ -128,33 +79,30 @@ export default function Fields(props: any) {
   return (
     <Wrapper>
       <Typography bold={true}>{displayLabel}</Typography>
-      <FixedContainer>
-        {fields.map((item: any, index: number) => {
-          return (
-            <ItemWrapper key={item.id}>
-              <Stretch>
-                <AttributeField
-                  namePath={`${namePath}.${index}`}
-                  attribute={{
-                    attributeType: type,
-                    dimensions: '',
-                  }}
-                />
-              </Stretch>
-              <Sticky>
-                <Button
-                  variant="outlined"
-                  type="button"
-                  onClick={() => remove(index)}
-                >
-                  Remove
-                </Button>
-              </Sticky>
-            </ItemWrapper>
-          )
-        })}
-      </FixedContainer>
-
+      {fields.map((item: any, index: number) => {
+        return (
+          <ItemWrapper key={item.id}>
+            <Stretch>
+              <AttributeField
+                namePath={`${namePath}.${index}`}
+                attribute={{
+                  attributeType: type,
+                  dimensions: '',
+                }}
+              />
+            </Stretch>
+            <Sticky>
+              <Button
+                variant="outlined"
+                type="button"
+                onClick={() => remove(index)}
+              >
+                Remove
+              </Button>
+            </Sticky>
+          </ItemWrapper>
+        )
+      })}
       <Button
         variant="outlined"
         data-testid={`add-${namePath}`}

--- a/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
@@ -1,5 +1,4 @@
 import {
-  // @ts-ignore
   EntityPickerButton,
   EntityView,
   ErrorResponse,
@@ -16,6 +15,7 @@ import styled from 'styled-components'
 import { useRegistryContext } from '../RegistryContext'
 import { TObjectFieldProps } from '../types'
 import { AttributeField } from './AttributeField'
+import { OpenObjectButton } from '../components/OpenObjectButton'
 
 const Wrapper = styled.div`
   margin-bottom: 20px;
@@ -61,7 +61,7 @@ const AddExternal = (props: any) => {
 }
 
 const AddObject = (props: any) => {
-  const { type, namePath, onAdd, contained, idReference } = props
+  const { type, namePath, onAdd, idReference } = props
   const { setValue } = useFormContext()
   const dmssAPI = useDMSS()
   const handleAdd = () => {
@@ -103,39 +103,6 @@ const AddObject = (props: any) => {
   )
 }
 
-export const OpenObject = (props: any) => {
-  const { type, namePath, contained, dataSourceId, documentId, entity } = props
-  const { onOpen, setValue } = useRegistryContext()
-
-  const idReference = contained
-    ? `${documentId}.${namePath}`
-    : `${dataSourceId}/${documentId}`
-  return (
-    <Button
-      variant="outlined"
-      onClick={() =>
-        onOpen({
-          attribute: namePath,
-          entity: entity || {
-            type,
-          },
-          // TODO: absoluteDottedId should be renamed to idReference after Tabs container rename it
-          absoluteDottedId: idReference,
-          onSubmit: (data: any) => {
-            const options = {
-              shouldValidate: true,
-              shouldDirty: true,
-              shouldTouch: true,
-            }
-            setValue(namePath, data, options)
-          },
-        })
-      }
-    >
-      Open
-    </Button>
-  )
-}
 const RemoveObject = (props: any) => {
   const { namePath, onRemove } = props
   const { setValue } = useFormContext()
@@ -237,7 +204,7 @@ const AttributeList = (props: any) => {
 }
 
 const External = (props: any) => {
-  const { type, namePath, contained = true, dataSourceId, documentId } = props
+  const { type, namePath, contained = true, idReference } = props
 
   const { getValues } = useFormContext()
   const { onOpen } = useRegistryContext()
@@ -245,14 +212,11 @@ const External = (props: any) => {
   const initialValue = getValues(namePath) || {
     type: type,
   }
-  const idReference = contained
-    ? `${dataSourceId}/${documentId}.${namePath}`
-    : `${dataSourceId}/${documentId}`
 
   return (
     <EntityView
       key={namePath}
-      idReference={idReference}
+      idReference={contained ? `${idReference}.${namePath}` : idReference}
       type={initialValue.type}
       onOpen={onOpen}
     />
@@ -272,7 +236,7 @@ export const Contained = (props: any): JSX.Element => {
   } = props
 
   const { getValues, setValue } = useFormContext()
-  const { documentId, dataSourceId, onOpen } = useRegistryContext()
+  const { idReference, onOpen } = useRegistryContext()
   const [isDefined, setIsDefined] = useState(
     namePath == ''
       ? getValues() !== undefined
@@ -281,9 +245,9 @@ export const Contained = (props: any): JSX.Element => {
   )
   const hasOpen = onOpen !== undefined
   const isRoot = namePath == ''
-  const values = isRoot ? getValues() : getValues(namePath)
-  // const hasValues = values !== undefined
   const shouldOpen = hasOpen && !isRoot
+
+  const attributePath = idReference?.split('.', 2).slice(-1)[0] ?? ''
 
   return (
     <Wrapper>
@@ -291,7 +255,7 @@ export const Contained = (props: any): JSX.Element => {
         <Typography bold={true}>{displayLabel}</Typography>
         {!isDefined && (
           <AddObject
-            idReference={documentId}
+            idReference={idReference}
             contained={contained}
             namePath={namePath}
             type={type}
@@ -299,14 +263,7 @@ export const Contained = (props: any): JSX.Element => {
           />
         )}
         {shouldOpen && isDefined && (
-          <OpenObject
-            type={type}
-            namePath={namePath}
-            contained={contained}
-            dataSourceId={dataSourceId}
-            documentId={documentId}
-            entity={values}
-          />
+          <OpenObjectButton namePath={`${attributePath}.${namePath}`} />
         )}
       </ItemWrapper>
       {!shouldOpen && isDefined && (
@@ -326,23 +283,15 @@ export const Contained = (props: any): JSX.Element => {
             />
           )}
           {uiRecipe && uiRecipe.plugin !== 'form' && (
-            <External
-              {...props}
-              documentId={documentId}
-              dataSourceId={dataSourceId}
-            />
+            <External {...props} idReference={idReference} />
           )}
           {(isRoot ||
             uiRecipe === null ||
             (uiRecipe && uiRecipe.plugin === 'form')) && (
             <AttributeList
-              type={type}
               namePath={namePath}
               config={uiRecipe ? uiRecipe.config : config}
               blueprint={blueprint}
-              contained={contained}
-              dataSourceId={dataSourceId}
-              documentId={documentId}
             />
           )}
         </>
@@ -396,16 +345,7 @@ export const NonContained = (props: any): JSX.Element => {
                       setValue(namePath, null, options)
                     }}
                   />
-                  {onOpen && (
-                    <OpenObject
-                      type={type}
-                      namePath={namePath}
-                      contained={contained}
-                      dataSourceId={dataSourceId}
-                      documentId={value._id}
-                      entity={value}
-                    />
-                  )}
+                  {onOpen && <OpenObjectButton namePath={namePath} />}
                 </ItemWrapper>
                 {!onOpen && (
                   <External

--- a/packages/dm-core-plugins/src/form/types.tsx
+++ b/packages/dm-core-plugins/src/form/types.tsx
@@ -1,14 +1,13 @@
 import { TViewConfig } from '@development-framework/dm-core'
 
 export type TFormProps = {
-  documentId?: string
-  dataSourceId?: string
+  idReference?: string
   type?: string
   formData?: any
-  onSubmit?: (data: any) => void
   widgets?: any
   config?: any
   onOpen?: (key: string, view: TViewConfig) => void
+  onSubmit?: (data: any) => void
 }
 
 export type TObjectFieldProps = {

--- a/packages/dm-core-plugins/src/generic-list/GenericListPlugin.tsx
+++ b/packages/dm-core-plugins/src/generic-list/GenericListPlugin.tsx
@@ -46,7 +46,7 @@ type TGenericListConfig = {
 }
 const defaultConfig: TGenericListConfig = {
   expanded: false,
-  headers: ['name'],
+  headers: ['name', 'type'],
   showDelete: true,
   defaultView: { type: 'ViewConfig', scope: 'self' },
   views: [],
@@ -125,8 +125,8 @@ export const GenericListPlugin = (
       .finally(() => setIsLoading(false))
   }
 
-  if (loading) return <Loading />
   if (error) throw new Error(JSON.stringify(error, null, 2))
+  if (loading) return <Loading />
   return (
     <div
       style={{
@@ -223,7 +223,6 @@ export const GenericListPlugin = (
                   {itemsExpanded[key] && (
                     <ViewCreator
                       idReference={`${idReference}.${index}`}
-                      type={item.type}
                       viewConfig={
                         internalConfig.views[index] ??
                         internalConfig.defaultView

--- a/packages/dm-core-plugins/src/generic-list/GenericTablePlugin.tsx
+++ b/packages/dm-core-plugins/src/generic-list/GenericTablePlugin.tsx
@@ -98,8 +98,8 @@ export const GenericTablePlugin = (
       .finally(() => setIsSaveLoading(false))
   }
 
-  if (loading) return <Loading />
   if (error) throw new Error(JSON.stringify(error, null, 2))
+  if (loading) return <Loading />
 
   return (
     <div

--- a/packages/dm-core-plugins/src/grid/GridElement.tsx
+++ b/packages/dm-core-plugins/src/grid/GridElement.tsx
@@ -1,7 +1,7 @@
 import { TGridItem, TGridArea } from './types'
 import styled from 'styled-components'
 import React from 'react'
-import { TGenericObject, ViewCreator } from '@development-framework/dm-core'
+import { ViewCreator } from '@development-framework/dm-core'
 
 const Element = styled.div`
   grid-area: ${(props: TGridArea) =>

--- a/packages/dm-core-plugins/src/job/JobControlPlugin.tsx
+++ b/packages/dm-core-plugins/src/job/JobControlPlugin.tsx
@@ -13,8 +13,8 @@ export const JobControlPlugin = (props: IUIPlugin) => {
   const [dataSourceId, documentId] = idReference.split('/', 2)
   const [document, documentLoading, updateDocument, error] =
     useDocument<TJob>(idReference)
-  if (documentLoading) return <Loading />
   if (error) throw new Error(JSON.stringify(error, null, 2))
+  if (documentLoading) return <Loading />
   if (!document) return <div>The job document is empty</div>
   return (
     <JobControl


### PR DESCRIPTION
## What does this pull request change?
- Update "attribute-selector" plugin to pass "onOpen" to Views
- Update "form"-plugins ArrayField to not render lists of complex lists if "onOpen" is passed

## Why is this pull request needed?
- Changes to "view-concept" and "attribute-selector" caused "onOpen" to no longer function

## Issues related to this change
closes #127 
