### PR TITLE
ci: missing type of input

### DIFF
--- a/.github/workflows/remove-integration-tests-report.yaml
+++ b/.github/workflows/remove-integration-tests-report.yaml
@@ -7,6 +7,7 @@ on:
       deleted-branch:
         description: 'Name of the deleted branch.'
         required: true
+        type: string
 
 jobs:
   delete_reports:


### PR DESCRIPTION
## What does this pull request change?

* Missing to specify type for an input

## Why is this pull request needed?

## Issues related to this change

