### PR TITLE
fix: handle scope with more than 1 level

### DIFF
--- a/packages/dm-core/src/components/ViewCreator/utils.ts
+++ b/packages/dm-core/src/components/ViewCreator/utils.ts
@@ -44,5 +44,10 @@ export async function getScopeTypeAndDimensions(
       )
     return [attribute.attributeType, attribute.dimensions]
   }
-  return getScopeTypeAndDimensions(attribute, dmssApi, scope.splice(0, 1))
+  if (attribute.dimensions == '*') {
+    scope.splice(0, 2)
+  } else {
+    scope.splice(0, 1)
+  }
+  return getScopeTypeAndDimensions(attribute, dmssApi, scope)
 }


### PR DESCRIPTION
## What does this pull request change?

* The getScopeTypeAndDimensions should handle scope with more than 1 level

## Why is this pull request needed?

## Issues related to this change

