### PR TITLE
refactor: use get document endpoint

### DIFF
--- a/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
@@ -48,7 +48,7 @@ export default function Fields(props: any) {
     const name: string = `${namePath}-${fields.length}`
     dmssAPI
       .instantiateEntity({
-        entity: { name: name, type: type as string },
+        entity: { type: type as string },
       })
       .then((newEntity: any) => {
         const data = JSON.stringify([...fields, newEntity.data])

--- a/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
@@ -73,7 +73,7 @@ const AddObject = (props: any) => {
 
     dmssAPI
       .instantiateEntity({
-        entity: { name: namePath as string, type: type as string },
+        entity: { type: type as string },
       })
       .then((newEntity: AxiosResponse<any>) => {
         const data = JSON.stringify(newEntity.data)

--- a/packages/dm-core/src/domain/Tree.tsx
+++ b/packages/dm-core/src/domain/Tree.tsx
@@ -202,8 +202,8 @@ export class TreeNode {
   // Fetches the unresolved document of the node
   async fetch() {
     return this.tree.dmssApi
-      .documentGetById({
-        idReference: this.nodeId,
+      .documentGet({
+        reference: this.nodeId,
         depth: 0,
       })
       .then((response: any) => response.data)
@@ -215,8 +215,8 @@ export class TreeNode {
         .blueprintGet({ typeRef: this.type })
         .then((response: any) => response.data.blueprint)
       this.tree.dmssApi
-        .documentGetById({
-          idReference: this.nodeId,
+        .documentGet({
+          reference: this.nodeId,
           depth: 0,
         })
         .then((response: any) => {
@@ -282,6 +282,7 @@ export class TreeNode {
     if (this.type === EBlueprint.PACKAGE) packageContent = '.content'
 
     const response = await this.tree.dmssApi.instantiateEntity({
+      // @ts-ignore
       entity: { name: name, type: type },
     })
     const newEntity = { ...response.data, name: name }
@@ -345,7 +346,7 @@ export class Tree {
   async initFromFolder(folderPath: string) {
     const dataSourceId = folderPath.split('/', 1)[0]
     this.dmssApi
-      .documentGetByPath({ absolutePath: folderPath })
+      .documentGet({ reference: folderPath })
       .then((response: any) => {
         const data = response.data
         const folderNode = new TreeNode(

--- a/packages/dm-core/src/hooks/useDocument.test.tsx
+++ b/packages/dm-core/src/hooks/useDocument.test.tsx
@@ -8,7 +8,7 @@ import { mockGetDocument } from '../utils/test-utils-dm-core'
 
 const mockDocument = [
   {
-    idReference: 'testDS/1',
+    reference: 'testDS/1',
     description: 'Description1',
   },
 ]
@@ -31,7 +31,7 @@ describe('useDocumentHook', () => {
         expect(result.current[0]).toEqual(mockDocument)
         expect(mock).toHaveBeenCalledTimes(1)
         expect(mock).toHaveBeenCalledWith({
-          idReference: 'testDS/1',
+          reference: 'testDS/1',
           depth: 1,
         })
       })

--- a/packages/dm-core/src/hooks/useDocument.tsx
+++ b/packages/dm-core/src/hooks/useDocument.tsx
@@ -56,8 +56,8 @@ export function useDocument<T>(
     if (documentDepth < 0 || documentDepth > 999)
       throw new Error('Depth must be a positive number < 999')
     dmssAPI
-      .documentGetById({
-        idReference: idReference,
+      .documentGet({
+        reference: idReference,
         depth: documentDepth,
       })
       .then((response: any) => {

--- a/packages/dm-core/src/hooks/useJob.tsx
+++ b/packages/dm-core/src/hooks/useJob.tsx
@@ -87,7 +87,7 @@ export function useJob(entityId?: string, jobId?: string): IUseJob {
     if (entityId) {
       setIsLoading(true)
       dmssAPI
-        .documentGetById({ idReference: entityId })
+        .documentGet({ reference: entityId })
         // @ts-ignore
         .then((response: AxiosResponse<TJob>) => {
           if (response.data?.uid) {

--- a/packages/dm-core/src/services/api/configs/gen/api/default-api.ts
+++ b/packages/dm-core/src/services/api/configs/gen/api/default-api.ts
@@ -612,18 +612,18 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
             };
         },
         /**
-         * Get document as JSON string.  - **id_reference**: <data_source>/<document_uuid> - **depth**: Maximum depth for resolving nested documents.
-         * @summary Get By Id
-         * @param {string} idReference 
+         * Get document as JSON string.  - **reference**:   - By id: PROTOCOL://DATA SOURCE/$ID.Attribute   - By path: PROTOCOL://DATA SOURCE/ROOT PACKAGE/SUB PACKAGE/ENTITY.Attribute   - By query: PROTOCOL://DATA SOURCE/$ID.list(key=value)    The PROTOCOL is optional, and the default is dmss.  - **depth**: Maximum depth for resolving nested documents.
+         * @summary Get
+         * @param {string} reference 
          * @param {number} [depth] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        documentGetById: async (idReference: string, depth?: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'idReference' is not null or undefined
-            assertParamExists('documentGetById', 'idReference', idReference)
-            const localVarPath = `/api/documents/{id_reference}`
-                .replace(`{${"id_reference"}}`, encodeURIComponent(String(idReference)));
+        documentGet: async (reference: string, depth?: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'reference' is not null or undefined
+            assertParamExists('documentGet', 'reference', reference)
+            const localVarPath = `/api/documents/{reference}`
+                .replace(`{${"reference"}}`, encodeURIComponent(String(reference)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -645,47 +645,6 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
             if (depth !== undefined) {
                 localVarQueryParameter['depth'] = depth;
             }
-
-
-    
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * Get a document by its absolute path.  - **absolute_path**: <protocol>://<data_source>/<path>.<attribute>
-         * @summary Get By Path
-         * @param {string} absolutePath 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        documentGetByPath: async (absolutePath: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'absolutePath' is not null or undefined
-            assertParamExists('documentGetByPath', 'absolutePath', absolutePath)
-            const localVarPath = `/api/documents-by-path/{absolute_path}`
-                .replace(`{${"absolute_path"}}`, encodeURIComponent(String(absolutePath)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            // authentication APIKeyHeader required
-            await setApiKeyToObject(localVarHeaderParameter, "Access-Key", configuration)
-
-            // authentication OAuth2AuthorizationCodeBearer required
-            // oauth required
-            await setOAuthToObject(localVarHeaderParameter, "OAuth2AuthorizationCodeBearer", [], configuration)
 
 
     
@@ -1604,26 +1563,15 @@ export const DefaultApiFp = function(configuration?: Configuration) {
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
-         * Get document as JSON string.  - **id_reference**: <data_source>/<document_uuid> - **depth**: Maximum depth for resolving nested documents.
-         * @summary Get By Id
-         * @param {string} idReference 
+         * Get document as JSON string.  - **reference**:   - By id: PROTOCOL://DATA SOURCE/$ID.Attribute   - By path: PROTOCOL://DATA SOURCE/ROOT PACKAGE/SUB PACKAGE/ENTITY.Attribute   - By query: PROTOCOL://DATA SOURCE/$ID.list(key=value)    The PROTOCOL is optional, and the default is dmss.  - **depth**: Maximum depth for resolving nested documents.
+         * @summary Get
+         * @param {string} reference 
          * @param {number} [depth] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async documentGetById(idReference: string, depth?: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<object>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.documentGetById(idReference, depth, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
-        },
-        /**
-         * Get a document by its absolute path.  - **absolute_path**: <protocol>://<data_source>/<path>.<attribute>
-         * @summary Get By Path
-         * @param {string} absolutePath 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async documentGetByPath(absolutePath: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<object>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.documentGetByPath(absolutePath, options);
+        async documentGet(reference: string, depth?: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<object>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.documentGet(reference, depth, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -1966,25 +1914,15 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
             return localVarFp.documentAddToPath(pathReference, document, updateUncontained, files, options).then((request) => request(axios, basePath));
         },
         /**
-         * Get document as JSON string.  - **id_reference**: <data_source>/<document_uuid> - **depth**: Maximum depth for resolving nested documents.
-         * @summary Get By Id
-         * @param {string} idReference 
+         * Get document as JSON string.  - **reference**:   - By id: PROTOCOL://DATA SOURCE/$ID.Attribute   - By path: PROTOCOL://DATA SOURCE/ROOT PACKAGE/SUB PACKAGE/ENTITY.Attribute   - By query: PROTOCOL://DATA SOURCE/$ID.list(key=value)    The PROTOCOL is optional, and the default is dmss.  - **depth**: Maximum depth for resolving nested documents.
+         * @summary Get
+         * @param {string} reference 
          * @param {number} [depth] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        documentGetById(idReference: string, depth?: number, options?: any): AxiosPromise<object> {
-            return localVarFp.documentGetById(idReference, depth, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Get a document by its absolute path.  - **absolute_path**: <protocol>://<data_source>/<path>.<attribute>
-         * @summary Get By Path
-         * @param {string} absolutePath 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        documentGetByPath(absolutePath: string, options?: any): AxiosPromise<object> {
-            return localVarFp.documentGetByPath(absolutePath, options).then((request) => request(axios, basePath));
+        documentGet(reference: string, depth?: number, options?: any): AxiosPromise<object> {
+            return localVarFp.documentGet(reference, depth, options).then((request) => request(axios, basePath));
         },
         /**
          * Remove document - **id_reference**: <data_source>/<document_uuid>.<attribute_path>  Example: id_reference=SomeDataSource/3978d9ca-2d7a-4b47-8fed-57710f6cf50b.attributes.1 will remove the first element in the attribute list of a blueprint with the given id in data source \'SomeDataSource\'.
@@ -2409,38 +2347,24 @@ export interface DefaultApiDocumentAddToPathRequest {
 }
 
 /**
- * Request parameters for documentGetById operation in DefaultApi.
+ * Request parameters for documentGet operation in DefaultApi.
  * @export
- * @interface DefaultApiDocumentGetByIdRequest
+ * @interface DefaultApiDocumentGetRequest
  */
-export interface DefaultApiDocumentGetByIdRequest {
+export interface DefaultApiDocumentGetRequest {
     /**
      * 
      * @type {string}
-     * @memberof DefaultApiDocumentGetById
+     * @memberof DefaultApiDocumentGet
      */
-    readonly idReference: string
+    readonly reference: string
 
     /**
      * 
      * @type {number}
-     * @memberof DefaultApiDocumentGetById
+     * @memberof DefaultApiDocumentGet
      */
     readonly depth?: number
-}
-
-/**
- * Request parameters for documentGetByPath operation in DefaultApi.
- * @export
- * @interface DefaultApiDocumentGetByPathRequest
- */
-export interface DefaultApiDocumentGetByPathRequest {
-    /**
-     * 
-     * @type {string}
-     * @memberof DefaultApiDocumentGetByPath
-     */
-    readonly absolutePath: string
 }
 
 /**
@@ -2888,27 +2812,15 @@ export class DefaultApi extends BaseAPI {
     }
 
     /**
-     * Get document as JSON string.  - **id_reference**: <data_source>/<document_uuid> - **depth**: Maximum depth for resolving nested documents.
-     * @summary Get By Id
-     * @param {DefaultApiDocumentGetByIdRequest} requestParameters Request parameters.
+     * Get document as JSON string.  - **reference**:   - By id: PROTOCOL://DATA SOURCE/$ID.Attribute   - By path: PROTOCOL://DATA SOURCE/ROOT PACKAGE/SUB PACKAGE/ENTITY.Attribute   - By query: PROTOCOL://DATA SOURCE/$ID.list(key=value)    The PROTOCOL is optional, and the default is dmss.  - **depth**: Maximum depth for resolving nested documents.
+     * @summary Get
+     * @param {DefaultApiDocumentGetRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof DefaultApi
      */
-    public documentGetById(requestParameters: DefaultApiDocumentGetByIdRequest, options?: AxiosRequestConfig) {
-        return DefaultApiFp(this.configuration).documentGetById(requestParameters.idReference, requestParameters.depth, options).then((request) => request(this.axios, this.basePath));
-    }
-
-    /**
-     * Get a document by its absolute path.  - **absolute_path**: <protocol>://<data_source>/<path>.<attribute>
-     * @summary Get By Path
-     * @param {DefaultApiDocumentGetByPathRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof DefaultApi
-     */
-    public documentGetByPath(requestParameters: DefaultApiDocumentGetByPathRequest, options?: AxiosRequestConfig) {
-        return DefaultApiFp(this.configuration).documentGetByPath(requestParameters.absolutePath, options).then((request) => request(this.axios, this.basePath));
+    public documentGet(requestParameters: DefaultApiDocumentGetRequest, options?: AxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).documentGet(requestParameters.reference, requestParameters.depth, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/packages/dm-core/src/services/api/configs/gen/api/document-api.ts
+++ b/packages/dm-core/src/services/api/configs/gen/api/document-api.ts
@@ -192,18 +192,18 @@ export const DocumentApiAxiosParamCreator = function (configuration?: Configurat
             };
         },
         /**
-         * Get document as JSON string.  - **id_reference**: <data_source>/<document_uuid> - **depth**: Maximum depth for resolving nested documents.
-         * @summary Get By Id
-         * @param {string} idReference 
+         * Get document as JSON string.  - **reference**:   - By id: PROTOCOL://DATA SOURCE/$ID.Attribute   - By path: PROTOCOL://DATA SOURCE/ROOT PACKAGE/SUB PACKAGE/ENTITY.Attribute   - By query: PROTOCOL://DATA SOURCE/$ID.list(key=value)    The PROTOCOL is optional, and the default is dmss.  - **depth**: Maximum depth for resolving nested documents.
+         * @summary Get
+         * @param {string} reference 
          * @param {number} [depth] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        documentGetById: async (idReference: string, depth?: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'idReference' is not null or undefined
-            assertParamExists('documentGetById', 'idReference', idReference)
-            const localVarPath = `/api/documents/{id_reference}`
-                .replace(`{${"id_reference"}}`, encodeURIComponent(String(idReference)));
+        documentGet: async (reference: string, depth?: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'reference' is not null or undefined
+            assertParamExists('documentGet', 'reference', reference)
+            const localVarPath = `/api/documents/{reference}`
+                .replace(`{${"reference"}}`, encodeURIComponent(String(reference)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -225,47 +225,6 @@ export const DocumentApiAxiosParamCreator = function (configuration?: Configurat
             if (depth !== undefined) {
                 localVarQueryParameter['depth'] = depth;
             }
-
-
-    
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * Get a document by its absolute path.  - **absolute_path**: <protocol>://<data_source>/<path>.<attribute>
-         * @summary Get By Path
-         * @param {string} absolutePath 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        documentGetByPath: async (absolutePath: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'absolutePath' is not null or undefined
-            assertParamExists('documentGetByPath', 'absolutePath', absolutePath)
-            const localVarPath = `/api/documents-by-path/{absolute_path}`
-                .replace(`{${"absolute_path"}}`, encodeURIComponent(String(absolutePath)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            // authentication APIKeyHeader required
-            await setApiKeyToObject(localVarHeaderParameter, "Access-Key", configuration)
-
-            // authentication OAuth2AuthorizationCodeBearer required
-            // oauth required
-            await setOAuthToObject(localVarHeaderParameter, "OAuth2AuthorizationCodeBearer", [], configuration)
 
 
     
@@ -474,26 +433,15 @@ export const DocumentApiFp = function(configuration?: Configuration) {
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
-         * Get document as JSON string.  - **id_reference**: <data_source>/<document_uuid> - **depth**: Maximum depth for resolving nested documents.
-         * @summary Get By Id
-         * @param {string} idReference 
+         * Get document as JSON string.  - **reference**:   - By id: PROTOCOL://DATA SOURCE/$ID.Attribute   - By path: PROTOCOL://DATA SOURCE/ROOT PACKAGE/SUB PACKAGE/ENTITY.Attribute   - By query: PROTOCOL://DATA SOURCE/$ID.list(key=value)    The PROTOCOL is optional, and the default is dmss.  - **depth**: Maximum depth for resolving nested documents.
+         * @summary Get
+         * @param {string} reference 
          * @param {number} [depth] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async documentGetById(idReference: string, depth?: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<object>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.documentGetById(idReference, depth, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
-        },
-        /**
-         * Get a document by its absolute path.  - **absolute_path**: <protocol>://<data_source>/<path>.<attribute>
-         * @summary Get By Path
-         * @param {string} absolutePath 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async documentGetByPath(absolutePath: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<object>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.documentGetByPath(absolutePath, options);
+        async documentGet(reference: string, depth?: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<object>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.documentGet(reference, depth, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -579,25 +527,15 @@ export const DocumentApiFactory = function (configuration?: Configuration, baseP
             return localVarFp.documentAddToPath(pathReference, document, updateUncontained, files, options).then((request) => request(axios, basePath));
         },
         /**
-         * Get document as JSON string.  - **id_reference**: <data_source>/<document_uuid> - **depth**: Maximum depth for resolving nested documents.
-         * @summary Get By Id
-         * @param {string} idReference 
+         * Get document as JSON string.  - **reference**:   - By id: PROTOCOL://DATA SOURCE/$ID.Attribute   - By path: PROTOCOL://DATA SOURCE/ROOT PACKAGE/SUB PACKAGE/ENTITY.Attribute   - By query: PROTOCOL://DATA SOURCE/$ID.list(key=value)    The PROTOCOL is optional, and the default is dmss.  - **depth**: Maximum depth for resolving nested documents.
+         * @summary Get
+         * @param {string} reference 
          * @param {number} [depth] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        documentGetById(idReference: string, depth?: number, options?: any): AxiosPromise<object> {
-            return localVarFp.documentGetById(idReference, depth, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Get a document by its absolute path.  - **absolute_path**: <protocol>://<data_source>/<path>.<attribute>
-         * @summary Get By Path
-         * @param {string} absolutePath 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        documentGetByPath(absolutePath: string, options?: any): AxiosPromise<object> {
-            return localVarFp.documentGetByPath(absolutePath, options).then((request) => request(axios, basePath));
+        documentGet(reference: string, depth?: number, options?: any): AxiosPromise<object> {
+            return localVarFp.documentGet(reference, depth, options).then((request) => request(axios, basePath));
         },
         /**
          * Remove document - **id_reference**: <data_source>/<document_uuid>.<attribute_path>  Example: id_reference=SomeDataSource/3978d9ca-2d7a-4b47-8fed-57710f6cf50b.attributes.1 will remove the first element in the attribute list of a blueprint with the given id in data source \'SomeDataSource\'.
@@ -720,38 +658,24 @@ export interface DocumentApiDocumentAddToPathRequest {
 }
 
 /**
- * Request parameters for documentGetById operation in DocumentApi.
+ * Request parameters for documentGet operation in DocumentApi.
  * @export
- * @interface DocumentApiDocumentGetByIdRequest
+ * @interface DocumentApiDocumentGetRequest
  */
-export interface DocumentApiDocumentGetByIdRequest {
+export interface DocumentApiDocumentGetRequest {
     /**
      * 
      * @type {string}
-     * @memberof DocumentApiDocumentGetById
+     * @memberof DocumentApiDocumentGet
      */
-    readonly idReference: string
+    readonly reference: string
 
     /**
      * 
      * @type {number}
-     * @memberof DocumentApiDocumentGetById
+     * @memberof DocumentApiDocumentGet
      */
     readonly depth?: number
-}
-
-/**
- * Request parameters for documentGetByPath operation in DocumentApi.
- * @export
- * @interface DocumentApiDocumentGetByPathRequest
- */
-export interface DocumentApiDocumentGetByPathRequest {
-    /**
-     * 
-     * @type {string}
-     * @memberof DocumentApiDocumentGetByPath
-     */
-    readonly absolutePath: string
 }
 
 /**
@@ -861,27 +785,15 @@ export class DocumentApi extends BaseAPI {
     }
 
     /**
-     * Get document as JSON string.  - **id_reference**: <data_source>/<document_uuid> - **depth**: Maximum depth for resolving nested documents.
-     * @summary Get By Id
-     * @param {DocumentApiDocumentGetByIdRequest} requestParameters Request parameters.
+     * Get document as JSON string.  - **reference**:   - By id: PROTOCOL://DATA SOURCE/$ID.Attribute   - By path: PROTOCOL://DATA SOURCE/ROOT PACKAGE/SUB PACKAGE/ENTITY.Attribute   - By query: PROTOCOL://DATA SOURCE/$ID.list(key=value)    The PROTOCOL is optional, and the default is dmss.  - **depth**: Maximum depth for resolving nested documents.
+     * @summary Get
+     * @param {DocumentApiDocumentGetRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof DocumentApi
      */
-    public documentGetById(requestParameters: DocumentApiDocumentGetByIdRequest, options?: AxiosRequestConfig) {
-        return DocumentApiFp(this.configuration).documentGetById(requestParameters.idReference, requestParameters.depth, options).then((request) => request(this.axios, this.basePath));
-    }
-
-    /**
-     * Get a document by its absolute path.  - **absolute_path**: <protocol>://<data_source>/<path>.<attribute>
-     * @summary Get By Path
-     * @param {DocumentApiDocumentGetByPathRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof DocumentApi
-     */
-    public documentGetByPath(requestParameters: DocumentApiDocumentGetByPathRequest, options?: AxiosRequestConfig) {
-        return DocumentApiFp(this.configuration).documentGetByPath(requestParameters.absolutePath, options).then((request) => request(this.axios, this.basePath));
+    public documentGet(requestParameters: DocumentApiDocumentGetRequest, options?: AxiosRequestConfig) {
+        return DocumentApiFp(this.configuration).documentGet(requestParameters.reference, requestParameters.depth, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/packages/dm-core/src/services/api/configs/gen/models/entity.ts
+++ b/packages/dm-core/src/services/api/configs/gen/models/entity.ts
@@ -26,6 +26,5 @@ export interface Entity {
      * @memberof Entity
      */
     'type': string;
-    [key: string]: any;
 }
 

--- a/packages/dm-core/src/services/api/configs/gen/models/recipe.ts
+++ b/packages/dm-core/src/services/api/configs/gen/models/recipe.ts
@@ -77,5 +77,11 @@ export interface Recipe {
      * @memberof Recipe
      */
     'label'?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof Recipe
+     */
+    'dimensions'?: string;
 }
 

--- a/packages/dm-core/src/services/api/configs/gen/models/reference.ts
+++ b/packages/dm-core/src/services/api/configs/gen/models/reference.ts
@@ -25,18 +25,18 @@ export interface Reference {
      * @type {string}
      * @memberof Reference
      */
-    '_id': string;
-    /**
-     * 
-     * @type {string}
-     * @memberof Reference
-     */
-    'name': string;
+    'address': string;
     /**
      * 
      * @type {string}
      * @memberof Reference
      */
     'type': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof Reference
+     */
+    'referenceType': string;
 }
 

--- a/packages/dm-core/src/utils/test-utils-dm-core.tsx
+++ b/packages/dm-core/src/utils/test-utils-dm-core.tsx
@@ -4,11 +4,11 @@ import { DmssAPI } from '../services/api/DmssAPI'
 import React from 'react'
 
 export const mockGetDocument = (documents: any) => {
-  const mock = jest.spyOn(DmssAPI.prototype, 'documentGetById')
+  const mock = jest.spyOn(DmssAPI.prototype, 'documentGet')
   //@ts-ignore
   mock.mockImplementation((parameters) => {
     return documents.some(
-      (document: any) => document.idReference === parameters['idReference']
+      (document: any) => document.reference === parameters['reference']
     )
       ? Promise.resolve({
           data: documents,


### PR DESCRIPTION
## What does this pull request change?

* Update to use the document get endpoint instead of get-by-path and get-by-id endpoint

## Why is this pull request needed?

## Issues related to this change

Related to https://github.com/equinor/data-modelling-storage-service/pull/421
