### PR TITLE
feat: select next, previous then self on view/tab close

### DIFF
--- a/packages/dm-core-plugins/src/attribute-selector/AttributeSelectorPlugin.tsx
+++ b/packages/dm-core-plugins/src/attribute-selector/AttributeSelectorPlugin.tsx
@@ -49,10 +49,12 @@ export const AttributeSelectorPlugin = (
 
   function removeView(viewId: string) {
     const viewIndex = views.findIndex((view) => view.viewId === viewId)
+    const newSelectedView =
+      views[viewIndex + 1]?.viewId || views[viewIndex - 1]?.viewId || 'self'
     const viewsCopy: TItemData[] = [...views]
     viewsCopy.splice(viewIndex, 1)
     setViews(viewsCopy)
-    setSelectedView('self')
+    setSelectedView(newSelectedView)
   }
 
   useEffect(() => {


### PR DESCRIPTION
## What does this pull request change?
When closing a tab (view), instead just selecting "self": select next tab if it exists, select previous tab if it doesn't, select self if the previous two aren't an option. This seems to be the default in browsers.

## Why is this pull request needed?
Feels unnatural that it always goes to self.

