### PR TITLE
ci: test dm-core-plugins with newest dm-core

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,7 +19,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        package: [ dm-core, dm-core-plugins ]
+        package: [dm-core, dm-core-plugins]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
@@ -28,12 +28,34 @@ jobs:
 
       # TODO: Cache yarn install
 
-      - name: "test"
+      - name: Set variables
+        id: variables
+        working-directory: packages/${{ matrix.package }}
         run: |
-          cd packages/${{ matrix.package }}
-          yarn install
-          yarn tsc
-          HAS_TESTS=$(cat package.json | jq '.["scripts"]["test"]')
-          if [[ $HAS_TESTS != "null" ]]; then
-            yarn test
-          fi
+          echo "DM_CORE_VERSION=$(cat package.json | jq '.["dependencies"]["@development-framework/dm-core"]')" >> "$GITHUB_OUTPUT"
+          echo "TEST_COMMAND=$(cat package.json | jq '.["scripts"]["test"]')" >> "$GITHUB_OUTPUT"
+
+      - name: 'Install dependencies'
+        working-directory: packages/${{ matrix.package }}
+        run: yarn install
+
+      - name: 'Copy local variant of dm-core to node_modules'
+        working-directory: packages/${{ matrix.package }}
+        if: steps.variables.outputs.DM_CORE_VERSION != 'null'
+        run: |
+          cd ../dm-core
+          yarn install --no-lockfile
+          yarn build
+          cd ../dm-core-plugins
+          rm -r node_modules/@development-framework/dm-core/*
+          cp -r ../dm-core/dist node_modules/@development-framework/dm-core/dist
+          cp ../dm-core/package.json node_modules/@development-framework/dm-core/package.json
+
+      - name: 'yarn tsc'
+        working-directory: packages/${{ matrix.package }}
+        run: yarn tsc
+
+      - name: 'yarn test'
+        working-directory: packages/${{ matrix.package }}
+        if: steps.variables.outputs.TEST_COMMAND != 'null'
+        run: yarn test


### PR DESCRIPTION
## What does this pull request change?

Use the local dm-core variant when testing packages

## Why is this pull request needed?

When updating dm-core, we had to first merge the changes to dm-core in on PR to get a new npm release, before updating dm-core-plugins to use the newest functionality in another PR due to issues in testing.

## Issues related to this change

Closes #389

