### PR TITLE
Fix/attribute selector recursiveness

### DIFF
--- a/example/app/data/DemoDataSource/plugins/attribute-selector/attributeSelectorSidebarEntity.json
+++ b/example/app/data/DemoDataSource/plugins/attribute-selector/attributeSelectorSidebarEntity.json
@@ -1,37 +1,36 @@
 {
-  "_id": "g6282220-4a90-4d02-8f34-b82255fc91d6",
-  "type": "./blueprints/AttributeSelectorSidebarBlueprint",
+  "type": "./blueprints/AttributeSelectorSidebar",
   "name": "attributeSelectorSidebarEntity",
   "firstAttribute": {
-    "type": "./blueprints/AttributeSelectorSidebarBlueprint",
+    "type": "./blueprints/AttributeSelectorSidebar",
     "name": "first attribute",
     "firstAttribute": {
-      "type": "./blueprints/AttributeSelectorSidebarBlueprint",
+      "type": "./blueprints/AttributeSelectorSidebar",
       "name": "first attribute"
     }
   },
   "secondAttribute": {
-    "type": "./blueprints/AttributeSelectorSidebarBlueprint",
+    "type": "./blueprints/AttributeSelectorSidebar",
     "name": "second attribute"
   },
   "thirdAttribute": {
-    "type": "./blueprints/AttributeSelectorSidebarBlueprint",
+    "type": "./blueprints/AttributeSelectorSidebar",
     "name": "third attribute",
     "firstAttribute": {
-      "type": "./blueprints/AttributeSelectorSidebarBlueprint",
+      "type": "./blueprints/AttributeSelectorSidebar",
       "name": "first attribute",
       "firstAttribute": {
-        "type": "./blueprints/AttributeSelectorSidebarBlueprint",
+        "type": "./blueprints/AttributeSelectorSidebar",
         "name": "first attribute",
         "aStringValue": "Something here"
       }
     },
     "secondAttribute": {
-      "type": "./blueprints/AttributeSelectorSidebarBlueprint",
+      "type": "./blueprints/AttributeSelectorSidebar",
       "name": "second attribute"
     },
     "thirdAttribute": {
-      "type": "./blueprints/AttributeSelectorSidebarBlueprint",
+      "type": "./blueprints/AttributeSelectorSidebar",
       "name": "third attribute",
       "aStringValue": "Hallo World!"
     }

--- a/example/app/data/DemoDataSource/plugins/attribute-selector/attributeSelectorTabsDefaultEntity.json
+++ b/example/app/data/DemoDataSource/plugins/attribute-selector/attributeSelectorTabsDefaultEntity.json
@@ -1,37 +1,37 @@
 {
-  "type": "./blueprints/AttributeSelectorTabs",
-  "name": "attributeSelectorTabsEntity",
+  "type": "./blueprints/AttributeSelectorTabsDefault",
+  "name": "AttributeSelectorTabsDefaultEntity",
   "firstAttribute": {
-    "type": "./blueprints/AttributeSelectorTabs",
+    "type": "./blueprints/AttributeSelectorTabsDefault",
     "name": "first attribute",
     "firstAttribute": {
-      "type": "./blueprints/AttributeSelectorTabs",
+      "type": "./blueprints/AttributeSelectorTabsDefault",
       "name": "first attribute"
     }
   },
   "secondAttribute": {
-    "type": "./blueprints/AttributeSelectorTabs",
+    "type": "./blueprints/AttributeSelectorTabsDefault",
     "name": ""
   },
   "thirdAttribute": {
-    "type": "./blueprints/AttributeSelectorTabs",
+    "type": "./blueprints/AttributeSelectorTabsDefault",
     "name": "third attribute",
     "firstAttribute": {
-      "type": "./blueprints/AttributeSelectorTabs",
+      "type": "./blueprints/AttributeSelectorTabsDefault",
       "name": "first attribute",
       "label": "First attribute label ½¡@£",
       "firstAttribute": {
-        "type": "./blueprints/AttributeSelectorTabs",
+        "type": "./blueprints/AttributeSelectorTabsDefault",
         "name": "first attribute",
         "aStringValue": "Something here"
       }
     },
     "secondAttribute": {
-      "type": "./blueprints/AttributeSelectorTabs",
+      "type": "./blueprints/AttributeSelectorTabsDefault",
       "name": "a"
     },
     "thirdAttribute": {
-      "type": "./blueprints/AttributeSelectorTabs",
+      "type": "./blueprints/AttributeSelectorTabsDefault",
       "name": "_third-attribute_test_name------____",
       "aStringValue": "Hallo World!"
     }

--- a/example/app/data/DemoDataSource/plugins/attribute-selector/blueprints/AttributeSelectorSidebar.json
+++ b/example/app/data/DemoDataSource/plugins/attribute-selector/blueprints/AttributeSelectorSidebar.json
@@ -1,6 +1,6 @@
 {
   "type": "CORE:Blueprint",
-  "name": "AttributeSelectorTabsBlueprint",
+  "name": "AttributeSelectorSidebar",
   "extends": ["CORE:NamedEntity"],
   "attributes": [
     {
@@ -9,21 +9,21 @@
       "name": "type"
     },
     {
-      "attributeType": "./AttributeSelectorTabsBlueprint",
+      "attributeType": "./AttributeSelectorSidebar",
       "type": "CORE:BlueprintAttribute",
       "name": "firstAttribute",
       "contained": true,
       "optional": true
     },
     {
-      "attributeType": "./AttributeSelectorTabsBlueprint",
+      "attributeType": "./AttributeSelectorSidebar",
       "type": "CORE:BlueprintAttribute",
       "name": "secondAttribute",
       "contained": true,
       "optional": true
     },
     {
-      "attributeType": "./AttributeSelectorTabsBlueprint",
+      "attributeType": "./AttributeSelectorSidebar",
       "type": "CORE:BlueprintAttribute",
       "name": "thirdAttribute",
       "contained": true,

--- a/example/app/data/DemoDataSource/plugins/attribute-selector/blueprints/AttributeSelectorTabs.json
+++ b/example/app/data/DemoDataSource/plugins/attribute-selector/blueprints/AttributeSelectorTabs.json
@@ -1,0 +1,39 @@
+{
+  "type": "CORE:Blueprint",
+  "name": "AttributeSelectorTabs",
+  "extends": ["CORE:NamedEntity"],
+  "attributes": [
+    {
+      "attributeType": "string",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "name": "type"
+    },
+    {
+      "attributeType": "./AttributeSelectorTabs",
+      "type": "CORE:BlueprintAttribute",
+      "name": "firstAttribute",
+      "contained": true,
+      "optional": true
+    },
+    {
+      "attributeType": "./AttributeSelectorTabs",
+      "type": "CORE:BlueprintAttribute",
+      "name": "secondAttribute",
+      "contained": true,
+      "optional": true
+    },
+    {
+      "attributeType": "./AttributeSelectorTabs",
+      "type": "CORE:BlueprintAttribute",
+      "name": "thirdAttribute",
+      "contained": true,
+      "optional": true
+    },
+    {
+      "attributeType": "string",
+      "type": "CORE:BlueprintAttribute",
+      "name": "aStringValue",
+      "optional": true
+    }
+  ]
+}

--- a/example/app/data/DemoDataSource/plugins/attribute-selector/blueprints/AttributeSelectorTabsDefault.json
+++ b/example/app/data/DemoDataSource/plugins/attribute-selector/blueprints/AttributeSelectorTabsDefault.json
@@ -1,6 +1,6 @@
 {
   "type": "CORE:Blueprint",
-  "name": "AttributeSelectorSidebarBlueprint",
+  "name": "AttributeSelectorTabsDefault",
   "extends": ["CORE:NamedEntity"],
   "attributes": [
     {
@@ -9,21 +9,21 @@
       "name": "type"
     },
     {
-      "attributeType": "./AttributeSelectorSidebarBlueprint",
+      "attributeType": "./AttributeSelectorTabsDefault",
       "type": "CORE:BlueprintAttribute",
       "name": "firstAttribute",
       "contained": true,
       "optional": true
     },
     {
-      "attributeType": "./AttributeSelectorSidebarBlueprint",
+      "attributeType": "./AttributeSelectorTabsDefault",
       "type": "CORE:BlueprintAttribute",
       "name": "secondAttribute",
       "contained": true,
       "optional": true
     },
     {
-      "attributeType": "./AttributeSelectorSidebarBlueprint",
+      "attributeType": "./AttributeSelectorTabsDefault",
       "type": "CORE:BlueprintAttribute",
       "name": "thirdAttribute",
       "contained": true,

--- a/example/app/data/DemoDataSource/recipes/plugins/attribute-selector/attribute_selector_sidebar.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/attribute-selector/attribute_selector_sidebar.json
@@ -1,6 +1,6 @@
 {
   "type": "CORE:RecipeLink",
-  "_blueprintPath_": "/plugins/attribute-selector/blueprints/AttributeSelectorSidebarBlueprint",
+  "_blueprintPath_": "/plugins/attribute-selector/blueprints/AttributeSelectorSidebar",
   "initialUiRecipe": {
     "name": "AttributeSelector",
     "type": "CORE:UiRecipe",

--- a/example/app/data/DemoDataSource/recipes/plugins/attribute-selector/attribute_selector_tabs.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/attribute-selector/attribute_selector_tabs.json
@@ -1,6 +1,6 @@
 {
   "type": "CORE:RecipeLink",
-  "_blueprintPath_": "/plugins/attribute-selector/blueprints/AttributeSelectorTabsBlueprint",
+  "_blueprintPath_": "/plugins/attribute-selector/blueprints/AttributeSelectorTabs",
   "initialUiRecipe": {
     "name": "AttributeSelector",
     "type": "CORE:UiRecipe",

--- a/example/app/data/DemoDataSource/recipes/plugins/attribute-selector/attribute_selector_tabs_default.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/attribute-selector/attribute_selector_tabs_default.json
@@ -1,0 +1,9 @@
+{
+  "type": "CORE:RecipeLink",
+  "_blueprintPath_": "/plugins/attribute-selector/blueprints/AttributeSelectorTabsDefault",
+  "initialUiRecipe": {
+    "name": "AttributeSelector",
+    "type": "CORE:UiRecipe",
+    "plugin": "@development-framework/dm-core-plugins/attribute-selector"
+  }
+}

--- a/example/docker-compose.yaml
+++ b/example/docker-compose.yaml
@@ -10,6 +10,8 @@ services:
       MONGO_INITDB_ROOT_USERNAME: maf
       MONGO_INITDB_ROOT_PASSWORD: maf
       SECRET_KEY: sg9aeUM5i1JO4gNN8fQadokJa3_gXQMLBjSGGYcfscs= # Don't reuse this in production...
+#    volumes:
+#      - ../../data-modelling-storage-service/src:/code/src
     ports:
       - "5000:5000"
     depends_on:

--- a/example/reset-all.sh
+++ b/example/reset-all.sh
@@ -1,7 +1,16 @@
 #!/usr/bin/env bash
 set -e
-docker-compose run --rm dmss reset-app
-docker-compose run --rm job-api dm -u http://dmss:5000 reset ../app
+
+# Get the available docker-compose command
+docker compose &> /dev/null
+if [[ $? == 0 ]]; then
+  compose="docker compose"
+else
+  compose="docker-compose"
+fi
+
+eval $compose run --rm dmss reset-app
+eval $compose run --rm job-api dm -u http://dmss:5000 reset ../app
 dm reset app
 dm import-plugin-blueprints node_modules/@development-framework/dm-core-plugins
 echo "Creating recipe lookup..."

--- a/packages/dm-core-plugins/src/attribute-selector/AttributeSelectorPlugin.tsx
+++ b/packages/dm-core-plugins/src/attribute-selector/AttributeSelectorPlugin.tsx
@@ -73,6 +73,7 @@ export const AttributeSelectorPlugin = (
           type: 'InlineRecipeViewConfig',
           scope: 'self',
           recipe: {
+            type: 'UiRecipe',
             name: 'Yaml',
             plugin: '@development-framework/dm-core-plugins/yaml',
           },

--- a/packages/dm-core-plugins/src/attribute-selector/AttributeSelectorPlugin.tsx
+++ b/packages/dm-core-plugins/src/attribute-selector/AttributeSelectorPlugin.tsx
@@ -70,8 +70,12 @@ export const AttributeSelectorPlugin = (
         label: 'self',
         viewId: 'self',
         view: {
-          type: 'ViewConfig',
+          type: 'InlineRecipeViewConfig',
           scope: 'self',
+          recipe: {
+            name: 'Yaml',
+            plugin: '@development-framework/dm-core-plugins/yaml',
+          },
           eds_icon: 'home',
         },
         rootEntityId: idReference,


### PR DESCRIPTION
## What does this pull request change?
- Set "yaml" as default plugin for "home" tab in "attribute-selector"
- Check for available docker-compose command in `example/reset-all.sh`
- Rename some test blueprints

## Why is this pull request needed?
- Avoid recursive "attribute-selector"
- Make `reset-all.sh` work with compose as a plugin
- Follow naming conventions
## Issues related to this change
closes #204 
