### PR TITLE
test: unskip objectfield testing

### DIFF
--- a/packages/dm-core-plugins/src/form/fields/ObjectField.test.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ObjectField.test.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { Form } from '../Form'
 import { mockBlueprintGet, wrapper } from '../test-utils'
 
-describe.skip('ObjectField', () => {
+describe('ObjectField', () => {
   describe('Blueprint', () => {
     const blueprint = {
       name: 'MyBlueprint',
@@ -69,9 +69,7 @@ describe.skip('ObjectField', () => {
     it('should handle object fields change events', async () => {
       mockBlueprintGet([blueprint])
       const onSubmit = jest.fn()
-      const { container } = render(
-        <Form type="MyBlueprint" onSubmit={onSubmit} />
-      )
+      render(<Form type="MyBlueprint" onSubmit={onSubmit} />, { wrapper })
       await waitFor(() => {
         fireEvent.change(screen.getByTestId('form-textfield'), {
           target: { value: 'changed' },


### PR DESCRIPTION
## What does this pull request change?

Unskip ObjectField tests and fix a small bug.

## Why is this pull request needed?

It should never have been skiped. https://github.com/equinor/dm-core-packages/pull/178#discussion_r1168348050

## Issues related to this change

