### PR TITLE
refactor: use dmss context

### DIFF
--- a/packages/dm-core-plugins/package.json
+++ b/packages/dm-core-plugins/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@development-framework/dm-core-plugins",
   "license": "MIT",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "main": "dist/index.js",
   "dependencies": {
-    "@development-framework/dm-core": "^1.0.49",
+    "@development-framework/dm-core": "^1.0.51",
     "@equinor/eds-core-react": "^0.29.1",
     "@equinor/eds-icons": "^0.18.0",
     "@equinor/eds-tokens": "^0.9.0",

--- a/packages/dm-core-plugins/src/blueprint-hierarchy/BlueprintHierarchyPlugin.tsx
+++ b/packages/dm-core-plugins/src/blueprint-hierarchy/BlueprintHierarchyPlugin.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react'
-import { useContext, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import {
-  AuthContext,
   DmssAPI,
   IUIPlugin,
   Loading,
+  useDMSS,
   useDocument,
 } from '@development-framework/dm-core'
-import MermaidWrapper from './MermaidWrapper'
 import { dfs, loader, Node } from './loader'
+import MermaidWrapper from './MermaidWrapper'
 import { TAttributeType } from './types'
 
 const classElement = (node: Node) => {
@@ -75,8 +75,7 @@ function useExplorer(dmssAPI: DmssAPI) {
 
 export const BlueprintHierarchyPlugin = (props: IUIPlugin) => {
   const { idReference } = props
-  const { token } = useContext(AuthContext)
-  const dmssAPI = new DmssAPI(token)
+  const dmssAPI = useDMSS()
   const explorer = useExplorer(dmssAPI)
 
   const [chart, setChart] = useState<string | undefined>(undefined)
@@ -84,7 +83,7 @@ export const BlueprintHierarchyPlugin = (props: IUIPlugin) => {
   const [document, isLoading] = useDocument(idReference)
 
   useEffect(() => {
-    loader(token, explorer, document).then(async (tree: Node) => {
+    loader(explorer, document).then(async (tree: Node) => {
       const chart = createChart(tree)
       setChart(chart)
     })

--- a/packages/dm-core-plugins/src/explorer/components/context-menu/ContextMenu.tsx
+++ b/packages/dm-core-plugins/src/explorer/components/context-menu/ContextMenu.tsx
@@ -1,37 +1,36 @@
-import React, { useContext, useState } from 'react'
-import { Button, Input, Label, Progress } from '@equinor/eds-core-react'
-import './../../style.css'
-import { ContextMenu, ContextMenuTrigger } from 'react-contextmenu'
-import { AxiosError } from 'axios'
 import {
-  AuthContext,
-  EBlueprint,
-  DmssAPI,
-  TreeNode,
-  Dialog,
   BlueprintPicker,
-  INPUT_FIELD_WIDTH,
+  Dialog,
+  DmssAPI,
+  EBlueprint,
   ErrorResponse,
+  INPUT_FIELD_WIDTH,
   TNodeWrapperProps,
+  TreeNode,
+  useDMSS,
 } from '@development-framework/dm-core'
+import { Button, Input, Label, Progress } from '@equinor/eds-core-react'
+import { AxiosError } from 'axios'
+import React, { useState } from 'react'
+import { ContextMenu, ContextMenuTrigger } from 'react-contextmenu'
+import './../../style.css'
 
 // @ts-ignore
 import { NotificationManager } from 'react-notifications'
-import { createContextMenuItems } from './utils/createContextMenuItmes'
-import { SingleTextInput } from './utils/SingleTextInput'
-import { DialogContent, edsButtonStyleConfig } from './utils/styles'
 import {
   DeleteAction,
   NewFolderAction,
   NewRootPackageAction,
 } from './utils/contextMenuActions'
+import { createContextMenuItems } from './utils/createContextMenuItmes'
+import { SingleTextInput } from './utils/SingleTextInput'
+import { DialogContent, edsButtonStyleConfig } from './utils/styles'
 
 //Component that can be used when a context menu action requires one text (string) input.
 
 export const NodeRightClickMenu = (props: TNodeWrapperProps) => {
-  const { node, children, removeNode } = props
-  const { token } = useContext(AuthContext)
-  const dmssAPI = new DmssAPI(token, 'http://localhost:5000')
+  const { node, children } = props
+  const dmssAPI = useDMSS()
   const [scrimToShow, setScrimToShow] = useState<string>('')
   const [formData, setFormData] = useState<any>('')
   const [loading, setLoading] = useState<boolean>(false)

--- a/packages/dm-core-plugins/src/form/Form.test.tsx
+++ b/packages/dm-core-plugins/src/form/Form.test.tsx
@@ -1,7 +1,7 @@
 import { render, waitFor } from '@testing-library/react'
 import React from 'react'
 import { Form } from './Form'
-import { mockBlueprintGet } from './test-utils'
+import { mockBlueprintGet, wrapper } from './test-utils'
 
 describe('Form', () => {
   afterEach(() => {
@@ -29,7 +29,7 @@ describe('Form', () => {
         },
       ])
 
-      const { container } = render(<Form type="Root" />)
+      const { container } = render(<Form type="Root" />, { wrapper })
       await waitFor(() => {
         expect(container.querySelector(`input[id="foo"]`)).toBeTruthy()
         expect(container.querySelector(`input[id="bar"]`)).toBeTruthy()
@@ -77,7 +77,9 @@ describe('Form', () => {
           bar: '',
         },
       }
-      const { container } = render(<Form type="Root" formData={formData} />)
+      const { container } = render(<Form type="Root" formData={formData} />, {
+        wrapper,
+      })
       await waitFor(() => {
         expect(container.querySelector(`input[id="foo"]`)).toBeTruthy()
         expect(container.querySelector(`input[id="child.bar"]`)).toBeTruthy()
@@ -113,7 +115,9 @@ describe('Form', () => {
         ],
       }
 
-      const { container } = render(<Form type="Root" config={config} />)
+      const { container } = render(<Form type="Root" config={config} />, {
+        wrapper,
+      })
       await waitFor(() => {
         expect(container.querySelector(`input[id="foo"]`)).toBeTruthy()
         // Should only call get blueprint once

--- a/packages/dm-core-plugins/src/form/fields/ArrayField.test.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ArrayField.test.tsx
@@ -1,7 +1,7 @@
-import { mockBlueprintGet } from '../test-utils'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { Form } from '../Form'
 import React from 'react'
+import { Form } from '../Form'
+import { mockBlueprintGet, wrapper } from '../test-utils'
 
 describe('ArrayField', () => {
   afterEach(() => {
@@ -31,7 +31,7 @@ describe('ArrayField', () => {
           },
         ],
       }
-      render(<Form type="MyBlueprint" formData={formData} />)
+      render(<Form type="MyBlueprint" formData={formData} />, { wrapper })
       await waitFor(() => {
         expect(screen.getByText('Could not find the blueprint')).toBeDefined()
       })
@@ -54,7 +54,7 @@ describe('ArrayField', () => {
 
     it('should contain no field in the list by default', async () => {
       mockBlueprintGet([blueprint])
-      const { container } = render(<Form type="MyBlueprint" />)
+      const { container } = render(<Form type="MyBlueprint" />, { wrapper })
       await waitFor(() => {
         expect(container.querySelectorAll(` input[type=text]`).length).toBe(0)
       })
@@ -62,7 +62,7 @@ describe('ArrayField', () => {
 
     it('should have an add button', async () => {
       mockBlueprintGet([blueprint])
-      const { container } = render(<Form type="MyBlueprint" />)
+      render(<Form type="MyBlueprint" />, { wrapper })
       await waitFor(() => {
         expect(screen.getByText('Add')).toBeDefined()
       })
@@ -70,7 +70,7 @@ describe('ArrayField', () => {
 
     it('should add a new field when clicking the add button', async () => {
       mockBlueprintGet([blueprint])
-      const { container } = render(<Form type="MyBlueprint" />)
+      const { container } = render(<Form type="MyBlueprint" />, { wrapper })
       await waitFor(() => {
         fireEvent.click(screen.getByText('Add'))
         expect(container.querySelectorAll(` input[type=text]`).length).toBe(1)
@@ -83,7 +83,8 @@ describe('ArrayField', () => {
         array: ['foo', 'bar'],
       }
       const { container } = render(
-        <Form type="MyBlueprint" formData={formData} />
+        <Form type="MyBlueprint" formData={formData} />,
+        { wrapper }
       )
       await waitFor(() => {
         const inputs = container.querySelectorAll(` input[type=text]`)
@@ -99,7 +100,8 @@ describe('ArrayField', () => {
         array: ['foo', 'bar'],
       }
       const { container } = render(
-        <Form type="MyBlueprint" formData={formData} />
+        <Form type="MyBlueprint" formData={formData} />,
+        { wrapper }
       )
       await waitFor(() => {
         const inputs = container.querySelectorAll(` input[type=text]`)
@@ -143,7 +145,8 @@ describe('ArrayField', () => {
         ],
       }
       const { container } = render(
-        <Form type="MyBlueprint" formData={formData} />
+        <Form type="MyBlueprint" formData={formData} />,
+        { wrapper }
       )
       await waitFor(() => {
         const inputs = container.querySelectorAll(` input[type=text]`)
@@ -188,7 +191,9 @@ describe('ArrayField', () => {
           },
         ],
       }
-      const { container } = render(<Form type="Root" formData={formData} />)
+      const { container } = render(<Form type="Root" formData={formData} />, {
+        wrapper,
+      })
       await waitFor(() => {
         const inputs = container.querySelectorAll(` input[type=text]`)
         expect(inputs.length).toBe(3)
@@ -200,7 +205,7 @@ describe('ArrayField', () => {
 
     it.skip('should add an inner when clicking the add button', async () => {
       mockBlueprintGet([outer, inner])
-      const { container } = render(<Form type="Root" />)
+      const { container } = render(<Form type="Root" />, { wrapper })
       await waitFor(() => {
         fireEvent.click(screen.getByTestId('add-array'))
         expect(container.querySelectorAll(` input[type=text]`).length).toBe(1)

--- a/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
@@ -1,19 +1,15 @@
-import React, { useContext } from 'react'
+import React from 'react'
 
-import { useFieldArray, useFormContext } from 'react-hook-form'
-import { AttributeField } from './AttributeField'
+import { ErrorResponse, useDMSS } from '@development-framework/dm-core'
 import { Button, Typography } from '@equinor/eds-core-react'
-import styled from 'styled-components'
-import { isPrimitive } from '../utils'
-import { useRegistryContext } from '../RegistryContext'
-import {
-  AuthContext,
-  DmssAPI,
-  ErrorResponse,
-} from '@development-framework/dm-core'
-import DynamicTable from '../components/DynamicTable'
-import { OpenObject } from './ObjectField'
 import { AxiosError } from 'axios'
+import { useFieldArray, useFormContext } from 'react-hook-form'
+import styled from 'styled-components'
+import DynamicTable from '../components/DynamicTable'
+import { useRegistryContext } from '../RegistryContext'
+import { isPrimitive } from '../utils'
+import { AttributeField } from './AttributeField'
+import { OpenObject } from './ObjectField'
 
 const Wrapper = styled.div`
   margin-bottom: 20px;
@@ -46,8 +42,7 @@ export default function Fields(props: any) {
   const { namePath, displayLabel, type, uiAttribute } = props
 
   const { documentId, dataSourceId, onOpen } = useRegistryContext()
-  const { token } = useContext(AuthContext)
-  const dmssAPI = new DmssAPI(token)
+  const dmssAPI = useDMSS()
   const { control } = useFormContext()
 
   const { fields, append, remove } = useFieldArray({

--- a/packages/dm-core-plugins/src/form/fields/AttributeField.test.tsx
+++ b/packages/dm-core-plugins/src/form/fields/AttributeField.test.tsx
@@ -1,7 +1,7 @@
-import { mockBlueprintGet } from '../test-utils'
 import { render, screen, waitFor } from '@testing-library/react'
-import { Form } from '../Form'
 import React from 'react'
+import { Form } from '../Form'
+import { mockBlueprintGet, wrapper } from '../test-utils'
 
 describe('AttributeField', () => {
   describe('Unsupported field', () => {
@@ -19,7 +19,7 @@ describe('AttributeField', () => {
           ],
         },
       ])
-      render(<Form type="SingleField" />)
+      render(<Form type="SingleField" />, { wrapper })
       await waitFor(() => {
         expect(
           screen.getByText('Could not find the blueprint', { exact: false })

--- a/packages/dm-core-plugins/src/form/fields/BooleanField.test.tsx
+++ b/packages/dm-core-plugins/src/form/fields/BooleanField.test.tsx
@@ -1,9 +1,8 @@
-import React from 'react'
-import { render, screen, waitFor, fireEvent } from '@testing-library/react'
-import { Form } from '../Form'
-import { mockBlueprintGet } from '../test-utils'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { act } from 'react-dom/test-utils'
+import React from 'react'
+import { Form } from '../Form'
+import { mockBlueprintGet, wrapper } from '../test-utils'
 
 describe('BooleanField', () => {
   afterEach(() => {
@@ -25,7 +24,7 @@ describe('BooleanField', () => {
           ],
         },
       ])
-      const { container } = render(<Form type="SingleField" />)
+      const { container } = render(<Form type="SingleField" />, { wrapper })
       await waitFor(() => {
         expect(container.querySelectorAll(` input[type=checkbox]`).length).toBe(
           1
@@ -49,7 +48,7 @@ describe('BooleanField', () => {
           ],
         },
       ])
-      const { container } = render(<Form type="SingleFieldWithLabel" />)
+      render(<Form type="SingleFieldWithLabel" />, { wrapper })
       await waitFor(() => {
         expect(screen.getByText('Foo')).toBeDefined()
       })
@@ -70,7 +69,7 @@ describe('BooleanField', () => {
           ],
         },
       ])
-      const { container } = render(<Form type="SingleField" />)
+      const { container } = render(<Form type="SingleField" />, { wrapper })
       await waitFor(() => {
         const inputNode: Element | null =
           container.querySelector(` input[name="foo"]`)
@@ -99,7 +98,8 @@ describe('BooleanField', () => {
         foo: 'beep',
       }
       const { container } = render(
-        <Form type="SingleField" formData={formData} />
+        <Form type="SingleField" formData={formData} />,
+        { wrapper }
       )
       await waitFor(() => {
         const inputNode: Element | null =
@@ -127,7 +127,8 @@ describe('BooleanField', () => {
       ])
       const onSubmit = jest.fn()
       const { container } = render(
-        <Form type="SingleField" onSubmit={onSubmit} />
+        <Form type="SingleField" onSubmit={onSubmit} />,
+        { wrapper }
       )
       await waitFor(() => {
         const inputNode: Element | null =
@@ -158,7 +159,7 @@ describe('BooleanField', () => {
           ],
         },
       ])
-      const { container } = render(<Form type="SingleField" />)
+      const { container } = render(<Form type="SingleField" />, { wrapper })
       await waitFor(() => {
         const inputNode: Element | null =
           container.querySelector(` input[id="foo"]`)

--- a/packages/dm-core-plugins/src/form/fields/NumberField.test.tsx
+++ b/packages/dm-core-plugins/src/form/fields/NumberField.test.tsx
@@ -1,8 +1,8 @@
-import React from 'react'
-import { render, screen, waitFor, fireEvent } from '@testing-library/react'
-import { Form } from '../Form'
-import { mockBlueprintGet } from '../test-utils'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import React from 'react'
+import { Form } from '../Form'
+import { mockBlueprintGet, wrapper } from '../test-utils'
 
 describe('NumberField', () => {
   describe('TextWidget', () => {
@@ -20,7 +20,7 @@ describe('NumberField', () => {
           ],
         },
       ])
-      const { container } = render(<Form type="SingleField" />)
+      const { container } = render(<Form type="SingleField" />, { wrapper })
       await waitFor(() => {
         expect(container.querySelectorAll(` input[type=text]`).length).toBe(1) // TODO type should be number not text
         expect(screen.getByText('foo')).toBeDefined()
@@ -44,7 +44,8 @@ describe('NumberField', () => {
       ])
       const onSubmit = jest.fn()
       const { container } = render(
-        <Form type="SingleField" onSubmit={onSubmit} />
+        <Form type="SingleField" onSubmit={onSubmit} />,
+        { wrapper }
       )
       await waitFor(() => {
         const inputNode: Element | null =
@@ -79,7 +80,8 @@ describe('NumberField', () => {
         foo: 2,
       }
       const { container } = render(
-        <Form type="SingleField" formData={formData} />
+        <Form type="SingleField" formData={formData} />,
+        { wrapper }
       )
       await waitFor(() => {
         const inputNode: Element | null =
@@ -104,7 +106,7 @@ describe('NumberField', () => {
           ],
         },
       ])
-      const { container } = render(<Form type="SingleField" />)
+      const { container } = render(<Form type="SingleField" />, { wrapper })
 
       await waitFor(() => {
         const inputNode: Element | null =
@@ -135,7 +137,7 @@ describe('NumberField', () => {
         },
       ])
       const onSubmit = jest.fn()
-      render(<Form type="SingleField" onSubmit={onSubmit} />)
+      render(<Form type="SingleField" onSubmit={onSubmit} />, { wrapper })
       await waitFor(() => {
         fireEvent.submit(screen.getByTestId('form-submit'))
       })
@@ -160,7 +162,7 @@ describe('NumberField', () => {
         },
       ])
       const onSubmit = jest.fn()
-      render(<Form type="SingleField" onSubmit={onSubmit} />)
+      render(<Form type="SingleField" onSubmit={onSubmit} />, { wrapper })
       fireEvent.submit(screen.getByTestId('form-submit'))
       await waitFor(() => {
         expect(onSubmit).not.toHaveBeenCalled()

--- a/packages/dm-core-plugins/src/form/fields/ObjectField.test.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ObjectField.test.tsx
@@ -1,7 +1,7 @@
-import React from 'react'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import React from 'react'
 import { Form } from '../Form'
-import { mockBlueprintGet } from '../test-utils'
+import { mockBlueprintGet, wrapper } from '../test-utils'
 
 describe.skip('ObjectField', () => {
   describe('Blueprint', () => {
@@ -27,7 +27,7 @@ describe.skip('ObjectField', () => {
 
     it('should render a string attribute', async () => {
       mockBlueprintGet([blueprint])
-      const { container } = render(<Form type="MyBlueprint" />)
+      const { container } = render(<Form type="MyBlueprint" />, { wrapper })
       await waitFor(() => {
         expect(container.querySelectorAll(` input[type=text]`).length).toBe(1)
         expect(screen.getByText('foo')).toBeDefined()
@@ -36,7 +36,7 @@ describe.skip('ObjectField', () => {
 
     it('should render a boolean attribute', async () => {
       mockBlueprintGet([blueprint])
-      const { container } = render(<Form type="MyBlueprint" />)
+      const { container } = render(<Form type="MyBlueprint" />, { wrapper })
       await waitFor(() => {
         expect(container.querySelectorAll(` input[type=checkbox]`).length).toBe(
           1
@@ -47,7 +47,7 @@ describe.skip('ObjectField', () => {
 
     it('should handle a default object value', async () => {
       mockBlueprintGet([blueprint])
-      const { container } = render(<Form type="MyBlueprint" />)
+      const { container } = render(<Form type="MyBlueprint" />, { wrapper })
 
       await waitFor(() => {
         const foo: Element | null = container.querySelector(` input[id="foo"]`)
@@ -84,7 +84,7 @@ describe.skip('ObjectField', () => {
 
     it('should render the widget with the expected id', async () => {
       mockBlueprintGet([blueprint])
-      const { container } = render(<Form type="MyBlueprint" />)
+      const { container } = render(<Form type="MyBlueprint" />, { wrapper })
       await waitFor(() => {
         const inputNode: Element | null =
           container.querySelector(` input[id="foo"]`)
@@ -122,7 +122,7 @@ describe.skip('ObjectField', () => {
       },
     ])
     const onSubmit = jest.fn()
-    render(<Form type="Parent" onSubmit={onSubmit} />)
+    render(<Form type="Parent" onSubmit={onSubmit} />, { wrapper })
     await waitFor(() => {
       // It's ok to submit
       fireEvent.submit(screen.getByText('Submit'))

--- a/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
@@ -1,24 +1,21 @@
 import {
-  DmssAPI,
   // @ts-ignore
   EntityPickerButton,
+  EntityView,
   ErrorResponse,
   Loading,
   NewEntityButton,
-  EntityView,
   useBlueprint,
-  // @ts-ignore
+  useDMSS,
 } from '@development-framework/dm-core'
-import { AxiosResponse } from 'axios'
-import React, { useContext, useState } from 'react'
-import { AttributeField } from './AttributeField'
 import { Button, Typography } from '@equinor/eds-core-react'
-import styled from 'styled-components'
-import { TObjectFieldProps } from '../types'
-import { useRegistryContext } from '../RegistryContext'
+import { AxiosError, AxiosResponse } from 'axios'
+import React, { useState } from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
-import { AxiosError } from 'axios'
-import { AuthContext } from 'react-oauth2-code-pkce'
+import styled from 'styled-components'
+import { useRegistryContext } from '../RegistryContext'
+import { TObjectFieldProps } from '../types'
+import { AttributeField } from './AttributeField'
 
 const Wrapper = styled.div`
   margin-bottom: 20px;
@@ -66,8 +63,7 @@ const AddExternal = (props: any) => {
 const AddObject = (props: any) => {
   const { type, namePath, onAdd, contained, idReference } = props
   const { setValue } = useFormContext()
-  const { token } = useContext(AuthContext)
-  const dmssAPI = new DmssAPI(token)
+  const dmssAPI = useDMSS()
   const handleAdd = () => {
     const options = {
       shouldValidate: true,

--- a/packages/dm-core-plugins/src/form/fields/StringField.test.tsx
+++ b/packages/dm-core-plugins/src/form/fields/StringField.test.tsx
@@ -1,14 +1,14 @@
-import React from 'react'
 import {
+  cleanup,
   fireEvent,
   render,
   screen,
   waitFor,
-  cleanup,
 } from '@testing-library/react'
-import { Form } from '../Form'
-import { mockBlueprintGet } from '../test-utils'
 import userEvent from '@testing-library/user-event'
+import React from 'react'
+import { Form } from '../Form'
+import { mockBlueprintGet, wrapper } from '../test-utils'
 
 describe('StringField', () => {
   afterEach(() => {
@@ -34,7 +34,7 @@ describe('StringField', () => {
           ],
         },
       ])
-      const { container } = render(<Form type="SingleField" />)
+      const { container } = render(<Form type="SingleField" />, { wrapper })
       await waitFor(() => {
         expect(container.querySelectorAll(` input[type=text]`).length).toBe(1)
         expect(screen.getByText('foo')).toBeDefined()
@@ -54,7 +54,7 @@ describe('StringField', () => {
           ],
         },
       ])
-      const { container } = render(<Form type="SingleField" />)
+      const { container } = render(<Form type="SingleField" />, { wrapper })
       await waitFor(() => {
         expect(container.querySelectorAll(` input[type=text]`).length).toBe(1)
         expect(screen.getByText('foo')).toBeDefined()
@@ -76,7 +76,9 @@ describe('StringField', () => {
           ],
         },
       ])
-      const { container } = render(<Form type="SingleFieldWithLabel" />)
+      const { container } = render(<Form type="SingleFieldWithLabel" />, {
+        wrapper,
+      })
       await waitFor(() => {
         expect(container.querySelectorAll(` input[type=text]`).length).toBe(1)
         expect(screen.getByText('Foo')).toBeDefined()
@@ -102,7 +104,8 @@ describe('StringField', () => {
         foo: 'beep',
       }
       const { container } = render(
-        <Form type="SingleField" formData={formData} />
+        <Form type="SingleField" formData={formData} />,
+        { wrapper }
       )
       await waitFor(() => {
         const inputNode: Element | null =
@@ -130,7 +133,8 @@ describe('StringField', () => {
       ])
       const onSubmit = jest.fn()
       const { container } = render(
-        <Form type="SingleField" onSubmit={onSubmit} />
+        <Form type="SingleField" onSubmit={onSubmit} />,
+        { wrapper }
       )
       await waitFor(() => {
         const inputNode: Element | null =
@@ -161,7 +165,7 @@ describe('StringField', () => {
           ],
         },
       ])
-      const { container } = render(<Form type="SingleField" />)
+      const { container } = render(<Form type="SingleField" />, { wrapper })
 
       await waitFor(() => {
         const inputNode: Element | null =
@@ -190,7 +194,7 @@ describe('StringField', () => {
           ],
         },
       ])
-      const { container } = render(<Form type="SingleField" />)
+      const { container } = render(<Form type="SingleField" />, { wrapper })
       await waitFor(() => {
         const inputNode: Element | null =
           container.querySelector(` input[id="foo"]`)
@@ -215,7 +219,7 @@ describe('StringField', () => {
           ],
         },
       ])
-      render(<Form type="SingleField" />)
+      render(<Form type="SingleField" />, { wrapper })
 
       waitFor(async () => {
         userEvent.type(screen.getByTestId('form-textfield'), 'foobar')
@@ -243,9 +247,7 @@ describe('StringField', () => {
       const formData = {
         foo: 'beep',
       }
-      const { container } = render(
-        <Form type="SingleField" formData={formData} />
-      )
+      render(<Form type="SingleField" formData={formData} />, { wrapper })
       await waitFor(() => {
         fireEvent.change(screen.getByTestId('form-textfield'), {
           target: { value: '' },
@@ -273,7 +275,8 @@ describe('StringField', () => {
       const onSubmit = jest.fn()
       const formData = {}
       render(
-        <Form type="SingleField" formData={formData} onSubmit={onSubmit} />
+        <Form type="SingleField" formData={formData} onSubmit={onSubmit} />,
+        { wrapper }
       )
       await waitFor(() => {
         fireEvent.submit(screen.getByTestId('form-submit'))
@@ -300,7 +303,8 @@ describe('StringField', () => {
       const onSubmit = jest.fn()
       const formData = {}
       render(
-        <Form type="SingleField" formData={formData} onSubmit={onSubmit} />
+        <Form type="SingleField" formData={formData} onSubmit={onSubmit} />,
+        { wrapper }
       )
       fireEvent.submit(screen.getByTestId('form-submit'))
       // The useForm "methods.handleSubmit" seems to be async, and needs to be awaited
@@ -327,7 +331,7 @@ describe('StringField', () => {
         },
       ])
       const onSubmit = jest.fn()
-      render(<Form type="SingleField" onSubmit={onSubmit} />)
+      render(<Form type="SingleField" onSubmit={onSubmit} />, { wrapper })
       fireEvent.submit(screen.getByRole('button'))
       await waitFor(() => {
         expect(onSubmit).not.toHaveBeenCalled()

--- a/packages/dm-core-plugins/src/form/test-utils.tsx
+++ b/packages/dm-core-plugins/src/form/test-utils.tsx
@@ -1,4 +1,5 @@
-import { DmssAPI } from '@development-framework/dm-core'
+import { DmssAPI, DMSSProvider } from '@development-framework/dm-core'
+import React from 'react'
 
 export const mockBlueprintGet = (blueprints: Array<any>) => {
   const mock = jest.spyOn(DmssAPI.prototype, 'blueprintGet')
@@ -14,3 +15,7 @@ export const mockBlueprintGet = (blueprints: Array<any>) => {
   )
   return mock
 }
+
+export const wrapper = (props: { children: React.ReactNode }) => (
+  <DMSSProvider>{props.children}</DMSSProvider>
+)

--- a/packages/dm-core-plugins/src/generic-list/GenericListPlugin.tsx
+++ b/packages/dm-core-plugins/src/generic-list/GenericListPlugin.tsx
@@ -1,18 +1,16 @@
-import React, { useContext, useEffect, useState } from 'react'
 import {
-  AuthContext,
-  DmssAPI,
   IUIPlugin,
   Loading,
   TGenericObject,
   TViewConfig,
+  useDMSS,
   useDocument,
   ViewCreator,
 } from '@development-framework/dm-core'
-import { AxiosResponse } from 'axios'
 import { Button, Icon, Typography } from '@equinor/eds-core-react'
 import { chevron_down, chevron_right } from '@equinor/eds-icons'
-
+import { AxiosResponse } from 'axios'
+import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
 import {
   AppendButton,
@@ -59,7 +57,7 @@ export const GenericListPlugin = (
 ) => {
   const { idReference, config, type } = props
   const internalConfig = { ...defaultConfig, ...config }
-  const [document, loading, _, error] = useDocument<TGenericObject[]>(
+  const [document, loading, , error] = useDocument<TGenericObject[]>(
     idReference,
     2
   )
@@ -69,8 +67,7 @@ export const GenericListPlugin = (
   }>({})
   const [unsavedChanges, setUnsavedChanges] = useState<boolean>(false)
   const [isLoading, setIsLoading] = useState<boolean>(false)
-  const { token } = useContext(AuthContext)
-  const dmssAPI = new DmssAPI(token)
+  const dmssAPI = useDMSS()
 
   useEffect(() => {
     if (loading || !document) return

--- a/packages/dm-core-plugins/src/generic-list/GenericTablePlugin.tsx
+++ b/packages/dm-core-plugins/src/generic-list/GenericTablePlugin.tsx
@@ -1,15 +1,14 @@
-import React, { ChangeEvent, useContext, useEffect, useState } from 'react'
 import {
-  AuthContext,
-  DmssAPI,
   ErrorResponse,
   IUIPlugin,
   Loading,
   TGenericObject,
+  useDMSS,
   useDocument,
 } from '@development-framework/dm-core'
-import { AxiosError, AxiosResponse } from 'axios'
 import { Input, Table } from '@equinor/eds-core-react'
+import { AxiosError, AxiosResponse } from 'axios'
+import React, { ChangeEvent, useEffect, useState } from 'react'
 import {
   AppendButton,
   DeleteButton,
@@ -35,15 +34,14 @@ export const GenericTablePlugin = (
 ) => {
   const { idReference, config, type } = props
   const internalConfig = { ...defaultConfig, ...config }
-  const [document, loading, _, error] = useDocument<TGenericObject[]>(
+  const [document, loading, , error] = useDocument<TGenericObject[]>(
     idReference,
     2
   )
   const [items, setItems] = useState<{ [key: string]: TGenericObject }>({})
   const [isSaveLoading, setIsSaveLoading] = useState<boolean>(false)
   const [dirtyState, setDirtyState] = useState<boolean>(false)
-  const { token } = useContext(AuthContext)
-  const dmssAPI = new DmssAPI(token)
+  const dmssAPI = useDMSS()
 
   useEffect(() => {
     if (loading || !document) return

--- a/packages/dm-core-plugins/src/header/components/UserInfoDialog.tsx
+++ b/packages/dm-core-plugins/src/header/components/UserInfoDialog.tsx
@@ -1,20 +1,13 @@
-import { Icon, Radio, TopBar } from '@equinor/eds-core-react'
-import {
-  Button,
-  Dialog,
-  DmssAPI,
-  IUIPlugin,
-  Loading,
-  useDocument,
-} from '@development-framework/dm-core'
-import styled from 'styled-components'
+import { Button, Dialog, useDMSS } from '@development-framework/dm-core'
+import { Radio } from '@equinor/eds-core-react'
 import React, { useContext, useState } from 'react'
 import { AuthContext } from 'react-oauth2-code-pkce'
+import styled from 'styled-components'
 // @ts-ignore
-import { NotificationManager } from 'react-notifications'
 import { AxiosResponse } from 'axios'
-import { useLocalStorage } from '../useLocalStorage'
+import { NotificationManager } from 'react-notifications'
 import { TApplication } from '../types'
+import { useLocalStorage } from '../useLocalStorage'
 
 const UnstyledList = styled.ul`
   margin: 0;
@@ -42,7 +35,7 @@ export const UserInfoDialog = (props: UserInfoDialogProps) => {
   const { isOpen, setIsOpen, applicationEntity } = props
   const [apiKey, setAPIKey] = useState<string | null>(null)
   const { tokenData, token, logOut } = useContext(AuthContext)
-  const dmssApi = new DmssAPI(token)
+  const dmssAPI = useDMSS()
   const [checked, updateChecked] = useLocalStorage<string | null>(
     'impersonateRoles',
     null
@@ -78,7 +71,7 @@ export const UserInfoDialog = (props: UserInfoDialogProps) => {
           </Button>
           <Button
             onClick={() =>
-              dmssApi
+              dmssAPI
                 .tokenCreate()
                 .then((response: AxiosResponse<string>) =>
                   setAPIKey(response.data)

--- a/packages/dm-core-plugins/src/job/JobControl.tsx
+++ b/packages/dm-core-plugins/src/job/JobControl.tsx
@@ -1,19 +1,19 @@
-import React, { useContext, useEffect, useState } from 'react'
-import styled from 'styled-components'
 import {
+  ApplicationContext,
   AuthContext,
   Dialog,
-  DmssAPI,
   DmJobAPI,
-  ErrorResponse,
   EntityView,
+  ErrorResponse,
   JobStatus,
   TJob,
-  ApplicationContext,
+  useDMSS,
 } from '@development-framework/dm-core'
 import { Button, Label, Progress } from '@equinor/eds-core-react'
-import Icons from './Icons'
 import { AxiosError } from 'axios'
+import React, { useContext, useEffect, useState } from 'react'
+import styled from 'styled-components'
+import Icons from './Icons'
 // @ts-ignore
 import { NotificationManager } from 'react-notifications'
 
@@ -84,7 +84,7 @@ export const JobControl = (props: {
   const { token } = useContext(AuthContext)
   const settings = useContext(ApplicationContext)
   const dmtApi = new DmJobAPI(token)
-  const dmssApi = new DmssAPI(token)
+  const dmssAPI = useDMSS()
   const [loading, setLoading] = useState<boolean>(false)
   const [jobUID, setJobUID] = useState<string | undefined>(document?.uid)
   const [jobLogs, setJobLogs] = useState<any>()
@@ -140,7 +140,7 @@ export const JobControl = (props: {
     setLoading(true)
     try {
       await dmtApi.removeJob({ jobUid: jobUID })
-      await dmssApi.documentRemove({ idReference: jobId })
+      await dmssAPI.documentRemove({ idReference: jobId })
     } catch (error: AxiosError<ErrorResponse> | any) {
       if (isAxiosError(error)) {
         console.error(error.response?.data)

--- a/packages/dm-core-plugins/src/pdf/PDFViewer.tsx
+++ b/packages/dm-core-plugins/src/pdf/PDFViewer.tsx
@@ -1,14 +1,13 @@
-import React, { useContext, useEffect, useState } from 'react'
-import styled from 'styled-components'
-import { formatBytes } from './formatBytes'
 import {
-  AuthContext,
-  DmssAPI,
   ErrorResponse,
   Loading,
   TGenericObject,
+  useDMSS,
 } from '@development-framework/dm-core'
 import { AxiosError } from 'axios'
+import React, { useEffect, useState } from 'react'
+import styled from 'styled-components'
+import { formatBytes } from './formatBytes'
 
 export const ErrorGroup = styled.div`
   display: flex;
@@ -40,8 +39,7 @@ export const ViewerPDFPlugin = (props: {
   const [blobUrl, setBlobUrl] = useState('')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const { token } = useContext(AuthContext)
-  const dmssAPI = new DmssAPI(token)
+  const dmssAPI = useDMSS()
 
   useEffect(() => {
     setError(null)

--- a/packages/dm-core-plugins/src/react-notifications.d.ts
+++ b/packages/dm-core-plugins/src/react-notifications.d.ts
@@ -1,0 +1,91 @@
+declare module 'react-notifications' {
+  import { EventEmitter } from 'events'
+  import { ReactNode } from 'react'
+
+  enum NotificationType {
+    INFO = 'info',
+    SUCCESS = 'success',
+    WARNING = 'warning',
+    ERROR = 'error',
+  }
+
+  enum EventType {
+    CHANGE = 'change',
+    INFO = 'info',
+    SUCCESS = 'success',
+    WARNING = 'warning',
+    ERROR = 'error',
+  }
+
+  interface NotificationProps {
+    type: NotificationType
+    title?: ReactNode
+    message: ReactNode
+    timeOut?: number
+    onClick: () => any
+    onRequestHide: () => any
+  }
+
+  interface NotificationsProps {
+    notifications: Notification[]
+    onRequestHide?: (notification: Notification) => any
+    enterTimeout?: number
+    leaveTimeout?: number
+  }
+
+  interface NotificationContainerProps {
+    enterTimeout?: number
+    leaveTimeout?: number
+  }
+
+  interface INotificationManagerCreate {
+    type: EventType
+    title?: NotificationProps['title']
+    message?: NotificationProps['message']
+    timeout?: number
+    onClick?: () => any
+    priority?: boolean
+  }
+
+  class Notification extends React.Component<NotificationProps, object> {}
+
+  class Notifications extends React.Component<NotificationsProps, object> {}
+
+  class NotificationContainer extends React.Component<
+    NotificationContainerProps,
+    object
+  > {}
+
+  class NotificationManager extends EventEmitter {
+    static create(INotificationManagerCreate): void
+    static info(
+      message?: INotificationManagerCreate['message'],
+      title?: INotificationManagerCreate['title'],
+      timeOut?: INotificationManagerCreate['timeout'],
+      onClick?: INotificationManagerCreate['onClick'],
+      priority?: INotificationManagerCreate['priority']
+    ): void
+    static success(
+      message?: INotificationManagerCreate['message'],
+      title?: INotificationManagerCreate['title'],
+      timeOut?: INotificationManagerCreate['timeout'],
+      onClick?: INotificationManagerCreate['onClick'],
+      priority?: INotificationManagerCreate['priority']
+    ): void
+    static warning(
+      message?: INotificationManagerCreate['message'],
+      title?: INotificationManagerCreate['title'],
+      timeOut?: INotificationManagerCreate['timeout'],
+      onClick?: INotificationManagerCreate['onClick'],
+      priority?: INotificationManagerCreate['priority']
+    ): void
+    static error(
+      message?: INotificationManagerCreate['message'],
+      title?: INotificationManagerCreate['title'],
+      timeOut?: INotificationManagerCreate['timeout'],
+      onClick?: INotificationManagerCreate['onClick'],
+      priority?: INotificationManagerCreate['priority']
+    ): void
+    static remove(notification: Notification): void
+  }
+}


### PR DESCRIPTION
## What does this pull request change?

- Use dmss context in dm-core-plugins
- add react-notifications types to avoid ts errors (note that the typings are more or less copy pasted from https://github.com/minhtranite/react-notifications/issues/29#issuecomment-648846225 and I have not verified that it's 100% correct)

## Why is this pull request needed?

## Issues related to this change

Refs #174

