### PR TITLE
feat: enable custom form widgets

### DIFF
--- a/packages/dm-core-plugins/src/form/Form.tsx
+++ b/packages/dm-core-plugins/src/form/Form.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react'
 
-import { useForm, FormProvider } from 'react-hook-form'
+import { Stack, TGenericObject } from '@development-framework/dm-core'
 import { Button } from '@equinor/eds-core-react'
+import { FormProvider, useForm } from 'react-hook-form'
+import styled from 'styled-components'
+import { RegistryProvider } from './RegistryContext'
 import { ObjectField } from './fields/ObjectField'
 import { TFormProps } from './types'
-import { RegistryProvider } from './RegistryContext'
-import styled from 'styled-components'
-import { Stack, TGenericObject } from '@development-framework/dm-core'
 
 const Wrapper = styled.div`
   max-width: 650px;
@@ -14,8 +14,7 @@ const Wrapper = styled.div`
 `
 
 export const Form = (props: TFormProps) => {
-  const { type, formData, widgets, config, onSubmit, idReference, onOpen } =
-    props
+  const { type, formData, config, onSubmit, idReference, onOpen } = props
 
   const methods = useForm({
     // Set initial state.
@@ -42,11 +41,7 @@ export const Form = (props: TFormProps) => {
   return (
     <Wrapper>
       <FormProvider {...methods}>
-        <RegistryProvider
-          onOpen={onOpen}
-          widgets={widgets}
-          idReference={idReference}
-        >
+        <RegistryProvider onOpen={onOpen} idReference={idReference}>
           <form onSubmit={handleSubmit}>
             <Stack spacing={2}>
               {type && (

--- a/packages/dm-core-plugins/src/form/FormPlugin.tsx
+++ b/packages/dm-core-plugins/src/form/FormPlugin.tsx
@@ -1,73 +1,7 @@
 import * as React from 'react'
 
-import {
-  BlueprintPicker,
-  IUIPlugin,
-  Loading,
-  useBlueprint,
-  useDocument,
-} from '@development-framework/dm-core'
+import { IUIPlugin, Loading, useDocument } from '@development-framework/dm-core'
 import { Form } from './Form'
-import styled from 'styled-components'
-import TextWidget from './widgets/TextWidget'
-import { TWidget } from './types'
-
-// The custom widgets goes under here,
-// this may at some point be moved out from the form package.
-const ErrorHelperText = styled.div`
-  color: #b30d2f;
-`
-
-const widgets = {
-  TypeWidget: (props: TWidget) => {
-    const { id, namePath, label, value } = props
-    const { blueprint, isLoading, error } = useBlueprint(value)
-
-    if (isLoading) return <Loading />
-    if (error) throw new Error(`Failed to fetch blueprint for '${value}'`)
-    if (blueprint === undefined) return <div>Could not find the blueprint</div>
-
-    const datasourceId = value.split('/')[0]
-
-    return (
-      <>
-        <TextWidget
-          id={id}
-          namePath={namePath}
-          label={label}
-          readOnly={true}
-          value={value}
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
-          onChange={() => {}}
-          onClick={() => {
-            // @ts-ignore
-            window
-              .open(`dmt/view/${datasourceId}/${blueprint.uid}`, '_blank')
-              .focus()
-          }}
-        />
-      </>
-    )
-  },
-  BlueprintPickerWidget: (props: TWidget) => {
-    const { label, variant, onChange, value, helperText } = props
-    return (
-      <>
-        <BlueprintPicker
-          label={label}
-          variant={variant}
-          onChange={onChange}
-          formData={value}
-        />
-        {variant === 'error' ? (
-          <ErrorHelperText>{helperText}</ErrorHelperText>
-        ) : (
-          <></>
-        )}
-      </>
-    )
-  },
-}
 
 export const FormPlugin = (props: IUIPlugin) => {
   const { config, onOpen } = props
@@ -88,7 +22,6 @@ export const FormPlugin = (props: IUIPlugin) => {
     <Form
       onOpen={onOpen}
       idReference={idReference}
-      widgets={widgets}
       type={document.type}
       config={config}
       formData={document}

--- a/packages/dm-core-plugins/src/form/RegistryContext.tsx
+++ b/packages/dm-core-plugins/src/form/RegistryContext.tsx
@@ -6,7 +6,7 @@ type Props = {
   onOpen?: (key: string, view: TViewConfig) => void
 }
 
-export const RegistryContext = createContext<Props | undefined>(undefined)
+const RegistryContext = createContext<Props | undefined>(undefined)
 
 export const useRegistryContext = () => {
   const context = useContext(RegistryContext)

--- a/packages/dm-core-plugins/src/form/RegistryContext.tsx
+++ b/packages/dm-core-plugins/src/form/RegistryContext.tsx
@@ -1,10 +1,12 @@
+import { TViewConfig } from '@development-framework/dm-core'
 import React, { createContext, useContext } from 'react'
-import widgets from './widgets/'
 
-export const RegistryContext = createContext<any>({
-  fields: {},
-  widgets: {},
-})
+type Props = {
+  idReference?: string
+  onOpen?: (key: string, view: TViewConfig) => void
+}
+
+export const RegistryContext = createContext<Props | undefined>(undefined)
 
 export const useRegistryContext = () => {
   const context = useContext(RegistryContext)
@@ -14,20 +16,8 @@ export const useRegistryContext = () => {
   return context
 }
 
-export const RegistryProvider = (props: any) => {
-  const { children, idReference, onOpen } = props
-
-  const getWidget = (namePath: string, widgetName: string) => {
-    const name = widgetName.trim()
-    if (name in widgets) return widgets[name]
-    return () => <div>Did not find widget: {name} </div>
-  }
-
-  const value = {
-    getWidget,
-    idReference,
-    onOpen,
-  }
+export const RegistryProvider = (props: Props & { children: JSX.Element }) => {
+  const { children, ...value } = props
 
   return (
     <RegistryContext.Provider value={value}>

--- a/packages/dm-core-plugins/src/form/RegistryContext.tsx
+++ b/packages/dm-core-plugins/src/form/RegistryContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext } from 'react'
-import defaultWidgets from './widgets/index'
+import widgets from './widgets/'
 
 export const RegistryContext = createContext<any>({
   fields: {},
@@ -15,13 +15,11 @@ export const useRegistryContext = () => {
 }
 
 export const RegistryProvider = (props: any) => {
-  const { widgets, children, idReference, onOpen } = props
-
-  const allWidgets = { ...widgets, ...defaultWidgets }
+  const { children, idReference, onOpen } = props
 
   const getWidget = (namePath: string, widgetName: string) => {
     const name = widgetName.trim()
-    if (name in allWidgets) return allWidgets[name]
+    if (name in widgets) return widgets[name]
     return () => <div>Did not find widget: {name} </div>
   }
 

--- a/packages/dm-core-plugins/src/form/components/OpenObjectButton.tsx
+++ b/packages/dm-core-plugins/src/form/components/OpenObjectButton.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
 import { Button } from '@equinor/eds-core-react'
+import React from 'react'
 import { useRegistryContext } from '../RegistryContext'
 
 export const OpenObjectButton = ({ namePath }: { namePath: string }) => {
@@ -9,7 +9,7 @@ export const OpenObjectButton = ({ namePath }: { namePath: string }) => {
     <Button
       variant="outlined"
       onClick={() =>
-        onOpen(namePath, {
+        onOpen?.(namePath, {
           type: 'ViewConfig',
           scope: namePath,
         })

--- a/packages/dm-core-plugins/src/form/context/WidgetContext.tsx
+++ b/packages/dm-core-plugins/src/form/context/WidgetContext.tsx
@@ -1,0 +1,36 @@
+import React, { createContext, useContext } from 'react'
+import { TWidgets } from '../types'
+import defaultWidgets from '../widgets'
+
+const WidgetContext = createContext<TWidgets | undefined>(undefined)
+
+/**
+ * This function can be used to select a widget among default and custom widgets.
+ * Note that it will only work for custom widgets if it's used in combination with the WidgetProvider
+ */
+export const getWidget = (widgetName: string) => {
+  const context = useContext(WidgetContext)
+  let widgets = { ...defaultWidgets }
+  if (context) {
+    widgets = { ...defaultWidgets, ...context }
+  }
+
+  const name = widgetName.trim()
+  if (!(name in widgets)) {
+    throw Error(`Could not find widget ${name}.`)
+  }
+  return widgets[name]
+}
+
+/**
+ * This provider is useful if you want to use custom widgets not provided by the form plugin
+ */
+export const WidgetProvider = (props: {
+  widgets?: TWidgets
+  children: JSX.Element | JSX.Element[]
+}) => {
+  const { widgets, children } = props
+  return (
+    <WidgetContext.Provider value={widgets}>{children}</WidgetContext.Provider>
+  )
+}

--- a/packages/dm-core-plugins/src/form/fields/BooleanField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/BooleanField.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
+import { getWidget } from '../context/WidgetContext'
 import { TBooleanFieldProps } from '../types'
-import getWidget from '../widgets'
 
 export const BooleanField = (props: TBooleanFieldProps) => {
   const { control } = useFormContext()

--- a/packages/dm-core-plugins/src/form/fields/BooleanField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/BooleanField.tsx
@@ -1,20 +1,18 @@
 import React from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
 import { TBooleanFieldProps } from '../types'
-import { useRegistryContext } from '../RegistryContext'
+import getWidget from '../widgets'
 
 export const BooleanField = (props: TBooleanFieldProps) => {
   const { control } = useFormContext()
   const { namePath, displayLabel, defaultValue, uiAttribute } = props
-
-  const { getWidget } = useRegistryContext()
 
   // We need to convert default values coming from the API since they are always strings
   const usedDefaultValue =
     (defaultValue !== undefined && defaultValue == 'True') || false
 
   const defaultWidget = uiAttribute ? uiAttribute.widget : 'CheckboxWidget'
-  const Widget = getWidget(namePath, defaultWidget)
+  const Widget = getWidget(defaultWidget)
 
   return (
     <Controller

--- a/packages/dm-core-plugins/src/form/fields/NumberField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/NumberField.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
+import { getWidget } from '../context/WidgetContext'
 import { TNumberFieldProps } from '../types'
-import getWidget from '../widgets'
 
 // Taken from: https://github.com/rjsf-team/react-jsonschema-form/blob/cff979dae5348e9b100447641bcb53374168367f/packages/core/src/utils.js#L436
 export const asNumber = (value: string): number | string => {

--- a/packages/dm-core-plugins/src/form/fields/NumberField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/NumberField.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
 import { TNumberFieldProps } from '../types'
-import { useRegistryContext } from '../RegistryContext'
+import getWidget from '../widgets'
 
 // Taken from: https://github.com/rjsf-team/react-jsonschema-form/blob/cff979dae5348e9b100447641bcb53374168367f/packages/core/src/utils.js#L436
 export const asNumber = (value: string): number | string => {
@@ -34,10 +34,8 @@ export const NumberField = (props: TNumberFieldProps) => {
   const { control } = useFormContext()
   const { namePath, displayLabel, defaultValue, optional, uiAttribute } = props
 
-  const { getWidget } = useRegistryContext()
-
   const defaultWidget = uiAttribute ? uiAttribute.widget : 'TextWidget'
-  const Widget = getWidget(namePath, defaultWidget)
+  const Widget = getWidget(defaultWidget)
 
   return (
     <Controller

--- a/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
@@ -16,8 +16,8 @@ import React, { useState } from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
 import { useRegistryContext } from '../RegistryContext'
 import { OpenObjectButton } from '../components/OpenObjectButton'
+import { getWidget } from '../context/WidgetContext'
 import { TObjectFieldProps } from '../types'
-import getWidget from '../widgets'
 import { AttributeField } from './AttributeField'
 
 const AddUncontained = (props: {

--- a/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
@@ -17,6 +17,7 @@ import { Controller, useFormContext } from 'react-hook-form'
 import { useRegistryContext } from '../RegistryContext'
 import { OpenObjectButton } from '../components/OpenObjectButton'
 import { TObjectFieldProps } from '../types'
+import getWidget from '../widgets'
 import { AttributeField } from './AttributeField'
 
 const AddUncontained = (props: {
@@ -368,12 +369,11 @@ export const UncontainedAttribute = (props: any): JSX.Element => {
 export const ObjectField = (props: TObjectFieldProps): JSX.Element => {
   const { type, namePath, uiAttribute } = props
   const { getValues } = useFormContext()
-  const { getWidget } = useRegistryContext()
 
   // Be able to override the object field
   const Widget =
     uiAttribute && uiAttribute.widget
-      ? getWidget(namePath, uiAttribute.widget)
+      ? getWidget(uiAttribute.widget)
       : ObjectTypeSelector
 
   const values = getValues(namePath)

--- a/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
@@ -246,7 +246,7 @@ export const ContainedAttribute = (props: any): JSX.Element => {
         {shouldOpen && isDefined && (
           <OpenObjectButton
             namePath={
-              attributePath.length > 1
+              attributePath && attributePath.length > 1
                 ? `${attributePath[1]}.${namePath}`
                 : namePath
             }
@@ -288,16 +288,9 @@ export const ContainedAttribute = (props: any): JSX.Element => {
 }
 
 export const UncontainedAttribute = (props: any): JSX.Element => {
-  const {
-    type,
-    namePath,
-    displayLabel = '',
-    contained = false,
-    config,
-    uiRecipe,
-  } = props
+  const { type, namePath, displayLabel = '', contained = false } = props
   const { getValues, control, setValue } = useFormContext()
-  const { dataSourceId, onOpen } = useRegistryContext()
+  const { idReference, onOpen } = useRegistryContext()
   const initialValue = getValues(namePath)
 
   return (
@@ -337,12 +330,8 @@ export const UncontainedAttribute = (props: any): JSX.Element => {
                       <External
                         type={type}
                         namePath={namePath}
-                        config={uiRecipe ? uiRecipe.config : config}
                         contained={contained}
-                        dataSourceId={dataSourceId}
-                        documentId={value.address}
-                        onOpen={onOpen}
-                        f
+                        idReference={idReference}
                       />
                     )}
                   </Stack>
@@ -367,7 +356,7 @@ export const UncontainedAttribute = (props: any): JSX.Element => {
 }
 
 export const ObjectField = (props: TObjectFieldProps): JSX.Element => {
-  const { type, namePath, uiAttribute } = props
+  const { type, namePath, uiAttribute, displayLabel } = props
   const { getValues } = useFormContext()
 
   // Be able to override the object field
@@ -381,6 +370,8 @@ export const ObjectField = (props: TObjectFieldProps): JSX.Element => {
   return (
     <Widget
       {...props}
+      id={namePath}
+      label={displayLabel ?? ''}
       type={type === 'object' && values ? values.type : type}
     />
   )

--- a/packages/dm-core-plugins/src/form/fields/StringField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/StringField.tsx
@@ -1,8 +1,7 @@
 import React from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
 import { TStringFieldProps } from '../types'
-import { useRegistryContext } from '../RegistryContext'
-import { asNumber } from './NumberField'
+import getWidget from '../widgets'
 
 const formatDate = (date: string) => {
   return new Date(date).toLocaleString(navigator.language)
@@ -12,10 +11,8 @@ export const StringField = (props: TStringFieldProps) => {
   const { control } = useFormContext()
   const { namePath, displayLabel, defaultValue, optional, uiAttribute } = props
 
-  const { getWidget } = useRegistryContext()
-
   const defaultWidget = uiAttribute ? uiAttribute.widget : 'TextWidget'
-  const Widget = getWidget(namePath, defaultWidget)
+  const Widget = getWidget(defaultWidget)
 
   return (
     <Controller

--- a/packages/dm-core-plugins/src/form/fields/StringField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/StringField.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
+import { getWidget } from '../context/WidgetContext'
 import { TStringFieldProps } from '../types'
-import getWidget from '../widgets'
 
 const formatDate = (date: string) => {
   return new Date(date).toLocaleString(navigator.language)

--- a/packages/dm-core-plugins/src/form/types.tsx
+++ b/packages/dm-core-plugins/src/form/types.tsx
@@ -62,3 +62,7 @@ export type TWidget = {
   namePath: string
   readOnly?: boolean
 }
+
+export type TWidgets = {
+  [key: string]: (props: TWidget) => JSX.Element
+}

--- a/packages/dm-core-plugins/src/form/types.tsx
+++ b/packages/dm-core-plugins/src/form/types.tsx
@@ -4,7 +4,6 @@ export type TFormProps = {
   idReference?: string
   type?: string
   formData?: any
-  widgets?: any
   config?: any
   onOpen?: (key: string, view: TViewConfig) => void
   onSubmit?: (data: any) => void

--- a/packages/dm-core-plugins/src/form/types.tsx
+++ b/packages/dm-core-plugins/src/form/types.tsx
@@ -52,14 +52,14 @@ export declare type Variants = 'error' | 'success' | 'warning'
 
 export type TWidget = {
   label: string
-  value: any
-  onChange: (value: any) => void
+  value?: any
+  onChange?: (value: any) => void
   onClick?: (value: any) => void
   id: string
   inputRef?: any
   helperText?: string
   variant?: Variants
-  namePath: string
+  type?: string
   readOnly?: boolean
 }
 

--- a/packages/dm-core-plugins/src/form/widgets/BlueprintPickerWidget.tsx
+++ b/packages/dm-core-plugins/src/form/widgets/BlueprintPickerWidget.tsx
@@ -17,7 +17,7 @@ const BlueprintPickerWidget = (props: TWidget) => {
       <BlueprintPicker
         label={label}
         variant={variant}
-        onChange={onChange}
+        onChange={onChange ?? (() => undefined)}
         formData={value}
       />
       {variant === 'error' ? (

--- a/packages/dm-core-plugins/src/form/widgets/BlueprintPickerWidget.tsx
+++ b/packages/dm-core-plugins/src/form/widgets/BlueprintPickerWidget.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react'
+
+import { BlueprintPicker } from '@development-framework/dm-core'
+import styled from 'styled-components'
+import { TWidget } from '../types'
+
+// The custom widgets goes under here,
+// this may at some point be moved out from the form package.
+const ErrorHelperText = styled.div`
+  color: #b30d2f;
+`
+
+const BlueprintPickerWidget = (props: TWidget) => {
+  const { label, variant, onChange, value, helperText } = props
+  return (
+    <>
+      <BlueprintPicker
+        label={label}
+        variant={variant}
+        onChange={onChange}
+        formData={value}
+      />
+      {variant === 'error' ? (
+        <ErrorHelperText>{helperText}</ErrorHelperText>
+      ) : (
+        <></>
+      )}
+    </>
+  )
+}
+
+export default BlueprintPickerWidget

--- a/packages/dm-core-plugins/src/form/widgets/CheckboxWidget.tsx
+++ b/packages/dm-core-plugins/src/form/widgets/CheckboxWidget.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { Checkbox } from '@equinor/eds-core-react'
-import { TWidget } from '../../types'
+import { TWidget } from '../types'
 
 const CheckboxWidget = (props: TWidget) => {
   const { value } = props

--- a/packages/dm-core-plugins/src/form/widgets/CheckboxWidget/index.ts
+++ b/packages/dm-core-plugins/src/form/widgets/CheckboxWidget/index.ts
@@ -1,2 +1,0 @@
-export { default } from './CheckboxWidget'
-export * from './CheckboxWidget'

--- a/packages/dm-core-plugins/src/form/widgets/TextWidget.tsx
+++ b/packages/dm-core-plugins/src/form/widgets/TextWidget.tsx
@@ -13,7 +13,7 @@ const TextWidget = (props: TWidget) => {
   const onChangeHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = event.target
     const formattedValue = value === '' ? null : value
-    onChange(formattedValue)
+    onChange?.(formattedValue)
   }
 
   return (

--- a/packages/dm-core-plugins/src/form/widgets/TextWidget.tsx
+++ b/packages/dm-core-plugins/src/form/widgets/TextWidget.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 
-import { TextField, Icon } from '@equinor/eds-core-react'
+import { Icon, TextField } from '@equinor/eds-core-react'
 
 import { error_filled } from '@equinor/eds-icons'
-import { TWidget } from '../../types'
+import { TWidget } from '../types'
 
 Icon.add({ error_filled })
 

--- a/packages/dm-core-plugins/src/form/widgets/TextWidget/index.ts
+++ b/packages/dm-core-plugins/src/form/widgets/TextWidget/index.ts
@@ -1,2 +1,0 @@
-export { default } from './TextWidget'
-export * from './TextWidget'

--- a/packages/dm-core-plugins/src/form/widgets/TextareaWidget.tsx
+++ b/packages/dm-core-plugins/src/form/widgets/TextareaWidget.tsx
@@ -13,7 +13,7 @@ const TextareaWidget = (props: TWidget) => {
   const onChangeHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = event.target
     const formattedValue = value === '' ? null : value
-    onChange(formattedValue)
+    onChange?.(formattedValue)
   }
 
   return (

--- a/packages/dm-core-plugins/src/form/widgets/TextareaWidget.tsx
+++ b/packages/dm-core-plugins/src/form/widgets/TextareaWidget.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 
-import { TextField, Icon } from '@equinor/eds-core-react'
+import { Icon, TextField } from '@equinor/eds-core-react'
 
 import { error_filled } from '@equinor/eds-icons'
-import { TWidget } from '../../types'
+import { TWidget } from '../types'
 
 Icon.add({ error_filled })
 

--- a/packages/dm-core-plugins/src/form/widgets/TextareaWidget/index.ts
+++ b/packages/dm-core-plugins/src/form/widgets/TextareaWidget/index.ts
@@ -1,2 +1,0 @@
-export { default } from './TextareaWidget'
-export * from './TextareaWidget'

--- a/packages/dm-core-plugins/src/form/widgets/TypeWidget.tsx
+++ b/packages/dm-core-plugins/src/form/widgets/TypeWidget.tsx
@@ -4,7 +4,7 @@ import { TWidget } from '../types'
 import TextWidget from './TextWidget'
 
 const TypeWidget = (props: TWidget) => {
-  const { id, namePath, label, value } = props
+  const { id, label, value } = props
   const { blueprint, isLoading, error } = useBlueprint(value)
 
   if (isLoading) return <Loading />
@@ -17,7 +17,6 @@ const TypeWidget = (props: TWidget) => {
     <>
       <TextWidget
         id={id}
-        namePath={namePath}
         label={label}
         readOnly={true}
         value={value}

--- a/packages/dm-core-plugins/src/form/widgets/TypeWidget.tsx
+++ b/packages/dm-core-plugins/src/form/widgets/TypeWidget.tsx
@@ -1,0 +1,37 @@
+import { Loading, useBlueprint } from '@development-framework/dm-core'
+import React from 'react'
+import { TWidget } from '../types'
+import TextWidget from './TextWidget'
+
+const TypeWidget = (props: TWidget) => {
+  const { id, namePath, label, value } = props
+  const { blueprint, isLoading, error } = useBlueprint(value)
+
+  if (isLoading) return <Loading />
+  if (error) throw new Error(`Failed to fetch blueprint for '${value}'`)
+  if (blueprint === undefined) return <div>Could not find the blueprint</div>
+
+  const datasourceId = value.split('/')[0]
+
+  return (
+    <>
+      <TextWidget
+        id={id}
+        namePath={namePath}
+        label={label}
+        readOnly={true}
+        value={value}
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        onChange={() => {}}
+        onClick={() => {
+          // @ts-ignore
+          window
+            .open(`dmt/view/${datasourceId}/${blueprint.uid}`, '_blank')
+            .focus()
+        }}
+      />
+    </>
+  )
+}
+
+export default TypeWidget

--- a/packages/dm-core-plugins/src/form/widgets/Widgets.ts
+++ b/packages/dm-core-plugins/src/form/widgets/Widgets.ts
@@ -1,9 +1,0 @@
-import CheckboxWidget from './CheckboxWidget/CheckboxWidget'
-import TextWidget from './TextWidget/TextWidget'
-import TextareaWidget from './TextareaWidget/TextareaWidget'
-
-export default {
-  CheckboxWidget,
-  TextWidget,
-  TextareaWidget,
-}

--- a/packages/dm-core-plugins/src/form/widgets/index.ts
+++ b/packages/dm-core-plugins/src/form/widgets/index.ts
@@ -15,4 +15,10 @@ const widgets: {
   TypeWidget,
 }
 
-export default widgets
+export default (widgetName: string) => {
+  const name = widgetName.trim()
+  if (!(name in widgets)) {
+    throw Error(`Could not find widget ${name}`)
+  }
+  return widgets[name]
+}

--- a/packages/dm-core-plugins/src/form/widgets/index.ts
+++ b/packages/dm-core-plugins/src/form/widgets/index.ts
@@ -1,2 +1,14 @@
-export { default } from './Widgets'
-export * from './Widgets'
+import { TWidget } from '../types'
+import CheckboxWidget from './CheckboxWidget'
+import TextWidget from './TextWidget'
+import TextareaWidget from './TextareaWidget'
+
+const widgets: {
+  [key: string]: (props: TWidget) => JSX.Element
+} = {
+  CheckboxWidget,
+  TextWidget,
+  TextareaWidget,
+}
+
+export default widgets

--- a/packages/dm-core-plugins/src/form/widgets/index.ts
+++ b/packages/dm-core-plugins/src/form/widgets/index.ts
@@ -1,13 +1,11 @@
-import { TWidget } from '../types'
+import { TWidgets } from '../types'
 import BlueprintPickerWidget from './BlueprintPickerWidget'
 import CheckboxWidget from './CheckboxWidget'
 import TextWidget from './TextWidget'
 import TextareaWidget from './TextareaWidget'
 import TypeWidget from './TypeWidget'
 
-const widgets: {
-  [key: string]: (props: TWidget) => JSX.Element
-} = {
+const widgets: TWidgets = {
   CheckboxWidget,
   TextWidget,
   TextareaWidget,
@@ -15,10 +13,4 @@ const widgets: {
   TypeWidget,
 }
 
-export default (widgetName: string) => {
-  const name = widgetName.trim()
-  if (!(name in widgets)) {
-    throw Error(`Could not find widget ${name}`)
-  }
-  return widgets[name]
-}
+export default widgets

--- a/packages/dm-core-plugins/src/form/widgets/index.ts
+++ b/packages/dm-core-plugins/src/form/widgets/index.ts
@@ -1,7 +1,9 @@
 import { TWidget } from '../types'
+import BlueprintPickerWidget from './BlueprintPickerWidget'
 import CheckboxWidget from './CheckboxWidget'
 import TextWidget from './TextWidget'
 import TextareaWidget from './TextareaWidget'
+import TypeWidget from './TypeWidget'
 
 const widgets: {
   [key: string]: (props: TWidget) => JSX.Element
@@ -9,6 +11,8 @@ const widgets: {
   CheckboxWidget,
   TextWidget,
   TextareaWidget,
+  BlueprintPickerWidget,
+  TypeWidget,
 }
 
 export default widgets

--- a/packages/dm-core-plugins/src/form/widgets/index.tsx
+++ b/packages/dm-core-plugins/src/form/widgets/index.tsx
@@ -1,7 +1,0 @@
-import TextWidget from './TextWidget'
-import CheckboxWidget from './CheckboxWidget'
-
-export default {
-  TextWidget,
-  CheckboxWidget,
-}


### PR DESCRIPTION
## What does this pull request change, and why?

I've removed some unnecessary folder levels and index files from form/widgets
I've moved two widgets that were defined in <Form/> into separate files
I've created a widget context and removed widget logic from the registrycontext. The widget context can be wrapped around an application to allow for custom widgets

## Issues related to this change

Refs #266

