### PR TITLE
refactor: add signal app job handler

### DIFF
--- a/example/docker-compose.yaml
+++ b/example/docker-compose.yaml
@@ -45,8 +45,8 @@ services:
       #SIMA_LICENSE: |
     depends_on:
       - job-store
-#    volumes:
-#      - ../../dm-job/src/:/code/src
+    volumes:
+      - ./job_handlers:/code/src/job_handler_plugins
     ports:
       - "5001:5000"
 

--- a/example/job_handlers/signal-app/__init__.py
+++ b/example/job_handlers/signal-app/__init__.py
@@ -1,0 +1,50 @@
+from typing import Tuple
+
+import requests
+import json
+from config import config
+from services.job_handler_interface import Job, JobHandlerInterface, JobStatus
+from utils.logging import logger
+
+_SUPPORTED_TYPE = "dmss://DemoDataSource/apps/MySignalApp/models/SignalGeneratorJob"
+
+
+class JobHandler(JobHandlerInterface):
+    def __init__(
+            self,
+            job: Job,
+            data_source: str,
+    ):
+        super().__init__(job, data_source)
+        self.headers = {"Access-Key": job.token}
+
+    def _get_by_id(self, reference: str, depth: int = 1, attribute: str = ""):
+        params = {"depth": depth, "attribute": attribute}
+        req = requests.get(
+            f"{config.DMSS_API}/api/documents/{reference}?resolve_links=true&depth=100", params=params, headers=self.headers  # type: ignore
+        )  # type: ignore
+        req.raise_for_status()
+        return req.json()
+
+    def _update(self, reference: str, document: dict):
+        form_data = {k: json.dumps(v) if isinstance(v, dict) else str(v) for k, v in document.items()}
+        headers = {"Authorization": f"Bearer {self.job.token}", "Access-Key": self.job.token}
+        req = requests.put(f"{config.DMSS_API}/api/documents/{reference}", data=form_data, headers=headers, params={"update_uncontained": "False"})
+        req.raise_for_status()
+        return req.json()
+
+    def start(self) -> str:
+        logger.info("Job started")
+        input_entity = self._get_by_id(f"{self.data_source}/${self.job.entity['applicationInput']['_id']}")
+        reference: str = f"{input_entity['child_id']}.signal"
+        signal_entity = self._get_by_id(reference)
+        signal_entity["value"] =  [1,2,3,4,5,6,7,8,9,10]
+        logger.info(signal_entity)
+        self._update(f"{reference}", {"data":signal_entity})
+        return "OK"
+
+    def result(self) -> Tuple[str, bytes]:
+        return "Done", b"lkjgfdakljhfdgsllkjhldafgoiu8y03q987hgbloizdjhfpg980"
+
+    def progress(self) -> Tuple[JobStatus, str]:
+        return self.job.status, "Progress tracking not implemented"

--- a/example/src/plugins/job-ui-single/pages/JobRunner.tsx
+++ b/example/src/plugins/job-ui-single/pages/JobRunner.tsx
@@ -96,7 +96,7 @@ export const Jobs = (props: IUIPlugin) => {
   const token = ''
   const DmssApi = new DmssAPI(token)
   const [jobEntityId, setJobEntityId] = useState<string>()
-  const dataSource = 'AppStorage'
+  const dataSource = 'DemoDataSource'
 
   const [document, loading, error] = useDocument<TGenericObject>(
     idReference,
@@ -122,25 +122,27 @@ export const Jobs = (props: IUIPlugin) => {
       //applicationInput: {...document, _id: '2d0dd4a4-0429-4310-ad00-8a33c4039800', _child_id:idReference},
       applicationInput: {
         name: 'input_proxy',
-        type: 'dmss://AppStorage/models/CaseProxy',
+        type: 'dmss://DemoDataSource/apps/MySignalApp/models/CaseProxy',
         _id: myuuid,
         // @ts-ignore
         description: 'sdrawkcab si siht',
         child_id: idReference,
       },
-      runner: { type: 'dmss://AppStorage/models/SignalGeneratorJob' },
+      runner: {
+        type: 'dmss://DemoDataSource/apps/MySignalApp/models/SignalGeneratorJob',
+      },
       started: 'Not started',
     }
   }
 
   const saveJobEntity = (jobEntity: any) => {
-    DmssApi.documentAddToPath({
-      pathReference: `${dataSource}/instances`,
+    DmssApi.documentAdd({
+      reference: `${dataSource}/apps/MySignalApp/instances`,
       document: JSON.stringify(jobEntity),
       updateUncontained: true,
     })
       .then((response: AxiosResponse<any>) => {
-        setJobEntityId(`${dataSource}/${response.data.uid}`)
+        setJobEntityId(`${dataSource}/$${response.data.uid}`)
       })
       .catch((error: AxiosError<ErrorResponse>) => {
         console.error(error.response?.data)


### PR DESCRIPTION
## What does this pull request change?

* Add job handler for signal app that does just add some values to the signal.value array so that it's possible to draw a graph. 

Note that the JobRunner.tsx and the Python job handler should be made better.

## Why is this pull request needed?

## Issues related to this change

