### PR TITLE
fix(ViewCreator): get type and dimensions from blueprints

### DIFF
--- a/example/reset-all.sh
+++ b/example/reset-all.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
+set -e
 docker-compose run --rm dmss reset-app
+docker-compose run --rm job-api dm -u http://dmss:5000 reset ../app
 dm reset app
 dm import-plugin-blueprints node_modules/@development-framework/dm-core-plugins
+echo "Creating recipe lookup..."
 dm create-lookup example DemoDataSource/DemoPackage/recipe_links

--- a/packages/dm-core-plugins/package.json
+++ b/packages/dm-core-plugins/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@development-framework/dm-core-plugins",
   "license": "MIT",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "main": "dist/index.js",
   "dependencies": {
     "@development-framework/dm-core": "^1.0.51",

--- a/packages/dm-core-plugins/src/attribute-selector/AttributeSelectorPlugin.tsx
+++ b/packages/dm-core-plugins/src/attribute-selector/AttributeSelectorPlugin.tsx
@@ -19,7 +19,7 @@ import {
 export const AttributeSelectorPlugin = (
   props: IUIPlugin & { config?: TAttributeSelectorConfig }
 ): JSX.Element => {
-  const { idReference, config } = props
+  const { idReference, config, type } = props
   const internalConfig: TAttributeSelectorConfig = {
     childTabsOnRender: true,
     asSidebar: false,
@@ -125,6 +125,7 @@ export const AttributeSelectorPlugin = (
         />
       )}
       <Content
+        type={type}
         onOpen={addView}
         formData={formData}
         selectedView={selectedView}

--- a/packages/dm-core-plugins/src/attribute-selector/Content.tsx
+++ b/packages/dm-core-plugins/src/attribute-selector/Content.tsx
@@ -14,13 +14,14 @@ const HidableWrapper = styled.div<any>`
 `
 
 export const Content = (props: {
+  type: string
   selectedView: string
   items: TItemData[]
   setFormData: (v: TGenericObject) => void
   onOpen: (id: string, v: TViewConfig) => void
   formData: TGenericObject
 }): JSX.Element => {
-  const { selectedView, items, setFormData, formData, onOpen } = props
+  const { selectedView, items, setFormData, formData, onOpen, type } = props
 
   return (
     <div style={{ width: '100%' }}>
@@ -31,6 +32,12 @@ export const Content = (props: {
         >
           <ViewCreator
             idReference={config.rootEntityId}
+            // @ts-ignore Remove after dm-core bump
+            blueprintAttribute={{
+              name: 'nil',
+              dimensions: '',
+              attributeType: type,
+            }}
             viewConfig={config.view}
             onOpen={onOpen}
             onSubmit={(data: TGenericObject) => {

--- a/packages/dm-core-plugins/src/generic-list/GenericListPlugin.tsx
+++ b/packages/dm-core-plugins/src/generic-list/GenericListPlugin.tsx
@@ -6,10 +6,11 @@ import {
   useDMSS,
   useDocument,
   ViewCreator,
+  ErrorResponse,
 } from '@development-framework/dm-core'
 import { Button, Icon, Typography } from '@equinor/eds-core-react'
 import { chevron_down, chevron_right } from '@equinor/eds-icons'
-import { AxiosResponse } from 'axios'
+import { AxiosResponse, AxiosError } from 'axios'
 import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
 import {
@@ -110,6 +111,10 @@ export const GenericListPlugin = (
               [crypto.randomUUID()]: { ...newEntity.data },
             })
           )
+          .catch((error: AxiosError<ErrorResponse>) => {
+            console.error(error)
+            alert(JSON.stringify(error.response?.data, null, 2))
+          })
       })
   }
 
@@ -223,6 +228,12 @@ export const GenericListPlugin = (
                   {itemsExpanded[key] && (
                     <ViewCreator
                       idReference={`${idReference}.${index}`}
+                      // @ts-ignore Remove after dm-core bump
+                      blueprintAttribute={{
+                        name: 'nil',
+                        attributeType: type,
+                        dimensions: '',
+                      }}
                       viewConfig={
                         internalConfig.views[index] ??
                         internalConfig.defaultView

--- a/packages/dm-core/package.json
+++ b/packages/dm-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@development-framework/dm-core",
-  "version": "1.0.51",
+  "version": "1.0.52",
   "license": "MIT",
   "peerDependencies": {
     "react-router-dom": ">=5.1.2",

--- a/packages/dm-core/src/components/EntityView.tsx
+++ b/packages/dm-core/src/components/EntityView.tsx
@@ -28,6 +28,8 @@ export const EntityView = (props: IEntityView): JSX.Element => {
     noInit,
     dimensions,
   } = props
+  if (!type)
+    throw new Error(`<EntityView> must be called with a type. Got "${type}"`)
   const { recipe, isLoading, error, getUiPlugin } = useRecipe(
     type,
     recipeName,

--- a/packages/dm-core/src/components/RecipeSelector.tsx
+++ b/packages/dm-core/src/components/RecipeSelector.tsx
@@ -111,6 +111,12 @@ export function RecipeSelector(
         idReference={idReference}
         viewConfig={selectableViews[selectedView]}
         type={type}
+        //@ts-ignore  Remove after dm-core bump
+        blueprintAttribute={{
+          name: 'nil',
+          attributeType: type,
+          dimensions: '',
+        }}
       />
     </Wrapper>
   )

--- a/packages/dm-core/src/components/ViewCreator/ViewCreator.tsx
+++ b/packages/dm-core/src/components/ViewCreator/ViewCreator.tsx
@@ -7,31 +7,22 @@ import {
   TReferenceViewConfig,
   TViewConfig,
 } from '../../types'
-import { EntityView, Loading, TGenericObject, useDocument } from '../../index'
-import React from 'react'
+import { EntityView, Loading, TAttribute, useDMSS } from '../../index'
+import React, { useEffect, useState } from 'react'
 import { InlineRecipeView } from './InlineRecipeView'
-import { getTarget, getType } from './utils'
-import { ErrorGroup } from '../../utils/ErrorBoundary'
+import { getTarget, getScopeTypeAndDimensions } from './utils'
 
 type TViewCreator = Omit<IUIPlugin, 'type'> & {
   viewConfig: TViewConfig | TInlineRecipeViewConfig | TReferenceViewConfig
-  type?: string
-}
-
-const getScopeDepth = (scope: string): number => {
-  if (scope) {
-    if (scope === 'self') {
-      return 1
-    }
-    return scope.split('.').length
-  }
-  return 1
+  type: string
+  blueprintAttribute: TAttribute
 }
 
 /**
  * A component that will create a view from a view config.
  *
  * A view config can contain a UIRecipe (InlineRecipeViewConfig) or reference an existing UIRecipe (ReferenceViewConfig).
+ * Passed type is for the document the idReference points to, _not_ any scope.
  *
  * @docs Components
  *
@@ -47,37 +38,42 @@ const getScopeDepth = (scope: string): number => {
  * @param props
  */
 export const ViewCreator = (props: TViewCreator): JSX.Element => {
-  const { idReference, viewConfig, type: passedType, onOpen } = props
-  const [document, isLoadingDocument, _, error] = useDocument<TGenericObject>(
-    idReference,
-    getScopeDepth(viewConfig?.scope ?? '')
-  )
+  const { idReference, viewConfig, onOpen, blueprintAttribute } = props
+  const dmssAPI = useDMSS()
+  const [isLoading, setIsLoading] = useState<boolean>(true)
+  const [error, setError] = useState<Error>()
+  const [targetType, setTargetType] = useState<string>()
+  const [targetDimensions, setTargetDimensions] = useState<string>()
 
-  if (isLoadingDocument) return <Loading />
-  if (error) throw new Error(JSON.stringify(error, null, 2))
-
-  if (document == null) return <>Could not find the document, check the scope</>
-
-  const type = getType(document, viewConfig) || passedType
-  if (type === undefined) {
-    // If no type is passed, and the entity pointed to in "scope" is empty, we have no way of knowing type.
-    //TODO: Fix this to get type from parent or something...
-    return (
-      <ErrorGroup>
-        <pre style={{ color: 'red' }}>
-          Not supported: Rendering views for empty documents are not yet
-          supported.
-        </pre>
-      </ErrorGroup>
+  if (!blueprintAttribute)
+    throw new Error(
+      "ViewCreator was called without being passed a 'blueprintAttribute'"
     )
-  }
+
+  useEffect(() => {
+    const scopeArray: string[] = viewConfig.scope
+      ? viewConfig.scope.split('.')
+      : []
+    getScopeTypeAndDimensions(blueprintAttribute, dmssAPI, scopeArray)
+      .then(([type, dimensions]) => {
+        setTargetType(type)
+        setTargetDimensions(dimensions)
+      })
+      .catch((error) => setError(error))
+      .finally(() => setIsLoading(false))
+  }, [])
+
+  if (isLoading) return <Loading />
+  if (error) throw error
+  if (!targetType || !targetDimensions === undefined)
+    throw new Error('Unable to find type and dimensions for view')
   const absoluteDottedId = getTarget(idReference, viewConfig)
 
   if (isInlineRecipeViewConfig(viewConfig))
     return (
       <InlineRecipeView
         idReference={absoluteDottedId}
-        type={type}
+        type={targetType}
         viewConfig={viewConfig}
         onOpen={onOpen}
       />
@@ -86,20 +82,22 @@ export const ViewCreator = (props: TViewCreator): JSX.Element => {
   if (isReferenceViewConfig(viewConfig))
     return (
       <EntityView
-        type={type}
+        type={targetType}
         idReference={absoluteDottedId}
         recipeName={viewConfig.recipe}
         onOpen={onOpen}
+        dimensions={targetDimensions}
       />
     )
   if (isViewConfig(viewConfig))
     return (
       <EntityView
         idReference={absoluteDottedId}
-        type={type}
+        type={targetType}
         // Don't use initialUiRecipes when rendering 'self'
         noInit={idReference === absoluteDottedId}
         onOpen={onOpen}
+        dimensions={targetDimensions}
       />
     )
 

--- a/packages/dm-core/src/domain/types.ts
+++ b/packages/dm-core/src/domain/types.ts
@@ -1,10 +1,10 @@
 export type TAttribute = {
-  type: string
+  type?: string
   name: string
   dimensions: string
   attributeType: string
-  optional: boolean
-  contained: boolean
+  optional?: boolean
+  contained?: boolean
   description?: string
   label?: string
   enumType?: string

--- a/packages/dm-core/src/hooks/useRecipe.tsx
+++ b/packages/dm-core/src/hooks/useRecipe.tsx
@@ -8,12 +8,15 @@ import {
 } from '../index'
 
 const findRecipe = (
-  initialUiRecipe: TUiRecipe | undefined,
   recipes: TUiRecipe[],
+  initialUiRecipe?: TUiRecipe,
   recipeName?: string,
   noInit: boolean = false,
   dimensions: string = ''
 ): TUiRecipe => {
+  if (dimensions) {
+    initialUiRecipe = undefined
+  }
   // If recipe is defined, find and return the ui recipe from available recipes.
   if (recipeName) {
     const recipe: TUiRecipe | undefined = recipes.find(
@@ -108,11 +111,13 @@ export const useRecipe = (
     if (isBlueprintLoading) return
     try {
       setFoundRecipe(
-        findRecipe(initialUiRecipe, uiRecipes, recipeName, noInit, dimensions)
+        findRecipe(uiRecipes, initialUiRecipe, recipeName, noInit, dimensions)
       )
     } catch (error) {
+      console.error(error)
       const errorResponse: ErrorResponse = {
         type: 'RecipeSelectionError',
+        debug: `type: "${typeRef}"`,
         message: error.message,
       }
       setFindRecipeError(errorResponse)

--- a/packages/dm-core/src/utils/ErrorBoundary.tsx
+++ b/packages/dm-core/src/utils/ErrorBoundary.tsx
@@ -9,6 +9,12 @@ export const ErrorGroup = styled.div`
   padding: 20px 20px;
   background-color: #f6dfdf;
 `
+
+const Message = styled.div`
+  overflow-wrap: break-word;
+  font-family: monospace;
+`
+
 export class ErrorBoundary extends React.Component<
   any,
   { hasError: boolean; error: Error }
@@ -16,7 +22,7 @@ export class ErrorBoundary extends React.Component<
   fallBack: (error: Error) => ReactNode = (error: Error) => (
     <ErrorGroup>
       <h4 style={{ color: 'red' }}>{this.message}</h4>
-      <pre>{error.message}</pre>
+      <Message>{error.message}</Message>
     </ErrorGroup>
   )
   message = 'unknown'


### PR DESCRIPTION
## What does this pull request change?
- Fix a bug in the viewcreator where type and dimensions(missing) where assumed found in entity, instead of blueprints

## Why is this pull request needed?
- "<EntityView>" needs to know if the target is a list or not, and of what type

## Issues related to this change
hotfix

