### PR TITLE
fix(form): pass typeFilter to EntityPicker

### DIFF
--- a/example/app/data/DemoDataSource/apps/MySignalApp/package.json
+++ b/example/app/data/DemoDataSource/apps/MySignalApp/package.json
@@ -6,30 +6,35 @@
     "version": "0.0.1",
     "dependencies": [
       {
+        "type": "CORE:Dependency",
         "alias": "CORE",
         "address": "system/SIMOS",
         "version": "0.0.1",
         "protocol": "dmss"
       },
       {
+        "type": "CORE:Dependency",
         "alias": "AppModels",
         "address": "DemoDataSource/apps/MySignalApp/models",
         "version": "0.0.1",
         "protocol": "dmss"
       },
       {
+        "type": "CORE:Dependency",
         "alias": "PLUGINS",
         "address": "system/Plugins",
         "version": "0.0.1",
         "protocol": "dmss"
       },
       {
+        "type": "CORE:Dependency",
         "alias": "JOBCORE",
         "address": "WorkflowDS/Blueprints",
         "version": "0.0.1",
         "protocol": "dmss"
       },
       {
+        "type": "CORE:Dependency",
         "alias": "SIMA",
         "address": "SIMADS/sima4.2.1",
         "version": "4.2.1",

--- a/example/app/data/DemoDataSource/apps/MySignalApp/signalApp.json
+++ b/example/app/data/DemoDataSource/apps/MySignalApp/signalApp.json
@@ -1,5 +1,5 @@
 {
-  "_id": "4483c9b0-d505-46c9-a157-94c79f4d7a6a",
+  "_id": "5483c9b0-d505-46c9-a157-94c79f4d7a6a",
   "type": "AppModels:SignalApp",
   "name": "signalApp",
   "description": "This is an app for generating and plotting sin signals.",

--- a/example/app/data/DemoDataSource/plugins/form/blueprints/FormBlueprint.json
+++ b/example/app/data/DemoDataSource/plugins/form/blueprints/FormBlueprint.json
@@ -14,6 +14,13 @@
       "label": "Blueprint picker widget"
     },
     {
+      "name": "aJob",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "JOBCORE:Job",
+      "optional": true,
+      "contained": false
+    },
+    {
       "name": "aNumber",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "number",

--- a/example/app/data/DemoDataSource/plugins/package.json
+++ b/example/app/data/DemoDataSource/plugins/package.json
@@ -18,6 +18,13 @@
         "address": "system/Plugins",
         "version": "0.0.1",
         "protocol": "dmss"
+      },
+      {
+        "type": "CORE:Dependency",
+        "alias": "JOBCORE",
+        "address": "WorkflowDS/Blueprints",
+        "version": "0.0.1",
+        "protocol": "dmss"
       }
     ]
   }

--- a/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
@@ -49,6 +49,7 @@ const AddExternal = (props: any) => {
       <EntityPickerButton
         data-testid={`select-${namePath}`}
         onChange={handleSelect}
+        typeFilter={type}
       />
       <NewEntityButton
         data-testid={`new-entity-${namePath}`}

--- a/packages/dm-core-plugins/src/generic-list/GenericListPlugin.tsx
+++ b/packages/dm-core-plugins/src/generic-list/GenericListPlugin.tsx
@@ -113,7 +113,7 @@ export const GenericListPlugin = (
           )
           .catch((error: AxiosError<ErrorResponse>) => {
             console.error(error)
-            alert(JSON.stringify(error.response?.data, null, 2))
+            alert(error.response?.data.message)
           })
       })
   }

--- a/packages/dm-core/src/components/Pickers/DestinationPicker.tsx
+++ b/packages/dm-core/src/components/Pickers/DestinationPicker.tsx
@@ -64,6 +64,7 @@ export const DestinationPicker = (props: TDestinationPickerProps) => {
           }}
           disabled={disabled || false}
           type="string"
+          readOnly
           value={truncatePathString(formData)}
           placeholder="Select folder"
           onClick={() => setShowModal(true)}


### PR DESCRIPTION
## What does this pull request change?
- Fixes a bug where in the form plugin when selecting an entity to reference, any type was allowed, resulting in invalid entities. ObjectField.tsx:52
- Add missing "type" to testApp package.json
- Update "form" plugin test entity to have an uncontained job attribute
- Set DestinationPicker input to be readOnly (it was a controlled field)
- Add a icon to signify entities not valid for selection in "EntityPicker" Tree (see image)

![Screenshot_20230519_142620](https://github.com/equinor/dm-core-packages/assets/11062560/07ed550c-b346-4651-b450-7bc7759cd561)



## Why is this pull request needed?
The user should be guided to know which entities are valid for selection in any given context

