### PR TITLE
chore: bump DMSS version and update signalApp to match renamed blueprints

### DIFF
--- a/example/app/data/DemoDataSource/apps/MySignalApp/instances/CaseUISelector.json
+++ b/example/app/data/DemoDataSource/apps/MySignalApp/instances/CaseUISelector.json
@@ -2,13 +2,31 @@
   "type": "CORE:RecipeLink",
   "_blueprintPath_": "AppModels:signals_simple/Case",
   "initialUiRecipe": {
+    "name": "UiRecipesSelector",
     "type": "CORE:UiRecipe",
-    "name": "Selector",
-    "description": "ESS Plot",
-    "plugin": "UiPluginSelector",
+    "plugin": "@development-framework/dm-core-plugins/attribute-selector",
     "config": {
-      "type": "PluginModels:uiPluginSelector/UiPluginSelectorConfig",
-      "recipes": ["Tabs", "Run"]
+      "type": "PLUGINS:dm-core-plugins/attribute-selector/AttributeSelectorConfig",
+      "items": [
+        {
+          "type": "PLUGINS:dm-core-plugins/attribute-selector/AttributeSelectorItem",
+          "label": "Tabs",
+          "view": {
+            "type": "CORE:ReferenceViewConfig",
+            "recipe": "Tabs",
+            "scope": "self"
+          }
+        },
+        {
+          "type": "PLUGINS:dm-core-plugins/attribute-selector/AttributeSelectorItem",
+          "label": "Run",
+          "view": {
+            "type": "CORE:ReferenceViewConfig",
+            "recipe": "Run",
+            "scope": "self"
+          }
+        }
+      ]
     }
   },
   "uiRecipes": [
@@ -22,10 +40,9 @@
       "type": "CORE:UiRecipe",
       "plugin": "@development-framework/dm-core-plugins/attribute-selector",
       "config": {
-        "type": "PluginModels:tabs/TabsPluginConfig",
+        "type": "PLUGINS:dm-core-plugins/attribute-selector/AttributeSelectorConfig",
         "childTabsOnRender": true,
-        "asSidebar": false,
-        "homeRecipe": "Edit"
+        "asSidebar": false
       }
     },
     {

--- a/example/app/data/DemoDataSource/apps/MySignalApp/package.json
+++ b/example/app/data/DemoDataSource/apps/MySignalApp/package.json
@@ -18,12 +18,6 @@
         "protocol": "dmss"
       },
       {
-        "alias": "PluginModels",
-        "address": "DemoDataSource/apps/MySignalApp/models/plugins",
-        "version": "0.0.1",
-        "protocol": "dmss"
-      },
-      {
         "alias": "PLUGINS",
         "address": "system/Plugins",
         "version": "0.0.1",

--- a/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/appDefault.json
+++ b/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/appDefault.json
@@ -4,9 +4,9 @@
   "initialUiRecipe": {
     "name": "Tabs",
     "type": "CORE:UiRecipe",
-    "plugin": "tabs",
+    "plugin": "@development-framework/dm-core-plugins/attribute-selector",
     "config": {
-      "type": "PluginModels:tabs/TabsPluginConfig",
+      "type": "PLUGINS:dm-core-plugins/attribute-selector/AttributeSelectorConfig",
       "childTabsOnRender": true,
       "asSidebar": false,
       "homeRecipe": "Edit"

--- a/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/containers/EquallySpacedSignalUI.json
+++ b/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/containers/EquallySpacedSignalUI.json
@@ -2,13 +2,31 @@
   "type": "CORE:RecipeLink",
   "_blueprintPath_": "AppModels:containers/EquallySpacedSignal",
   "initialUiRecipe": {
+    "name": "UiRecipesSelector",
     "type": "CORE:UiRecipe",
-    "name": "Selector",
-    "description": "ESS Plot",
-    "plugin": "UiPluginSelector",
+    "plugin": "@development-framework/dm-core-plugins/attribute-selector",
     "config": {
-      "type": "PluginModels:uiPluginSelector/UiPluginSelectorConfig",
-      "recipes": ["Plot", "Table"]
+      "type": "PLUGINS:dm-core-plugins/attribute-selector/AttributeSelectorConfig",
+      "items": [
+        {
+          "type": "PLUGINS:dm-core-plugins/attribute-selector/AttributeSelectorItem",
+          "label": "Plot",
+          "view": {
+            "type": "CORE:ReferenceViewConfig",
+            "recipe": "Plot",
+            "scope": "self"
+          }
+        },
+        {
+          "type": "PLUGINS:dm-core-plugins/attribute-selector/AttributeSelectorItem",
+          "label": "Table",
+          "view": {
+            "type": "CORE:ReferenceViewConfig",
+            "recipe": "Table",
+            "scope": "self"
+          }
+        }
+      ]
     }
   },
   "uiRecipes": [

--- a/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/signalAppUI.json
+++ b/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/signalAppUI.json
@@ -7,7 +7,7 @@
     "plugin": "@development-framework/dm-core-plugins/header",
     "config": {
       "uiRecipesList": ["SideBar", "Explorer", "Yaml"],
-      "type": "PluginModels:header/HeaderPluginConfig",
+      "type": "PLUGINS:dm-core-plugins/header/HeaderPluginConfig",
       "hideAbout": false,
       "hideUserInfo": true
     }

--- a/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/signals_simple/CaseUI.json
+++ b/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/signals_simple/CaseUI.json
@@ -8,21 +8,21 @@
       "description": "ESS Plot",
       "plugin": "@development-framework/dm-core-plugins/grid",
       "config": {
-        "type": "PluginModels:grid/GridPluginConfig",
+        "type": "PLUGINS:dm-core-plugins/grid/GridPluginConfig",
         "size": {
-          "type": "PluginModels:grid/GridSize",
+          "type": "PLUGINS:dm-core-plugins/grid/GridSize",
           "columns": 12,
           "rows": 15
         },
         "items": [
           {
-            "type": "PluginModels:grid/GridItem",
+            "type": "PLUGINS:dm-core-plugins/grid/GridItem",
             "viewConfig": {
               "type": "CORE:ReferenceViewConfig",
               "recipe": "Tabs"
             },
             "gridArea": {
-              "type": "PluginModels:grid/GridArea",
+              "type": "PLUGINS:dm-core-plugins/grid/GridArea",
               "rowStart": 1,
               "columnStart": 1,
               "rowEnd": 10,
@@ -30,14 +30,14 @@
             }
           },
           {
-            "type": "PluginModels:grid/GridItem",
+            "type": "PLUGINS:dm-core-plugins/grid/GridItem",
             "viewConfig": {
               "type": "CORE:ReferenceViewConfig",
               "scope": "signal",
               "recipe": "Plot"
             },
             "gridArea": {
-              "type": "PluginModels:grid/GridArea",
+              "type": "PLUGINS:dm-core-plugins/grid/GridArea",
               "rowStart": 1,
               "columnStart": 6,
               "rowEnd": 3,
@@ -45,13 +45,13 @@
             }
           },
           {
-            "type": "PluginModels:grid/GridItem",
+            "type": "PLUGINS:dm-core-plugins/grid/GridItem",
             "viewConfig": {
               "type": "CORE:ReferenceViewConfig",
               "recipe": "RunInt"
             },
             "gridArea": {
-              "type": "PluginModels:grid/GridArea",
+              "type": "PLUGINS:dm-core-plugins/grid/GridArea",
               "rowStart": 3,
               "columnStart": 6,
               "rowEnd": 10,
@@ -71,7 +71,7 @@
       "type": "CORE:UiRecipe",
       "plugin": "@development-framework/dm-core-plugins/attribute-selector",
       "config": {
-        "type": "PluginModels:tabs/AttributeSelectorPluginConfig",
+        "type": "PLUGINS:dm-core-plugins/attribute-selector/AttributeSelectorConfig",
         "childTabsOnRender": true,
         "asSidebar": false,
         "items": [

--- a/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/signals_simple/StudyNCUI.json
+++ b/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/signals_simple/StudyNCUI.json
@@ -5,9 +5,9 @@
   "initialUiRecipe": {
     "name": "Tabs",
     "type": "CORE:UiRecipe",
-    "plugin": "tabs",
+    "plugin": "@development-framework/dm-core-plugins/attribute-selector",
     "config": {
-      "type": "PluginModels:tabs/TabsPluginConfig",
+      "type": "PLUGINS:dm-core-plugins/attribute-selector/AttributeSelectorConfig",
       "childTabsOnRender": true,
       "asSidebar": false,
       "homeRecipe": "Edit"

--- a/example/app/data/DemoDataSource/recipes/package.json
+++ b/example/app/data/DemoDataSource/recipes/package.json
@@ -28,13 +28,6 @@
       },
       {
         "type": "CORE:Dependency",
-        "alias": "PluginModels",
-        "address": "DemoDataSource/apps/MySignalApp/models/plugins",
-        "version": "0.0.1",
-        "protocol": "dmss"
-      },
-      {
-        "type": "CORE:Dependency",
         "alias": "JOBCORE",
         "address": "WorkflowDS/Blueprints",
         "version": "0.0.1",

--- a/packages/dm-core/src/domain/Tree.tsx
+++ b/packages/dm-core/src/domain/Tree.tsx
@@ -217,7 +217,8 @@ export class TreeNode {
       this.tree.dmssApi
         .documentGet({
           reference: this.nodeId,
-          depth: 0,
+          depth: 2,
+          resolveLinks: true,
         })
         .then((response: any) => {
           const data = response.data

--- a/packages/dm-core/src/services/api/configs/gen/api/default-api.ts
+++ b/packages/dm-core/src/services/api/configs/gen/api/default-api.ts
@@ -616,10 +616,11 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          * @summary Get
          * @param {string} reference 
          * @param {number} [depth] 
+         * @param {boolean} [resolveLinks] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        documentGet: async (reference: string, depth?: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        documentGet: async (reference: string, depth?: number, resolveLinks?: boolean, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'reference' is not null or undefined
             assertParamExists('documentGet', 'reference', reference)
             const localVarPath = `/api/documents/{reference}`
@@ -644,6 +645,10 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
 
             if (depth !== undefined) {
                 localVarQueryParameter['depth'] = depth;
+            }
+
+            if (resolveLinks !== undefined) {
+                localVarQueryParameter['resolve_links'] = resolveLinks;
             }
 
 
@@ -1567,11 +1572,12 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @summary Get
          * @param {string} reference 
          * @param {number} [depth] 
+         * @param {boolean} [resolveLinks] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async documentGet(reference: string, depth?: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<object>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.documentGet(reference, depth, options);
+        async documentGet(reference: string, depth?: number, resolveLinks?: boolean, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<object>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.documentGet(reference, depth, resolveLinks, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -1918,11 +1924,12 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          * @summary Get
          * @param {string} reference 
          * @param {number} [depth] 
+         * @param {boolean} [resolveLinks] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        documentGet(reference: string, depth?: number, options?: any): AxiosPromise<object> {
-            return localVarFp.documentGet(reference, depth, options).then((request) => request(axios, basePath));
+        documentGet(reference: string, depth?: number, resolveLinks?: boolean, options?: any): AxiosPromise<object> {
+            return localVarFp.documentGet(reference, depth, resolveLinks, options).then((request) => request(axios, basePath));
         },
         /**
          * Remove document - **id_reference**: <data_source>/<document_uuid>.<attribute_path>  Example: id_reference=SomeDataSource/3978d9ca-2d7a-4b47-8fed-57710f6cf50b.attributes.1 will remove the first element in the attribute list of a blueprint with the given id in data source \'SomeDataSource\'.
@@ -2365,6 +2372,13 @@ export interface DefaultApiDocumentGetRequest {
      * @memberof DefaultApiDocumentGet
      */
     readonly depth?: number
+
+    /**
+     * 
+     * @type {boolean}
+     * @memberof DefaultApiDocumentGet
+     */
+    readonly resolveLinks?: boolean
 }
 
 /**
@@ -2820,7 +2834,7 @@ export class DefaultApi extends BaseAPI {
      * @memberof DefaultApi
      */
     public documentGet(requestParameters: DefaultApiDocumentGetRequest, options?: AxiosRequestConfig) {
-        return DefaultApiFp(this.configuration).documentGet(requestParameters.reference, requestParameters.depth, options).then((request) => request(this.axios, this.basePath));
+        return DefaultApiFp(this.configuration).documentGet(requestParameters.reference, requestParameters.depth, requestParameters.resolveLinks, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/packages/dm-core/src/services/api/configs/gen/api/document-api.ts
+++ b/packages/dm-core/src/services/api/configs/gen/api/document-api.ts
@@ -196,10 +196,11 @@ export const DocumentApiAxiosParamCreator = function (configuration?: Configurat
          * @summary Get
          * @param {string} reference 
          * @param {number} [depth] 
+         * @param {boolean} [resolveLinks] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        documentGet: async (reference: string, depth?: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        documentGet: async (reference: string, depth?: number, resolveLinks?: boolean, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'reference' is not null or undefined
             assertParamExists('documentGet', 'reference', reference)
             const localVarPath = `/api/documents/{reference}`
@@ -224,6 +225,10 @@ export const DocumentApiAxiosParamCreator = function (configuration?: Configurat
 
             if (depth !== undefined) {
                 localVarQueryParameter['depth'] = depth;
+            }
+
+            if (resolveLinks !== undefined) {
+                localVarQueryParameter['resolve_links'] = resolveLinks;
             }
 
 
@@ -437,11 +442,12 @@ export const DocumentApiFp = function(configuration?: Configuration) {
          * @summary Get
          * @param {string} reference 
          * @param {number} [depth] 
+         * @param {boolean} [resolveLinks] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async documentGet(reference: string, depth?: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<object>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.documentGet(reference, depth, options);
+        async documentGet(reference: string, depth?: number, resolveLinks?: boolean, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<object>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.documentGet(reference, depth, resolveLinks, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -531,11 +537,12 @@ export const DocumentApiFactory = function (configuration?: Configuration, baseP
          * @summary Get
          * @param {string} reference 
          * @param {number} [depth] 
+         * @param {boolean} [resolveLinks] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        documentGet(reference: string, depth?: number, options?: any): AxiosPromise<object> {
-            return localVarFp.documentGet(reference, depth, options).then((request) => request(axios, basePath));
+        documentGet(reference: string, depth?: number, resolveLinks?: boolean, options?: any): AxiosPromise<object> {
+            return localVarFp.documentGet(reference, depth, resolveLinks, options).then((request) => request(axios, basePath));
         },
         /**
          * Remove document - **id_reference**: <data_source>/<document_uuid>.<attribute_path>  Example: id_reference=SomeDataSource/3978d9ca-2d7a-4b47-8fed-57710f6cf50b.attributes.1 will remove the first element in the attribute list of a blueprint with the given id in data source \'SomeDataSource\'.
@@ -676,6 +683,13 @@ export interface DocumentApiDocumentGetRequest {
      * @memberof DocumentApiDocumentGet
      */
     readonly depth?: number
+
+    /**
+     * 
+     * @type {boolean}
+     * @memberof DocumentApiDocumentGet
+     */
+    readonly resolveLinks?: boolean
 }
 
 /**
@@ -793,7 +807,7 @@ export class DocumentApi extends BaseAPI {
      * @memberof DocumentApi
      */
     public documentGet(requestParameters: DocumentApiDocumentGetRequest, options?: AxiosRequestConfig) {
-        return DocumentApiFp(this.configuration).documentGet(requestParameters.reference, requestParameters.depth, options).then((request) => request(this.axios, this.basePath));
+        return DocumentApiFp(this.configuration).documentGet(requestParameters.reference, requestParameters.depth, requestParameters.resolveLinks, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**


### PR DESCRIPTION
## What does this pull request change?
- Fix some outdated names for types and plugins in the signalApp
- Update the DMSS TS API
- Fix Tree.ts to fetch enough depth to get name of TreeNodes

## Why is this pull request needed?
- Make the test app "SignalApp" work

## Issues related to this change
none
