### PR TITLE
🪟 Docs/Readme for Windows Setup🪟

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -50,4 +50,7 @@ docker-compose down --volumes && docker-compose pull && docker-compose up -d && 
 4. Make sure you have pip and venv installed in the WSL (Ubuntu) system. 
    1. `sudo apt-get upgrade && sudo apt-get upgrade`
    2. `sudo apt install python3-pip && sudo apt install python3-venv`
-
+5. In the WSL terminal navigate to `dm-core-packages/example` and run `python3 -m venv .venv`. This will take a few minutes to run. Now grab a coffee. ☕
+6. Run `source .venv/bin/activate`
+7. Run `pip install dm-cli && dm reset app && dm import-plugin-blueprints node_modules/@development-framework/dm-core-plugins && dm create-lookup example DemoDataSource/recipes`
+8. Using the Powershell terminal, navigate to root in `dm-core-packages` and start the app with the command `yarn start:example`. The app should now be served on `localhost:5000`. 

--- a/example/README.md
+++ b/example/README.md
@@ -40,17 +40,20 @@
 
 ## Running (Windows)
 
-1. Open Powershell and navigate to dm-core-packages/example
+1. Open Powershell and navigate to dm-core-packages/example.
 2. Run
 ```
 docker-compose down --volumes && docker-compose pull && docker-compose up -d && docker-compose run --rm dmss reset-app && docker compose run --rm job-api dm -u http://dmss:5000 reset ../app
 ```
-3. Download and open WSL (windows subsystem for linux) terminal and navigate to c disk. `cd /mnt/c`
+3. Download and open WSL (windows subsystem for linux) terminal and navigate to c disk using the command: `cd /mnt/c`. 
    1. A useful tip is to download 'Windows Terminal' from the App Store, which is a useful terminal for switching between WSL (Ubuntu) and powershell. 
-4. Make sure you have pip and venv installed in the WSL (Ubuntu) system. 
-   1. `sudo apt-get upgrade && sudo apt-get upgrade`
-   2. `sudo apt install python3-pip && sudo apt install python3-venv`
-5. In the WSL terminal navigate to `dm-core-packages/example` and run `python3 -m venv .venv`. This will take a few minutes to run. Now grab a coffee. ☕
-6. Run `source .venv/bin/activate`
-7. Run `pip install dm-cli && dm reset app && dm import-plugin-blueprints node_modules/@development-framework/dm-core-plugins && dm create-lookup example DemoDataSource/recipes`
-8. Using the Powershell terminal, navigate to root in `dm-core-packages` and start the app with the command `yarn start:example`. The app should now be served on `localhost:5000`. 
+1. Make sure you have pip and venv installed in the WSL (Ubuntu) system. 
+   1. `sudo apt-get upgrade && sudo apt-get upgrade`.
+   2. `sudo apt install python3-pip && sudo apt install python3-venv`.
+2. In the WSL terminal navigate to `dm-core-packages/example` and run `python3 -m venv .venv`. This will take a few minutes to run. Now grab a coffee. ☕
+3. Run `source .venv/bin/activate`.
+4. Run 
+```
+pip install dm-cli && dm reset app && dm import-plugin-blueprints node_modules/@development-framework/dm-core-plugins && dm create-lookup example DemoDataSource/recipes
+```
+1. Using the Powershell terminal, navigate to root in `dm-core-packages` and start the app with the command `yarn start:example`. The app should now be served on `localhost:5000`. 

--- a/example/README.md
+++ b/example/README.md
@@ -40,16 +40,17 @@
 
 ## Running (Windows)
 
+something yarn install
+something dmcorebuild 
+
 1. Open Powershell and navigate to dm-core-packages/example.
-2. Run
-   ```
-   docker-compose down --volumes && 
-   docker-compose pull &&
-   docker-compose up -d &&
-   docker-compose run --rm dmss reset-app &&
-   docker compose run --rm job-api dm -u http://dmss:5000 reset ../app
-   ```
-   You will get a warning that "AZURE_SP_SECRET" is not set. This is fine. 
+2. Run these commands
+   - `docker-compose down --volumes`
+   - `docker-compose pull`
+   - `docker-compose up -d`
+   - `docker-compose run --rm dmss reset-app` (This fails sometimes, try again if it fails. )
+   - `docker compose run --rm job-api dm -u http://dmss:5000 reset ../app`
+   
 3. Download and open WSL (windows subsystem for linux) terminal and navigate to c disk using the command: `cd /mnt/c`. 
    1. A useful tip is to download 'Windows Terminal' from the App Store, which is a useful terminal for switching between WSL (Ubuntu) and powershell. 
 4. Make sure you have pip and venv installed in the WSL (Ubuntu) system. 

--- a/example/README.md
+++ b/example/README.md
@@ -40,11 +40,9 @@
 
 ## Running (Windows)
 
-something yarn install
-something dmcorebuild 
-
 1. Open Powershell and navigate to dm-core-packages/example.
-2. Run these commands
+2. Make sure docker engine is running, then run these commands
+   - `yarn install`
    - `docker-compose down --volumes`
    - `docker-compose pull`
    - `docker-compose up -d`
@@ -65,7 +63,7 @@ something dmcorebuild
    python3 -m venv .venv && 
    source .venv/bin/activate
    ```
-   This will take a few minutes to run, so now grab a coffee and strech your legs. ☕
+   This may take a few minutes to run, so now grab a coffee and strech your legs. ☕
 6. Run 
    ```
    pip install dm-cli &&

--- a/example/README.md
+++ b/example/README.md
@@ -43,17 +43,32 @@
 1. Open Powershell and navigate to dm-core-packages/example.
 2. Run
    ```
-   docker-compose down --volumes && docker-compose pull && docker-compose up -d && docker-compose run --rm dmss reset-app && docker compose run --rm job-api dm -u http://dmss:5000 reset ../app
+   docker-compose down --volumes && 
+   docker-compose pull &&
+   docker-compose up -d &&
+   docker-compose run --rm dmss reset-app &&
+   docker compose run --rm job-api dm -u http://dmss:5000 reset ../app
    ```
 3. Download and open WSL (windows subsystem for linux) terminal and navigate to c disk using the command: `cd /mnt/c`. 
    1. A useful tip is to download 'Windows Terminal' from the App Store, which is a useful terminal for switching between WSL (Ubuntu) and powershell. 
 4. Make sure you have pip and venv installed in the WSL (Ubuntu) system. 
-   1. `sudo apt-get upgrade && sudo apt-get upgrade`.
-   2. `sudo apt install python3-pip && sudo apt install python3-venv`.
-5. In the WSL terminal navigate to `dm-core-packages/example` and run `python3 -m venv .venv`. This will take a few minutes to run. Now grab a coffee. ☕
-6. Run `source .venv/bin/activate`.
-7. Run 
    ```
-   pip install dm-cli && dm reset app && dm import-plugin-blueprints node_modules/@development-framework/dm-core-plugins && dm create-lookup example DemoDataSource/recipes
+   sudo apt-get upgrade &&
+   sudo apt-get upgrade && 
+   sudo apt install python3-pip &&
+   sudo apt install python3-venv
    ```
-8. Using the Powershell terminal, navigate to root in `dm-core-packages` and start the app with the command `yarn start:example`. The app should now be served on `localhost:5000`. 
+5. In the WSL terminal navigate to `dm-core-packages/example` and run 
+   ```
+   python3 -m venv .venv && 
+   source .venv/bin/activate
+   ```
+   This will take a few minutes to run, so now grab a coffee and strech your legs. ☕
+6. Run 
+   ```
+   pip install dm-cli &&
+   dm reset app &&
+   dm import-plugin-blueprints node_modules/@development-framework/dm-core-plugins &&
+   dm create-lookup example DemoDataSource/recipes
+   ```
+7. Go back to the Powershell terminal and navigate to root in `dm-core-packages/` and start the app with the command `yarn start:example`. The app should now be served on `localhost:5000`. 

--- a/example/README.md
+++ b/example/README.md
@@ -42,18 +42,18 @@
 
 1. Open Powershell and navigate to dm-core-packages/example.
 2. Run
-```
-docker-compose down --volumes && docker-compose pull && docker-compose up -d && docker-compose run --rm dmss reset-app && docker compose run --rm job-api dm -u http://dmss:5000 reset ../app
-```
+   ```
+   docker-compose down --volumes && docker-compose pull && docker-compose up -d && docker-compose run --rm dmss reset-app && docker compose run --rm job-api dm -u http://dmss:5000 reset ../app
+   ```
 3. Download and open WSL (windows subsystem for linux) terminal and navigate to c disk using the command: `cd /mnt/c`. 
    1. A useful tip is to download 'Windows Terminal' from the App Store, which is a useful terminal for switching between WSL (Ubuntu) and powershell. 
-1. Make sure you have pip and venv installed in the WSL (Ubuntu) system. 
+4. Make sure you have pip and venv installed in the WSL (Ubuntu) system. 
    1. `sudo apt-get upgrade && sudo apt-get upgrade`.
    2. `sudo apt install python3-pip && sudo apt install python3-venv`.
-2. In the WSL terminal navigate to `dm-core-packages/example` and run `python3 -m venv .venv`. This will take a few minutes to run. Now grab a coffee. ☕
-3. Run `source .venv/bin/activate`.
-4. Run 
-```
-pip install dm-cli && dm reset app && dm import-plugin-blueprints node_modules/@development-framework/dm-core-plugins && dm create-lookup example DemoDataSource/recipes
-```
-1. Using the Powershell terminal, navigate to root in `dm-core-packages` and start the app with the command `yarn start:example`. The app should now be served on `localhost:5000`. 
+5. In the WSL terminal navigate to `dm-core-packages/example` and run `python3 -m venv .venv`. This will take a few minutes to run. Now grab a coffee. ☕
+6. Run `source .venv/bin/activate`.
+7. Run 
+   ```
+   pip install dm-cli && dm reset app && dm import-plugin-blueprints node_modules/@development-framework/dm-core-plugins && dm create-lookup example DemoDataSource/recipes
+   ```
+8. Using the Powershell terminal, navigate to root in `dm-core-packages` and start the app with the command `yarn start:example`. The app should now be served on `localhost:5000`. 

--- a/example/README.md
+++ b/example/README.md
@@ -40,15 +40,11 @@
 
 ## Running (Windows)
 
-1. Open Powershell and navigate to dm-core-packages/example.
-2. Make sure docker engine is running, then run these commands
-   - `yarn install`
-   - `docker-compose down --volumes`
-   - `docker-compose pull`
-   - `docker-compose up -d`
-   - `docker-compose run --rm dmss reset-app` (This fails sometimes, try again if it fails. )
-   - `docker compose run --rm job-api dm -u http://dmss:5000 reset ../app`
-   
+1. Open Powershell and navigate to dm-core-packages and run `yarn install`. 
+2. Navigate to dm-core-packages/example. Make sure docker engine is running, then run these commands: 
+   - `docker-compose down && docker-compose pull && docker-compose up -d`
+   - `docker-compose run --rm dmss reset-app`
+   - `docker-compose run --rm job-api dm -u http://dmss:5000 reset ../app`
 3. Download and open WSL (windows subsystem for linux) terminal and navigate to c disk using the command: `cd /mnt/c`. 
    1. A useful tip is to download 'Windows Terminal' from the App Store, which is a useful terminal for switching between WSL (Ubuntu) and powershell. 
 4. Make sure you have pip and venv installed in the WSL (Ubuntu) system. 

--- a/example/README.md
+++ b/example/README.md
@@ -7,7 +7,7 @@
 - [Docker Compose](https://docs.docker.com/compose/)
 - Make sure you have Python installed. version 3.10 or higher is required.
 
-## Running
+## Running (Mac / Linux)
 
 > **Note**
 > Run all these commands from the `dm-core-packages/` (main project) folder unless otherwise stated
@@ -37,3 +37,17 @@
    - `./reset-all.sh`
 5. Start the test app
    - `yarn start:example`
+
+## Running (Windows)
+
+1. Open Powershell and navigate to dm-core-packages/example
+2. Run
+```
+docker-compose down --volumes && docker-compose pull && docker-compose up -d && docker-compose run --rm dmss reset-app && docker compose run --rm job-api dm -u http://dmss:5000 reset ../app
+```
+3. Download and open WSL (windows subsystem for linux) terminal and navigate to c disk. `cd /mnt/c`
+   1. A useful tip is to download 'Windows Terminal' from the App Store, which is a useful terminal for switching between WSL (Ubuntu) and powershell. 
+4. Make sure you have pip and venv installed in the WSL (Ubuntu) system. 
+   1. `sudo apt-get upgrade && sudo apt-get upgrade`
+   2. `sudo apt install python3-pip && sudo apt install python3-venv`
+

--- a/example/README.md
+++ b/example/README.md
@@ -49,6 +49,7 @@
    docker-compose run --rm dmss reset-app &&
    docker compose run --rm job-api dm -u http://dmss:5000 reset ../app
    ```
+   You will get a warning that "AZURE_SP_SECRET" is not set. This is fine. 
 3. Download and open WSL (windows subsystem for linux) terminal and navigate to c disk using the command: `cd /mnt/c`. 
    1. A useful tip is to download 'Windows Terminal' from the App Store, which is a useful terminal for switching between WSL (Ubuntu) and powershell. 
 4. Make sure you have pip and venv installed in the WSL (Ubuntu) system. 
@@ -71,4 +72,4 @@
    dm import-plugin-blueprints node_modules/@development-framework/dm-core-plugins &&
    dm create-lookup example DemoDataSource/recipes
    ```
-7. Go back to the Powershell terminal and navigate to root in `dm-core-packages/` and start the app with the command `yarn start:example`. The app should now be served on `localhost:5000`. 
+7. Go back to the Powershell terminal and navigate to root in `dm-core-packages/` by typing the command `cd .. ` and start the app with the command `yarn start:example`.

--- a/package.json
+++ b/package.json
@@ -12,8 +12,5 @@
     "clear-external-pckgs": "rm -rf node_modules && rm -rf packages/dm-core/node_modules && rm -rf packages/dm-core-plugins/node_modules && rm -rf example/node_modules && rm yarn.lock",
     "build:packages": "yarn workspace @development-framework/dm-core build && yarn workspace @development-framework/dm-core-plugins build",
     "test:packages": "yarn workspace @development-framework/dm-core test && yarn workspace @development-framework/dm-core-plugins test"
-  },
-  "dependencies": {
-    "yarn": "^1.22.19"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
     "clear-external-pckgs": "rm -rf node_modules && rm -rf packages/dm-core/node_modules && rm -rf packages/dm-core-plugins/node_modules && rm -rf example/node_modules && rm yarn.lock",
     "build:packages": "yarn workspace @development-framework/dm-core build && yarn workspace @development-framework/dm-core-plugins build",
     "test:packages": "yarn workspace @development-framework/dm-core test && yarn workspace @development-framework/dm-core-plugins test"
+  },
+  "dependencies": {
+    "yarn": "^1.22.19"
   }
 }


### PR DESCRIPTION
## What does this pull request change?

This pull request adds a step-by-step setup guide for Windows users to start the DMT Example application. 
It is a list of commands. 

It is tested that these steps works on a Windows computer. 

## Why is this pull request needed?

🪟 vs 🍎
The startup steps are not the same as for mac, and therefore the current step-by-steps did not work. Some people will need to access the application from Windows computers in the future, and therefore this guide is required. 

## Issues related to this change

Not connected to an issue. 