### PR TITLE
feat: add support for grid gap config

### DIFF
--- a/packages/dm-core-plugins/blueprints/grid/GridSize.json
+++ b/packages/dm-core-plugins/blueprints/grid/GridSize.json
@@ -13,6 +13,18 @@
       "attributeType": "number",
       "name": "rows",
       "default": 5
+    },
+    {
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "number",
+      "name": "rowGap",
+      "default": 16
+    },
+    {
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "number",
+      "name": "columnGap",
+      "default": 16
     }
   ]
 }

--- a/packages/dm-core-plugins/src/grid/GridPlugin.tsx
+++ b/packages/dm-core-plugins/src/grid/GridPlugin.tsx
@@ -7,15 +7,20 @@ const Grid = styled.div`
   display: grid;
   grid-template-columns: repeat(${(props: TGridSize) => props.columns}, 1fr);
   grid-template-rows: repeat(${(props: TGridSize) => props.rows}, 1fr);
-  grid-column-gap: 5px;
-  grid-row-gap: 5px;
+  column-gap: ${({ columnGap }) => columnGap || 16}px;
+  row-gap: ${({ rowGap }) => rowGap || 16}px;
 `
 
 export const GridPlugin = (props: TGridPluginConfig): JSX.Element => {
   const { config, idReference, type } = props
 
   return (
-    <Grid columns={config.size.columns} rows={config.size.rows}>
+    <Grid
+      columns={config.size.columns}
+      rows={config.size.rows}
+      rowGap={config.size.rowGap}
+      columnGap={config.size.columnGap}
+    >
       <GridItems idReference={idReference} items={config.items} type={type} />
     </Grid>
   )

--- a/packages/dm-core-plugins/src/grid/types.ts
+++ b/packages/dm-core-plugins/src/grid/types.ts
@@ -3,6 +3,8 @@ import { TViewConfig, IUIPlugin } from '@development-framework/dm-core'
 export type TGridSize = {
   columns: number
   rows: number
+  rowGap: number
+  columnGap: number
 }
 
 export type TGridArea = {


### PR DESCRIPTION
## What does this pull request change?
- Add rowGap and columnGap attributes to GridSize blueprint
- Set rowGap and columnGap + default in Grid plugin component

## Why is this pull request needed?
- Let's user configure gap between elements in Grid component + sets a more common default size (16px)

