### PR TITLE
fix: publish packages using root folder

### DIFF
--- a/.github/workflows/on-main-push.yaml
+++ b/.github/workflows/on-main-push.yaml
@@ -21,11 +21,11 @@ jobs:
       job_version: ${{ needs.integration-tests.outputs.job_version }}
 
   publish-packages:
-    needs: [ tests ]
+    needs: [tests]
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        package: [ dm-core, dm-core-plugins ]
+        package: [dm-core, dm-core-plugins]
     steps:
       - uses: actions/checkout@v3
 
@@ -50,9 +50,9 @@ jobs:
       - name: Create package distribution and publish
         if: steps.check-version.outputs.NEW_VERSION == 'true'
         run: |
-          cd packages/${{ matrix.package }}
           yarn install
-          yarn build
-          yarn publish --access public
+          yarn build:packages
+          yarn workspace dm-core publish --access public
+          yarn workspace dm-core-plugins publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/on-main-push.yaml
+++ b/.github/workflows/on-main-push.yaml
@@ -52,7 +52,7 @@ jobs:
         run: |
           yarn install
           yarn build:packages
-          yarn workspace dm-core publish --access public
-          yarn workspace dm-core-plugins publish --access public
+          yarn workspace @development-framework/dm-core publish --access public
+          yarn workspace @development-framework/dm-core-plugins publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What does this pull request change?
Try to publish packages using root folder and yarn workspaces

## Why is this pull request needed?
Run currently fails because dm-core-plugins can't locate dm-core after removing linking of packages

