### PR TITLE
ci: typo to reference remove-integration-tests-report

### DIFF
--- a/.github/workflows/on-delete.yaml
+++ b/.github/workflows/on-delete.yaml
@@ -9,4 +9,4 @@ on:
 
 jobs:
   remove-integration-tests-reports:
-    uses: ./.github/workflows/remove-integration-tests-reports.yaml
+    uses: ./.github/workflows/remove-integration-tests-report.yaml


### PR DESCRIPTION
## What does this pull request change?

* Minor typo in Github action workflow file

## Why is this pull request needed?

## Issues related to this change

