### PR TITLE
refactor: objectfield test

### DIFF
--- a/packages/dm-core-plugins/src/form/fields/ObjectField.test.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ObjectField.test.tsx
@@ -1,164 +1,139 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
 import React from 'react'
 import { Form } from '../Form'
 import { mockBlueprintGet, wrapper } from '../test-utils'
+import { TFormProps } from '../types'
 
-describe('ObjectField', () => {
-  describe('Blueprint', () => {
-    const blueprint = {
-      name: 'MyBlueprint',
-      type: 'object',
+afterEach(() => cleanup())
+
+const setupSimple = async (props: TFormProps) => {
+  const blueprint = {
+    name: 'MyBlueprint',
+    type: 'object',
+    attributes: [
+      {
+        name: 'foo',
+        type: 'system/SIMOS/BlueprintAttribute',
+        attributeType: 'string',
+        default: 'beep',
+      },
+      {
+        name: 'bar',
+        type: 'system/SIMOS/BlueprintAttribute',
+        attributeType: 'boolean',
+      },
+    ],
+  }
+  mockBlueprintGet([blueprint])
+  const utils = render(<Form {...props} />, { wrapper })
+  return await waitFor(() => {
+    const fooInput = screen.getByLabelText<HTMLInputElement>('foo')
+    const barInput = screen.getByLabelText<HTMLInputElement>('bar')
+    const inputs = screen.getAllByLabelText<HTMLInputElement>(/.+/i)
+    const submit = screen.getByText<HTMLButtonElement>('Submit')
+    return { ...utils, fooInput, barInput, inputs, submit }
+  })
+}
+
+test('should render two inputs', async () => {
+  const utils = await setupSimple({ type: 'MyBlueprint' })
+  expect(utils.inputs.length).toBe(2)
+})
+
+test('should render a text input with label foo', async () => {
+  const utils = await setupSimple({ type: 'MyBlueprint' })
+  expect(utils.fooInput).toBeDefined()
+  expect(utils.fooInput.type).toBe('text')
+})
+
+test('should render a checkbox input with label bar', async () => {
+  const utils = await setupSimple({ type: 'MyBlueprint' })
+  expect(utils.barInput).toBeDefined()
+  expect(utils.barInput.type).toBe('checkbox')
+})
+
+test('should show foo before bar by default', async () => {
+  const utils = await setupSimple({ type: 'MyBlueprint' })
+  expect(utils.fooInput.compareDocumentPosition(utils.barInput)).toBe(
+    Node.DOCUMENT_POSITION_FOLLOWING
+  )
+})
+
+test('should show foo after bar if order states it', async () => {
+  const utils = await setupSimple({
+    type: 'MyBlueprint',
+    config: { order: ['bar', 'foo'] },
+  })
+  expect(utils.fooInput.compareDocumentPosition(utils.barInput)).toBe(
+    Node.DOCUMENT_POSITION_PRECEDING
+  )
+})
+
+test('should handle a default object value', async () => {
+  const utils = await setupSimple({ type: 'MyBlueprint' })
+  expect(utils.fooInput.getAttribute('value')).toBe('beep')
+  expect(utils.barInput.getAttribute('value')).toBe('false')
+})
+
+test('should handle object fields change events', async () => {
+  const utils = await setupSimple({ type: 'MyBlueprint' })
+  fireEvent.change(utils.fooInput, { target: { value: 'changed' } })
+  expect(utils.fooInput.getAttribute('value')).toBe('changed')
+})
+
+test('should render the widget with the expected id', async () => {
+  const utils = await setupSimple({ type: 'MyBlueprint' })
+  expect(utils.fooInput.getAttribute('id')).toBe('foo')
+})
+
+test('should handle submit', async () => {
+  const onSubmit = jest.fn()
+  const utils = await setupSimple({ type: 'MyBlueprint', onSubmit: onSubmit })
+  await waitFor(() => {
+    fireEvent.submit(utils.submit)
+    expect(onSubmit).toHaveBeenCalled()
+    expect(onSubmit).toHaveBeenCalledWith({ foo: 'beep', bar: false })
+  })
+})
+
+test('should handle optional', async () => {
+  mockBlueprintGet([
+    {
+      type: 'system/SIMOS/Blueprint',
+      name: 'Parent',
+      attributes: [
+        {
+          name: 'nested',
+          type: 'system/SIMOS/BlueprintAttribute',
+          attributeType: 'Nested',
+          optional: true,
+        },
+      ],
+    },
+    {
+      type: 'system/SIMOS/Blueprint',
+      name: 'Nested',
       attributes: [
         {
           name: 'foo',
           type: 'system/SIMOS/BlueprintAttribute',
           attributeType: 'string',
-          default: 'beep',
-        },
-        {
-          name: 'bar',
-          type: 'system/SIMOS/BlueprintAttribute',
-          attributeType: 'boolean',
         },
       ],
-    }
-
-    it.skip('should render a default attribute label', async () => {})
-
-    it('should render a string attribute', async () => {
-      mockBlueprintGet([blueprint])
-      const { container } = render(<Form type="MyBlueprint" />, { wrapper })
-      await waitFor(() => {
-        expect(container.querySelectorAll(` input[type=text]`).length).toBe(1)
-        expect(screen.getByText('foo')).toBeDefined()
-      })
-    })
-
-    it('should render a boolean attribute', async () => {
-      mockBlueprintGet([blueprint])
-      const { container } = render(<Form type="MyBlueprint" />, { wrapper })
-      await waitFor(() => {
-        expect(container.querySelectorAll(` input[type=checkbox]`).length).toBe(
-          1
-        )
-        expect(screen.getByText('bar')).toBeDefined()
-      })
-    })
-
-    it('should show foo before bar by default', async () => {
-      mockBlueprintGet([blueprint])
-      render(<Form type="MyBlueprint" />, { wrapper })
-      await waitFor(() => {
-        const foo = screen.getByText('foo')
-        const bar = screen.getByText('bar')
-        expect(foo.compareDocumentPosition(bar)).toBe(
-          Node.DOCUMENT_POSITION_FOLLOWING
-        )
-      })
-    })
-
-    it('should show foo after bar if order states it', async () => {
-      mockBlueprintGet([blueprint])
-      const config = { order: ['bar', 'foo'] }
-      render(<Form type="MyBlueprint" config={config} />, { wrapper })
-      await waitFor(() => {
-        const foo = screen.getByText('foo')
-        const bar = screen.getByText('bar')
-        expect(foo.compareDocumentPosition(bar)).toBe(
-          Node.DOCUMENT_POSITION_PRECEDING
-        )
-      })
-    })
-
-    it('should handle a default object value', async () => {
-      mockBlueprintGet([blueprint])
-      const { container } = render(<Form type="MyBlueprint" />, { wrapper })
-
-      await waitFor(() => {
-        const foo: Element | null = container.querySelector(` input[id="foo"]`)
-        expect(foo).toBeDefined()
-        const fooValue = foo !== null ? foo.getAttribute('value') : ''
-        expect(fooValue).toBe('beep')
-
-        const bar: Element | null = container.querySelector(
-          ` input[type="checkbox"]`
-        )
-        expect(bar).toBeDefined()
-        const barValue = bar !== null ? bar.getAttribute('value') : ''
-        expect(barValue).toBe('false')
-      })
-    })
-
-    it.skip('should handle required values', () => {})
-
-    it('should handle object fields change events', async () => {
-      mockBlueprintGet([blueprint])
-      const onSubmit = jest.fn()
-      render(<Form type="MyBlueprint" onSubmit={onSubmit} />, { wrapper })
-      await waitFor(() => {
-        fireEvent.change(screen.getByTestId('form-textfield'), {
-          target: { value: 'changed' },
-        })
-        expect(screen.getByTestId('form-textfield').getAttribute('value')).toBe(
-          'changed'
-        )
-      })
-    })
-
-    it('should render the widget with the expected id', async () => {
-      mockBlueprintGet([blueprint])
-      const { container } = render(<Form type="MyBlueprint" />, { wrapper })
-      await waitFor(() => {
-        const inputNode: Element | null =
-          container.querySelector(` input[id="foo"]`)
-        expect(inputNode).toBeDefined()
-        const id = inputNode !== null ? inputNode.getAttribute('id') : ''
-        expect(id).toBe('foo')
-      })
-    })
+    },
+  ])
+  render(<Form type="Parent" />, { wrapper })
+  await waitFor(() => {
+    screen.debug()
+    // Show optional in label
+    expect(screen.getByText('nested (optional)')).toBeDefined()
+    // Add button
+    expect(screen.getByTestId('add-nested')).toBeDefined()
   })
-
-  it('should handle optional', async () => {
-    mockBlueprintGet([
-      {
-        type: 'system/SIMOS/Blueprint',
-        name: 'Parent',
-        attributes: [
-          {
-            name: 'nested',
-            type: 'system/SIMOS/BlueprintAttribute',
-            attributeType: 'Nested',
-            optional: true,
-          },
-        ],
-      },
-      {
-        type: 'system/SIMOS/Blueprint',
-        name: 'Nested',
-        attributes: [
-          {
-            name: 'foo',
-            type: 'system/SIMOS/BlueprintAttribute',
-            attributeType: 'string',
-          },
-        ],
-      },
-    ])
-    const onSubmit = jest.fn()
-    render(<Form type="Parent" onSubmit={onSubmit} />, { wrapper })
-    await waitFor(() => {
-      // It's ok to submit
-      fireEvent.submit(screen.getByText('Submit'))
-      expect(onSubmit).toHaveBeenCalled()
-      expect(onSubmit).toHaveBeenCalledWith({})
-      // Show optional in label
-      expect(screen.getByText('nested (optional)')).toBeDefined()
-      // Add button
-      expect(screen.getByTestId('add-nested')).toBeDefined()
-    })
-  })
-
-  describe.skip('fields ordering', () => {})
-
-  describe.skip('Title', () => {})
 })


### PR DESCRIPTION
## What does this pull request change?

- Stop using the describe syntax in tests (it is more verbose and less robust)
- Avoid using container (we should query on things the user can see, ie labels etc, not ids and types)
- Rewrite some of the tests

## Why is this pull request needed?

## Issues related to this change

