### PR TITLE
Refactor/yarn workspaces

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,7 +19,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        package: [ dm-core, dm-core-plugins ]
+        package: [dm-core, dm-core-plugins]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
@@ -28,34 +28,11 @@ jobs:
 
       # TODO: Cache yarn install
 
-      - name: Set variables
-        id: variables
-        working-directory: packages/${{ matrix.package }}
-        run: |
-          echo "DM_CORE_VERSION=$(cat package.json | jq '.["dependencies"]["@development-framework/dm-core"]')" >> "$GITHUB_OUTPUT"
-          echo "TEST_COMMAND=$(cat package.json | jq '.["scripts"]["test"]')" >> "$GITHUB_OUTPUT"
-
       - name: 'Install dependencies'
-        working-directory: packages/${{ matrix.package }}
         run: yarn install
 
-      #      - name: 'Copy local variant of dm-core to node_modules'
-      #        working-directory: packages/${{ matrix.package }}
-      #        if: steps.variables.outputs.DM_CORE_VERSION != 'null'
-      #        run: |
-      #          cd ../dm-core
-      #          yarn install --no-lockfile
-      #          yarn build
-      #          cd ../dm-core-plugins
-      #          rm -r node_modules/@development-framework/dm-core/*
-      #          cp -r ../dm-core/dist node_modules/@development-framework/dm-core/dist
-      #          cp ../dm-core/package.json node_modules/@development-framework/dm-core/package.json
+      - name: 'Build packages'
+        run: yarn build:packages
 
-      - name: 'yarn tsc'
-        working-directory: packages/${{ matrix.package }}
-        run: yarn tsc
-
-      - name: 'yarn test'
-        working-directory: packages/${{ matrix.package }}
-        if: steps.variables.outputs.TEST_COMMAND != 'null'
-        run: yarn test
+      - name: 'Test packages'
+        run: yarn test:packages

--- a/example/README.md
+++ b/example/README.md
@@ -2,31 +2,38 @@
 
 ## Prerequisites
 
-Make sure you have installed the following:
+- Node and yarn
+- [Docker](https://www.docker.com/)
+- [Docker Compose](https://docs.docker.com/compose/)
+- Make sure you have Python installed. version 3.10 or higher is required.
 
-- Docker compose
-- Python and the dm-cli python package(`pip install dm-cli`).
-- Node
-
-## Running the app
-
-Open the terminal and navigate to the `dm-core-packages/example` folder before running the commands.
-
-1. Pull and start API services with the command:
-   `docker-compose pull && docker-compose up`
-
-2. Build packages locally and create symlinks. Open a new terminal window, navigate to the `example` folder and run:
-
-- `yarn build-all-packages`
-- `yarn symlinks`
-
-3. Start the test app (npm will not work)
-   `yarn start`
-
-2. Load all documents into the database. Open a new terminal window, navigate to the `example` folder and run:
-   `./reset-all.sh`
+## Running
 
 > **Note**
-> There can be no remaining `node_modules` in the packages.
-> That will cause strange and subtle bugs
+> Run all these commands from the `dm-core-packages`/ (main project) folder
 
+1. Install dependecies.
+
+   #### Frontend
+
+   The project uses yarn workspaces to handle dependencies for all three sub-projects.
+
+   - Run `yarn install`
+
+   #### Backend
+
+   Install dm-cli locally
+
+   - Initialize and activate virtual env
+     - `python3 -m venv .venv`
+     - `source .venv/bin/activate`
+   - Install dm-cli package by running `pip install dm-cli`
+
+2. Build the required packages locally (dm-core and dm-core-plugins).
+   - Run `yarn build:dm-core` and `yarn build:dm-core-plugins` in that order
+3. Pull and start API services
+   - `docker-compose pull && docker-compose up -d`
+4. Run shell script to load dmss data
+   - `./reset-all.sh`
+5. Start the test app
+   - `yarn start:example`

--- a/example/craco.config.js
+++ b/example/craco.config.js
@@ -19,6 +19,20 @@ module.exports = {
           mainFields: ['module', 'main'],
         })
       )
+
+      if ((process.env.NODE_ENV || '').trim() === 'development') {
+        config.resolve.alias = {
+          '@development-framework/dm-core': path.resolve(
+            __dirname,
+            '../packages/dm-core/src/index.tsx'
+          ),
+          '@development-framework/dm-core-plugins': path.resolve(
+            __dirname,
+            '../packages/dm-core-plugins/src/index.tsx'
+          ),
+        }
+      }
+
       const oneOfRule = config.module.rules.find((rule) => rule.oneOf)
       // Replace include option for babel loader with exclude
       // so babel will handle workspace projects as well.

--- a/example/package.json
+++ b/example/package.json
@@ -3,10 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@craco/craco": "^7.0.0",
-    "@development-framework/dm-core": "link:../packages/dm-core",
-    "@development-framework/dm-core-plugins": "link:../packages/dm-core-plugins",
     "plotly.js": "^2.18.2",
+    "@development-framework/dm-core": "1.0.55",
+    "@development-framework/dm-core-plugins": "1.0.22",
+    "@craco/craco": "^7.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-oauth2-code-pkce": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "start:example": "yarn workspace example start",
     "build:dm-core": "yarn workspace @development-framework/dm-core build",
     "build:dm-core-plugins": "yarn workspace @development-framework/dm-core-plugins build",
-    "clear-external-pckgs": "rm -rf node_modules && rm -rf packages/dm-core/node_modules && rm -rf packages/dm-core-plugins/node_modules && rm -rf example/node_modules && rm yarn.lock"
+    "clear-external-pckgs": "rm -rf node_modules && rm -rf packages/dm-core/node_modules && rm -rf packages/dm-core-plugins/node_modules && rm -rf example/node_modules && rm yarn.lock",
+    "build:packages": "yarn workspace @development-framework/dm-core build && yarn workspace @development-framework/dm-core-plugins build",
+    "test:packages": "yarn workspace @development-framework/dm-core test && yarn workspace @development-framework/dm-core-plugins test"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "private": true,
+  "workspaces": [
+    "example",
+    "packages/dm-core",
+    "packages/dm-core-plugins"
+  ],
+  "scripts": {
+    "start:example": "yarn workspace example start",
+    "build:dm-core": "yarn workspace @development-framework/dm-core build",
+    "build:dm-core-plugins": "yarn workspace @development-framework/dm-core-plugins build",
+    "clear-external-pckgs": "rm -rf node_modules && rm -rf packages/dm-core/node_modules && rm -rf packages/dm-core-plugins/node_modules && rm -rf example/node_modules && rm yarn.lock"
+  }
+}

--- a/packages/dm-core-plugins/package.json
+++ b/packages/dm-core-plugins/package.json
@@ -27,26 +27,23 @@
     "@types/highlightjs": "^9.12.2",
     "@types/jest": "^29.5.0",
     "@types/js-yaml": "^4.0.5",
-    "@types/react": "^17.0.39",
     "@types/react-dom": "^17.0.11",
     "@types/react-router-dom": "^5.3.3",
     "@types/styled-components": "^4.1.18",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
     "react-router-dom": ">=5.1.2",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
     "react-test-renderer": "17.0.2",
     "shx": " 0.3.4",
     "ts-jest": "^29.1.0",
     "ts-loader": "^9.3.1",
-    "typescript": "^4.5.5",
-    "styled-components": ">=5.1.0"
+    "typescript": "^4.5.5"
   },
   "peerDependencies": {
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "styled-components": ">=5.1.0"
+    "styled-components": ">=5.1.0",
+    "@types/react": "^17.0.39"
   },
   "files": [
     "blueprints",
@@ -58,7 +55,6 @@
     "copy-yaml-css-file": "shx cp src/yaml/index.css ./dist/yaml",
     "copy-explorer-css-file": "shx cp src/explorer/style.css ./dist/explorer",
     "build": "tsc && yarn copy-explorer-css-file && yarn copy-yaml-css-file && yarn copy-explorer-css-file",
-    "postbuild": "shx rm -rf node_modules",
     "test": "jest test",
     "test-watch": "jest test --watchAll"
   }

--- a/packages/dm-core/package.json
+++ b/packages/dm-core/package.json
@@ -6,7 +6,8 @@
     "react-router-dom": ">=5.1.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "styled-components": "^5.2.3"
+    "styled-components": "^5.2.3",
+    "@types/react": "^17.0.39"
   },
   "dependencies": {
     "@equinor/eds-core-react": "^0.29.1",
@@ -17,17 +18,12 @@
     "react-icons": "3.11.0",
     "react-is": "^17.0.2",
     "react-notifications": "^1.7.4",
-    "react-oauth2-code-pkce": "^1.6.1"
+    "react-oauth2-code-pkce": "^1.10.1"
   },
   "devDependencies": {
-    "react-router-dom": ">=5.1.2",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "styled-components": "^5.2.3",
     "@testing-library/react": "^11.2.7",
     "@testing-library/react-hooks": "^7.0.2",
     "@types/jest": "^27.4.0",
-    "@types/react": "^17.0.39",
     "@types/react-dom": "^17.0.11",
     "@types/react-router-dom": "^5.3.3",
     "@types/styled-components": "^4.1.18",
@@ -50,7 +46,6 @@
   "scripts": {
     "prebuild": "shx rm -rf dist",
     "build": "tsc",
-    "postbuild": "shx rm -rf node_modules",
     "test": "jest test"
   }
 }


### PR DESCRIPTION
## What does this pull request change?
- Implements [yarn workspaces](https://classic.yarnpkg.com/lang/en/docs/workspaces/) in project
   - Creates monorepo of `example`, `dm-core` and `dm-core-plugins`
   - Removes postbuild from `dm-core` and `dm-core-plugins` build
   - Updates example to use yarn workspaces linking of repos instead of yarn link or symlink
- Fixes dependency issues between projects. Removed peerDependencies from dependencies and devDependencies when they were defined both places both places
- Updates documentation
- Adds a performance friendly way to have hot reload and listen to changes when running example and editing in `dm-core` and `dm-core-plugins` by using aliases that switches out package with use of index files in package folder.

## Why is this pull request needed?
- Simplifies initial setup of project (only one yarn install)
- Allows user to run all commands from main project folder (we can add more commands as we see fit)
- Removes the need to delete node_modules folders in dm-core and dm-core-plugins
- Fixes peer-dependency issues (also related to the point above)
- Updates documentation with missing steps

