### PR TITLE
fix: avoid eslint failure

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,40 +1,40 @@
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.5.0
-  hooks:
-    - id: check-merge-conflict
-    - id: check-case-conflict
-    - id: check-json
-    - id: check-toml
-    - id: check-yaml
-    - id: trailing-whitespace
-      exclude: ^.*\.(lock)$||^docs\/
-    - id: mixed-line-ending
-      exclude: ^.*\.(lock)$||^docs\/
-    - id: detect-private-key
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: check-merge-conflict
+      - id: check-case-conflict
+      - id: check-json
+      - id: check-toml
+      - id: check-yaml
+      - id: trailing-whitespace
+        exclude: ^.*\.(lock)$||^docs\/
+      - id: mixed-line-ending
+        exclude: ^.*\.(lock)$||^docs\/
+      - id: detect-private-key
 
-- repo: https://github.com/pre-commit/mirrors-prettier
-  rev: v2.2.1
-  hooks:
-    - id: prettier
-      files: ^.*\.(ts|tsx|js|css|html|json)$
-      args: ['--config=.prettierrc.js', '--ignore-path=.prettierignore']
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.0.0-alpha.6
+    hooks:
+      - id: prettier
+        files: ^.*\.(ts|tsx|js|css|html|json)$
+        args: ['--config=.prettierrc.js', '--ignore-path=.prettierignore']
 
-- repo: https://github.com/pre-commit/mirrors-eslint
-  rev: 'v8.24.0'
-  hooks:
-  -   id: eslint
-      files: \.[jt]sx?$  # *.js, *.jsx, *.ts and *.tsx
-      types: [ file ]
-      additional_dependencies:
-        - eslint
-        - eslint-config-react-app
-        - typescript
-        - "@typescript-eslint/parser"
-        - "@typescript-eslint/eslint-plugin"
-        - eslint-config-prettier # turns off all rules that might conflict with prettier
-        - eslint-plugin-jsx-a11y # checks accessibility rules on jsx elements
-        - eslint-plugin-prettier # runs prettier as an eslint rule
-        - eslint-plugin-react # react specific linting rules
-        - eslint-plugin-react-hooks # enforces the rules of hooks
-      args: ["--config=.eslintrc.json", "--ignore-path=.eslintignore"]
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: 'v8.38.0'
+    hooks:
+      - id: eslint
+        files: \.[jt]sx?$ # *.js, *.jsx, *.ts and *.tsx
+        types: [file]
+        additional_dependencies:
+          - eslint
+          - eslint-config-react-app
+          - typescript
+          - '@typescript-eslint/parser'
+          - '@typescript-eslint/eslint-plugin'
+          - eslint-config-prettier # turns off all rules that might conflict with prettier
+          - eslint-plugin-jsx-a11y # checks accessibility rules on jsx elements
+          - eslint-plugin-prettier # runs prettier as an eslint rule
+          - eslint-plugin-react # react specific linting rules
+          - eslint-plugin-react-hooks # enforces the rules of hooks
+        args: ['--config=.eslintrc.json', '--ignore-path=.eslintignore']

--- a/example/package.json
+++ b/example/package.json
@@ -26,12 +26,6 @@
     "symlinks": "for package in ../packages/*/; do echo $package && cd $package && mkdir -p dist && cd dist && ln -sf ../src/index.tsx index.js && cd ../../../example; done",
     "remove-symlinks": "for package in ../packages/*/; do echo $package && rm -rf dist && cd ../example; done"
   },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ]
-  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/example/public/index.html
+++ b/example/public/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <link

--- a/packages/dm-core-plugins/src/blueprint/BlueprintPlugin.tsx
+++ b/packages/dm-core-plugins/src/blueprint/BlueprintPlugin.tsx
@@ -211,9 +211,8 @@ const BlueprintAttribute = (props: {
 
 export const BlueprintPlugin = (props: IUIPlugin) => {
   const { idReference } = props
-  const [document, _loading, updateDocument] = useDocument<TBlueprint>(
-    idReference
-  )
+  const [document, _loading, updateDocument] =
+    useDocument<TBlueprint>(idReference)
   const [formData, setFormData] = useState<any>({ ...document }) //TODO remove any type (requires TBlueprint to be updated)
 
   useEffect(() => {

--- a/packages/dm-core-plugins/src/form/fields/BooleanField.test.tsx
+++ b/packages/dm-core-plugins/src/form/fields/BooleanField.test.tsx
@@ -72,9 +72,8 @@ describe('BooleanField', () => {
       ])
       const { container } = render(<Form type="SingleField" />)
       await waitFor(() => {
-        const inputNode: Element | null = container.querySelector(
-          ` input[name="foo"]`
-        )
+        const inputNode: Element | null =
+          container.querySelector(` input[name="foo"]`)
         expect(inputNode).toBeDefined()
         const id = inputNode !== null ? inputNode.getAttribute('id') : ''
         expect(id).toBe('foo')
@@ -103,9 +102,8 @@ describe('BooleanField', () => {
         <Form type="SingleField" formData={formData} />
       )
       await waitFor(() => {
-        const inputNode: Element | null = container.querySelector(
-          ` input[id="foo"]`
-        )
+        const inputNode: Element | null =
+          container.querySelector(` input[id="foo"]`)
         expect(inputNode).toBeDefined()
         const value = inputNode !== null ? inputNode.getAttribute('value') : ''
         expect(value).toBe(formData.foo)
@@ -132,9 +130,8 @@ describe('BooleanField', () => {
         <Form type="SingleField" onSubmit={onSubmit} />
       )
       await waitFor(() => {
-        const inputNode: Element | null = container.querySelector(
-          ` input[id="foo"]`
-        )
+        const inputNode: Element | null =
+          container.querySelector(` input[id="foo"]`)
         expect(inputNode).toBeDefined()
         const value = inputNode !== null ? inputNode.getAttribute('value') : ''
         expect(value).toBe('true')
@@ -163,9 +160,8 @@ describe('BooleanField', () => {
       ])
       const { container } = render(<Form type="SingleField" />)
       await waitFor(() => {
-        const inputNode: Element | null = container.querySelector(
-          ` input[id="foo"]`
-        )
+        const inputNode: Element | null =
+          container.querySelector(` input[id="foo"]`)
         expect(inputNode).toBeDefined()
         const value = inputNode !== null ? inputNode.getAttribute('value') : ''
         expect(value).toBe('true')

--- a/packages/dm-core-plugins/src/form/fields/NumberField.test.tsx
+++ b/packages/dm-core-plugins/src/form/fields/NumberField.test.tsx
@@ -47,9 +47,8 @@ describe('NumberField', () => {
         <Form type="SingleField" onSubmit={onSubmit} />
       )
       await waitFor(() => {
-        const inputNode: Element | null = container.querySelector(
-          ` input[id="foo"]`
-        )
+        const inputNode: Element | null =
+          container.querySelector(` input[id="foo"]`)
         expect(inputNode).toBeDefined()
         const value = inputNode !== null ? inputNode.getAttribute('value') : ''
         expect(value).toBe('2')
@@ -83,9 +82,8 @@ describe('NumberField', () => {
         <Form type="SingleField" formData={formData} />
       )
       await waitFor(() => {
-        const inputNode: Element | null = container.querySelector(
-          ` input[id="foo"]`
-        )
+        const inputNode: Element | null =
+          container.querySelector(` input[id="foo"]`)
         expect(inputNode).toBeDefined()
         const value = inputNode !== null ? inputNode.getAttribute('value') : ''
         expect(value).toBe('2')
@@ -109,9 +107,8 @@ describe('NumberField', () => {
       const { container } = render(<Form type="SingleField" />)
 
       await waitFor(() => {
-        const inputNode: Element | null = container.querySelector(
-          ` input[id="foo"]`
-        )
+        const inputNode: Element | null =
+          container.querySelector(` input[id="foo"]`)
         expect(inputNode).toBeDefined()
         if (inputNode) {
           userEvent.type(inputNode, '2')

--- a/packages/dm-core-plugins/src/form/fields/ObjectField.test.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ObjectField.test.tsx
@@ -86,9 +86,8 @@ describe.skip('ObjectField', () => {
       mockBlueprintGet([blueprint])
       const { container } = render(<Form type="MyBlueprint" />)
       await waitFor(() => {
-        const inputNode: Element | null = container.querySelector(
-          ` input[id="foo"]`
-        )
+        const inputNode: Element | null =
+          container.querySelector(` input[id="foo"]`)
         expect(inputNode).toBeDefined()
         const id = inputNode !== null ? inputNode.getAttribute('id') : ''
         expect(id).toBe('foo')

--- a/packages/dm-core-plugins/src/form/fields/StringField.test.tsx
+++ b/packages/dm-core-plugins/src/form/fields/StringField.test.tsx
@@ -105,9 +105,8 @@ describe('StringField', () => {
         <Form type="SingleField" formData={formData} />
       )
       await waitFor(() => {
-        const inputNode: Element | null = container.querySelector(
-          ` input[id="foo"]`
-        )
+        const inputNode: Element | null =
+          container.querySelector(` input[id="foo"]`)
         expect(inputNode).toBeDefined()
         const value = inputNode !== null ? inputNode.getAttribute('value') : ''
         expect(value).toBe(formData.foo)
@@ -134,9 +133,8 @@ describe('StringField', () => {
         <Form type="SingleField" onSubmit={onSubmit} />
       )
       await waitFor(() => {
-        const inputNode: Element | null = container.querySelector(
-          ` input[id="foo"]`
-        )
+        const inputNode: Element | null =
+          container.querySelector(` input[id="foo"]`)
         expect(inputNode).toBeDefined()
         const value = inputNode !== null ? inputNode.getAttribute('value') : ''
         expect(value).toBe('boo')
@@ -166,9 +164,8 @@ describe('StringField', () => {
       const { container } = render(<Form type="SingleField" />)
 
       await waitFor(() => {
-        const inputNode: Element | null = container.querySelector(
-          ` input[id="foo"]`
-        )
+        const inputNode: Element | null =
+          container.querySelector(` input[id="foo"]`)
         expect(inputNode).toBeDefined()
         const id =
           inputNode !== null
@@ -195,9 +192,8 @@ describe('StringField', () => {
       ])
       const { container } = render(<Form type="SingleField" />)
       await waitFor(() => {
-        const inputNode: Element | null = container.querySelector(
-          ` input[id="foo"]`
-        )
+        const inputNode: Element | null =
+          container.querySelector(` input[id="foo"]`)
         expect(inputNode).toBeDefined()
         const id = inputNode !== null ? inputNode.getAttribute('id') : ''
         expect(id).toBe('foo')

--- a/packages/dm-core-plugins/src/job/JobControlPlugin.tsx
+++ b/packages/dm-core-plugins/src/job/JobControlPlugin.tsx
@@ -11,9 +11,8 @@ import { JobControl } from './JobControl'
 export const JobControlPlugin = (props: IUIPlugin) => {
   const { idReference } = props
   const [dataSourceId, documentId] = idReference.split('/', 2)
-  const [document, documentLoading, updateDocument, error] = useDocument<TJob>(
-    idReference
-  )
+  const [document, documentLoading, updateDocument, error] =
+    useDocument<TJob>(idReference)
   if (documentLoading) return <Loading />
   if (error) throw new Error(JSON.stringify(error, null, 2))
   if (!document) return <div>The job document is empty</div>

--- a/packages/dm-core-plugins/src/job/JobInputEditPlugin.tsx
+++ b/packages/dm-core-plugins/src/job/JobInputEditPlugin.tsx
@@ -12,9 +12,8 @@ import { useEffect, useState } from 'react'
 export const JobInputEditPlugin = (props: IUIPlugin) => {
   const { idReference } = props
   const [dataSourceId, documentId] = idReference.split('/', 2)
-  const [document, documentLoading, updateDocument, error] = useDocument<TJob>(
-    idReference
-  )
+  const [document, documentLoading, updateDocument, error] =
+    useDocument<TJob>(idReference)
   const [formData, setFormData] = useState<TJob | null>(null)
 
   useEffect(() => {

--- a/packages/dm-core-plugins/src/yaml/YamlPlugin.tsx
+++ b/packages/dm-core-plugins/src/yaml/YamlPlugin.tsx
@@ -80,12 +80,8 @@ const YamlView = (props: { document: TGenericObject }) => {
 export const YamlPlugin = (props: IUIPlugin) => {
   const { idReference } = props
   // eslint-disable-next-line
-  const [
-    document,
-    loading,
-    updateDocument,
-    error,
-  ] = useDocument<TGenericObject>(idReference, 999)
+  const [document, loading, updateDocument, error] =
+    useDocument<TGenericObject>(idReference, 999)
   if (loading) return <Loading />
 
   if (error) throw new Error(JSON.stringify(error, null, 2))

--- a/packages/dm-core/src/domain/Tree.tsx
+++ b/packages/dm-core/src/domain/Tree.tsx
@@ -284,13 +284,12 @@ export class TreeNode {
       entity: { name: name, type: type },
     })
     const newEntity = { ...response.data, name: name }
-    const createResponse: AxiosResponse<any> = await this.tree.dmssApi.documentAdd(
-      {
+    const createResponse: AxiosResponse<any> =
+      await this.tree.dmssApi.documentAdd({
         absoluteRef: `${this.nodeId}${packageContent}`,
         body: newEntity,
         updateUncontained: true,
-      }
-    )
+      })
     await this.expand()
     return createResponse.data.uid
   }

--- a/packages/dm-core/src/hooks/useDocument.tsx
+++ b/packages/dm-core/src/hooks/useDocument.tsx
@@ -44,7 +44,7 @@ export function useDocument<T>(
   T | null,
   boolean,
   (newDocument: T, notify: boolean) => void,
-  ErrorResponse | null
+  ErrorResponse | null,
 ] {
   const [document, setDocument] = useState<T | null>(null)
   const [isLoading, setLoading] = useState<boolean>(true)

--- a/packages/dm-core/src/hooks/useRecipe.tsx
+++ b/packages/dm-core/src/hooks/useRecipe.tsx
@@ -97,9 +97,8 @@ export const useRecipe = (
     isLoading: isBlueprintLoading,
     error,
   } = useBlueprint(typeRef)
-  const { loading: isPluginContextLoading, getUiPlugin } = useContext(
-    UiPluginContext
-  )
+  const { loading: isPluginContextLoading, getUiPlugin } =
+    useContext(UiPluginContext)
   const [foundRecipe, setFoundRecipe] = useState<TUiRecipe>()
   const [findRecipeError, setFindRecipeError] = useState<ErrorResponse | null>(
     null


### PR DESCRIPTION
## What does this pull request change?

Updates the pre-commit hooks and fixes code according to it suggestions. Also removes the eslint config from package.json, since we're only using eslint through the pre-commit and having them there caused some strange errors when building

## Why is this pull request needed?

## Issues related to this change

