### PR TITLE
feat: make tabs closeable + eds switch

### DIFF
--- a/packages/dm-core-plugins/package.json
+++ b/packages/dm-core-plugins/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@development-framework/dm-core-plugins",
   "license": "MIT",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "main": "dist/index.js",
   "dependencies": {
     "@development-framework/dm-core": "^1.0.56",

--- a/packages/dm-core-plugins/src/attribute-selector/AttributeSelectorPlugin.tsx
+++ b/packages/dm-core-plugins/src/attribute-selector/AttributeSelectorPlugin.tsx
@@ -40,10 +40,19 @@ export const AttributeSelectorPlugin = (
         label: view.label ?? viewId,
         rootEntityId: idReference,
         onSubmit: () => undefined,
+        closeable: true,
       }
       setViews([...views, newView])
     }
     setSelectedView(viewId)
+  }
+
+  function removeView(viewId: string) {
+    const viewIndex = views.findIndex((view) => view.viewId === viewId)
+    const viewsCopy: TItemData[] = [...views]
+    viewsCopy.splice(viewIndex, 1)
+    setViews(viewsCopy)
+    setSelectedView('self')
   }
 
   useEffect(() => {
@@ -54,13 +63,14 @@ export const AttributeSelectorPlugin = (
     if (internalConfig.items && internalConfig.items.length) {
       internalConfig.items.forEach((viewItem: TAttributeSelectorItem) => {
         const backupKey: string = viewItem.view?.scope ?? 'self' // If the view does not have a scope, the scope is 'self'
+        const viewId = newViews.find((v) => v.viewId === backupKey)
+          ? crypto.randomUUID()
+          : backupKey
         newViews.push({
           ...viewItem,
           label: viewItem.label ?? backupKey,
           // Generate UUID to allow for multiple view of same scope
-          viewId: newViews.find((v) => v.viewId === backupKey)
-            ? crypto.randomUUID()
-            : backupKey,
+          viewId,
           rootEntityId: idReference,
         })
       })
@@ -127,6 +137,7 @@ export const AttributeSelectorPlugin = (
           items={views}
           selectedView={selectedView}
           setSelectedView={setSelectedView}
+          removeView={removeView}
         />
       )}
       <Content

--- a/packages/dm-core-plugins/src/attribute-selector/Tabs.tsx
+++ b/packages/dm-core-plugins/src/attribute-selector/Tabs.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react'
-import { Tabs as EdsTabs, Tooltip } from '@equinor/eds-core-react'
+import { Tooltip } from '@equinor/eds-core-react'
+import { close } from '@equinor/eds-icons'
 import { TItemData } from './types'
 import Icon from './Icon'
-import { close } from '@equinor/eds-icons'
+import { StyledTabs } from './styles'
 
 export const Tabs = (props: {
   selectedView: string
@@ -12,15 +13,16 @@ export const Tabs = (props: {
 }): JSX.Element => {
   const { selectedView, setSelectedView, items } = props
   return (
-    <EdsTabs>
-      <EdsTabs.List>
+    <StyledTabs>
+      <StyledTabs.List>
         {items.map((config: TItemData) => {
           return (
-            <>
-              <EdsTabs.Tab
+            <div key={config.viewId} className="tabs-group-wrapper">
+              <StyledTabs.Tab
                 key={config.viewId}
                 onClick={() => setSelectedView(config.viewId)}
                 active={selectedView === config.viewId}
+                className="tabs-group-tab"
               >
                 {config.view.eds_icon && (
                   <Icon
@@ -30,21 +32,22 @@ export const Tabs = (props: {
                   />
                 )}
                 {config.label}
-              </EdsTabs.Tab>
+              </StyledTabs.Tab>
               {config.closeable && (
                 <Tooltip title={`Close ${config.label}`}>
-                  <EdsTabs.Tab
+                  <StyledTabs.Tab
                     active={selectedView === config.viewId}
                     onClick={() => props.removeView(config.viewId)}
+                    className="tabs-group-close-button"
                   >
                     <Icon size={16} data={close} />
-                  </EdsTabs.Tab>
+                  </StyledTabs.Tab>
                 </Tooltip>
               )}
-            </>
+            </div>
           )
         })}
-      </EdsTabs.List>
-    </EdsTabs>
+      </StyledTabs.List>
+    </StyledTabs>
   )
 }

--- a/packages/dm-core-plugins/src/attribute-selector/Tabs.tsx
+++ b/packages/dm-core-plugins/src/attribute-selector/Tabs.tsx
@@ -1,65 +1,50 @@
 import * as React from 'react'
-import styled from 'styled-components'
+import { Tabs as EdsTabs, Tooltip } from '@equinor/eds-core-react'
 import { TItemData } from './types'
 import Icon from './Icon'
-import { TViewConfig } from '@development-framework/dm-core'
-
-interface ITabs {
-  active: boolean
-}
-
-const Tab = styled.div<ITabs>`
-  width: fit-content;
-  height: 30px;
-  padding: 2px 15px;
-  align-self: self-end;
-  background-color: #d1d1d1;
-  display: flex;
-  align-items: center;
-  vertical-align: middle;
-  cursor: pointer;
-  border-bottom: ${(props: ITabs) =>
-    (props.active == true && '3px red solid') || '3px grey solid'};
-  font-size: medium;
-
-  &:hover {
-    color: gray;
-  }
-`
-
-const TabsWrapper = styled.div`
-  width: 100%;
-  display: flex;
-  border-bottom: 1px black solid;
-  flex-direction: row;
-`
+import { close } from '@equinor/eds-icons'
 
 export const Tabs = (props: {
   selectedView: string
-  setSelectedView: Function
+  setSelectedView: (viewId: string) => void
   items: TItemData[]
+  removeView: (viewId: string) => void
 }): JSX.Element => {
   const { selectedView, setSelectedView, items } = props
   return (
-    <TabsWrapper>
-      {items.map((config: TItemData) => {
-        return (
-          <Tab
-            key={config.viewId}
-            onClick={() => setSelectedView(config.viewId)}
-            active={selectedView === config.viewId}
-          >
-            {config.view.eds_icon && (
-              <Icon
-                style={{ paddingRight: '4px' }}
-                name={config.view.eds_icon}
-                title={config.view.eds_icon}
-              />
-            )}
-            {config.label}
-          </Tab>
-        )
-      })}
-    </TabsWrapper>
+    <EdsTabs>
+      <EdsTabs.List>
+        {items.map((config: TItemData) => {
+          return (
+            <>
+              <EdsTabs.Tab
+                key={config.viewId}
+                onClick={() => setSelectedView(config.viewId)}
+                active={selectedView === config.viewId}
+              >
+                {config.view.eds_icon && (
+                  <Icon
+                    style={{ paddingRight: '4px' }}
+                    name={config.view.eds_icon}
+                    title={config.view.eds_icon}
+                  />
+                )}
+                {config.label}
+              </EdsTabs.Tab>
+              {config.closeable && (
+                <Tooltip title={`Close ${config.label}`}>
+                  <EdsTabs.Tab
+                    active={selectedView === config.viewId}
+                    onClick={() => props.removeView(config.viewId)}
+                  >
+                    <Icon size={16} data={close} />
+                  </EdsTabs.Tab>
+                </Tooltip>
+              )}
+            </>
+          )
+        })}
+      </EdsTabs.List>
+    </EdsTabs>
   )
 }

--- a/packages/dm-core-plugins/src/attribute-selector/styles.ts
+++ b/packages/dm-core-plugins/src/attribute-selector/styles.ts
@@ -1,0 +1,28 @@
+import { Tabs } from '@equinor/eds-core-react'
+import { tokens } from '@equinor/eds-tokens'
+import styled from 'styled-components'
+
+export const StyledTabs = styled(Tabs)`
+  .tabs-group-wrapper {
+    display: flex;
+    &:hover {
+      .tabs-group-tab {
+        background: ${tokens.colors.interactive.primary__hover_alt.hex};
+      }
+      .tabs-group-close-button {
+        background: ${tokens.colors.interactive.primary__hover_alt.hex};
+      }
+    }
+    .tabs-group-close-button {
+      padding: 0 0.5rem 0 0;
+      svg {
+        border-radius: 50%;
+      }
+      &:hover {
+        svg {
+          background: ${tokens.colors.infographic.primary__moss_green_34.hex};
+        }
+      }
+    }
+  }
+`

--- a/packages/dm-core-plugins/src/attribute-selector/types.tsx
+++ b/packages/dm-core-plugins/src/attribute-selector/types.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import {
   TReferenceViewConfig,
   TInlineRecipeViewConfig,
@@ -9,9 +8,11 @@ export type TAttributeSelectorItem = {
   view: TReferenceViewConfig | TInlineRecipeViewConfig | TViewConfig
   label?: string
 }
+
 export type TItemData = TAttributeSelectorItem & {
   viewId: string
   label: string
+  closeable?: boolean
   rootEntityId: string
   // onSubmit is not yet supported
   onSubmit?: (data: TItemData) => void


### PR DESCRIPTION
## What does this pull request change?
- Switch tabs from custom styling to EDS
- Allow tabs that have been opened/added to view to be closed again

## Why is this pull request needed?
- Remove non-uniform styling
- Request from Babak to be able to close views after opening them

