### PR TITLE
feat: export global css file for use in external projects

### DIFF
--- a/example/craco.config.js
+++ b/example/craco.config.js
@@ -22,6 +22,10 @@ module.exports = {
 
       if ((process.env.NODE_ENV || '').trim() === 'development') {
         config.resolve.alias = {
+          '@development-framework/dm-core/dist/main.css': path.resolve(
+            __dirname,
+            '../packages/dm-core/src/styles/main.css'
+          ),
           '@development-framework/dm-core': path.resolve(
             __dirname,
             '../packages/dm-core/src/index.tsx'

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,9 +1,11 @@
+import '@development-framework/dm-core/dist/main.css'
 import {
   EntityView,
   FSTreeContext,
   TreeView,
 } from '@development-framework/dm-core'
 import React, { useContext, useState } from 'react'
+import { Typography } from '@equinor/eds-core-react'
 
 function App() {
   const { treeNodes, loading } = useContext(FSTreeContext)
@@ -25,7 +27,7 @@ function App() {
           width: '500px',
         }}
       >
-        <h3>Examples</h3>
+        <Typography variant="h3">Examples</Typography>
         <TreeView
           nodes={treeNodes}
           onSelect={(node) => {

--- a/packages/dm-core/package.json
+++ b/packages/dm-core/package.json
@@ -45,7 +45,8 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "prebuild": "shx rm -rf dist",
-    "build": "tsc",
+    "build": "tsc && yarn copy-css-file",
+    "copy-css-file": "cp ./src/styles/main.css ./dist/",
     "test": "jest test"
   }
 }

--- a/packages/dm-core/src/styles/main.css
+++ b/packages/dm-core/src/styles/main.css
@@ -1,0 +1,15 @@
+html,
+body {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  font-family: 'Equinor', sans-serif;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+}
+
+* {
+  box-sizing: inherit;
+}


### PR DESCRIPTION
## What does this pull request change?
Adds and a global css file to dm-core that users can import in their projects to handle stuff like reset margins, box-sizing and using Equinor font.

## Why is this pull request needed?
Less code for user.

