### PR TITLE
fix(grid): pass type to grid elements

### DIFF
--- a/packages/dm-core-plugins/package.json
+++ b/packages/dm-core-plugins/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@development-framework/dm-core-plugins",
   "license": "MIT",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "main": "dist/index.js",
   "dependencies": {
-    "@development-framework/dm-core": "^1.0.51",
+    "@development-framework/dm-core": "^1.0.52",
     "@equinor/eds-core-react": "^0.29.1",
     "@equinor/eds-icons": "^0.18.0",
     "@equinor/eds-tokens": "^0.9.0",

--- a/packages/dm-core-plugins/src/attribute-selector/Content.tsx
+++ b/packages/dm-core-plugins/src/attribute-selector/Content.tsx
@@ -30,9 +30,9 @@ export const Content = (props: {
           key={config.viewId}
           hidden={config.viewId !== selectedView}
         >
+          {/*@ts-ignore*/}
           <ViewCreator
             idReference={config.rootEntityId}
-            // @ts-ignore Remove after dm-core bump
             blueprintAttribute={{
               name: 'nil',
               dimensions: '',

--- a/packages/dm-core-plugins/src/generic-list/GenericListPlugin.tsx
+++ b/packages/dm-core-plugins/src/generic-list/GenericListPlugin.tsx
@@ -226,9 +226,9 @@ export const GenericListPlugin = (
                   }}
                 >
                   {itemsExpanded[key] && (
+                    // @ts-ignore
                     <ViewCreator
                       idReference={`${idReference}.${index}`}
-                      // @ts-ignore Remove after dm-core bump
                       blueprintAttribute={{
                         name: 'nil',
                         attributeType: type,

--- a/packages/dm-core-plugins/src/grid/GridElement.tsx
+++ b/packages/dm-core-plugins/src/grid/GridElement.tsx
@@ -11,10 +11,11 @@ const Element = styled.div`
 type TGridItemProps = {
   idReference: string
   item: TGridItem
+  type: string
 }
 
 export const GridElement = (props: TGridItemProps): JSX.Element => {
-  const { idReference, item } = props
+  const { idReference, item, type } = props
 
   return (
     <Element
@@ -26,6 +27,11 @@ export const GridElement = (props: TGridItemProps): JSX.Element => {
       <ViewCreator
         idReference={idReference}
         viewConfig={item.viewConfig}
+        blueprintAttribute={{
+          name: 'nil',
+          attributeType: type,
+          dimensions: '',
+        }}
         type={item.type}
       />
     </Element>

--- a/packages/dm-core-plugins/src/grid/GridItems.tsx
+++ b/packages/dm-core-plugins/src/grid/GridItems.tsx
@@ -5,16 +5,18 @@ import { GridElement } from './GridElement'
 type GridItemsProps = {
   items: TGridItem[]
   idReference: string
+  type: string
 }
 
 export const GridItems = (props: GridItemsProps) => {
-  const { idReference, items } = props
+  const { idReference, items, type } = props
   const elements = items.map((item: TGridItem, index) => {
     return (
       <GridElement
         key={`${idReference}-${index}`}
         idReference={idReference}
         item={item}
+        type={type}
       />
     )
   })

--- a/packages/dm-core-plugins/src/grid/GridPlugin.tsx
+++ b/packages/dm-core-plugins/src/grid/GridPlugin.tsx
@@ -12,11 +12,11 @@ const Grid = styled.div`
 `
 
 export const GridPlugin = (props: TGridPluginConfig): JSX.Element => {
-  const { config, idReference } = props
+  const { config, idReference, type } = props
 
   return (
     <Grid columns={config.size.columns} rows={config.size.rows}>
-      <GridItems idReference={idReference} items={config.items} />
+      <GridItems idReference={idReference} items={config.items} type={type} />
     </Grid>
   )
 }

--- a/packages/dm-core/package.json
+++ b/packages/dm-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@development-framework/dm-core",
-  "version": "1.0.52",
+  "version": "1.0.53",
   "license": "MIT",
   "peerDependencies": {
     "react-router-dom": ">=5.1.2",

--- a/packages/dm-core/src/components/EntityView.tsx
+++ b/packages/dm-core/src/components/EntityView.tsx
@@ -14,26 +14,16 @@ const Wrapper = styled.div`
 
 type IEntityView = IUIPlugin & {
   recipeName?: string
-  noInit?: boolean
   dimensions?: string
 }
 
 export const EntityView = (props: IEntityView): JSX.Element => {
-  const {
-    idReference,
-    type,
-    onSubmit,
-    onOpen,
-    recipeName,
-    noInit,
-    dimensions,
-  } = props
+  const { idReference, type, onSubmit, onOpen, recipeName, dimensions } = props
   if (!type)
     throw new Error(`<EntityView> must be called with a type. Got "${type}"`)
   const { recipe, isLoading, error, getUiPlugin } = useRecipe(
     type,
     recipeName,
-    noInit,
     dimensions
   )
 

--- a/packages/dm-core/src/components/RecipeSelector.tsx
+++ b/packages/dm-core/src/components/RecipeSelector.tsx
@@ -110,8 +110,6 @@ export function RecipeSelector(
       <ViewCreator
         idReference={idReference}
         viewConfig={selectableViews[selectedView]}
-        type={type}
-        //@ts-ignore  Remove after dm-core bump
         blueprintAttribute={{
           name: 'nil',
           attributeType: type,

--- a/packages/dm-core/src/components/ViewCreator/ViewCreator.tsx
+++ b/packages/dm-core/src/components/ViewCreator/ViewCreator.tsx
@@ -14,7 +14,6 @@ import { getTarget, getScopeTypeAndDimensions } from './utils'
 
 type TViewCreator = Omit<IUIPlugin, 'type'> & {
   viewConfig: TViewConfig | TInlineRecipeViewConfig | TReferenceViewConfig
-  type: string
   blueprintAttribute: TAttribute
 }
 
@@ -94,8 +93,6 @@ export const ViewCreator = (props: TViewCreator): JSX.Element => {
       <EntityView
         idReference={absoluteDottedId}
         type={targetType}
-        // Don't use initialUiRecipes when rendering 'self'
-        noInit={idReference === absoluteDottedId}
         onOpen={onOpen}
         dimensions={targetDimensions}
       />

--- a/packages/dm-core/src/hooks/useRecipe.tsx
+++ b/packages/dm-core/src/hooks/useRecipe.tsx
@@ -11,7 +11,6 @@ const findRecipe = (
   recipes: TUiRecipe[],
   initialUiRecipe?: TUiRecipe,
   recipeName?: string,
-  noInit: boolean = false,
   dimensions: string = ''
 ): TUiRecipe => {
   if (dimensions) {
@@ -39,7 +38,7 @@ const findRecipe = (
   }
 
   // If no recipe is defined, use initial recipe, or the first from recipes list or lastly fallback.
-  if (!noInit && initialUiRecipe && Object.keys(initialUiRecipe).length > 0) {
+  if (initialUiRecipe && Object.keys(initialUiRecipe).length > 0) {
     return initialUiRecipe
   }
   if (recipes.length > 0) {
@@ -91,7 +90,6 @@ interface IUseRecipe {
 export const useRecipe = (
   typeRef: string,
   recipeName?: string,
-  noInit: boolean = false,
   dimensions: string = ''
 ): IUseRecipe => {
   const {
@@ -111,7 +109,7 @@ export const useRecipe = (
     if (isBlueprintLoading) return
     try {
       setFoundRecipe(
-        findRecipe(uiRecipes, initialUiRecipe, recipeName, noInit, dimensions)
+        findRecipe(uiRecipes, initialUiRecipe, recipeName, dimensions)
       )
     } catch (error) {
       console.error(error)


### PR DESCRIPTION
## What does this pull request change?
- ViewCreator needs to know the type for the root entity, in order to find the type for the scope

## Why is this pull request needed?
- Updated Grid plugin to pass root entity type to ViewCreator

## Issues related to this change
none
