### PR TITLE
fix: expanded simple-form pluging and updated e2e

### DIFF
--- a/e2e/tests/plugin-form-Simple.spec.ts
+++ b/e2e/tests/plugin-form-Simple.spec.ts
@@ -9,7 +9,7 @@ test('Simple form', async ({ page }) => {
   await page.getByText('DemoDataSource/$Simple').click()
 
   //Remove prefilled optional string
-  await page.getByLabel('Optional string (optional)').fill('')
+  await page.getByLabel('An optional string (optional)').fill('')
 
   //Fill out required string
   await page.getByTestId('form-submit').click()

--- a/e2e/tests/plugin-form-Simple.spec.ts
+++ b/e2e/tests/plugin-form-Simple.spec.ts
@@ -8,30 +8,48 @@ test('Simple form', async ({ page }) => {
   await page.getByText('simple', { exact: true }).click()
   await page.getByText('DemoDataSource/$Simple').click()
 
-  //Fill out optional string
-  await page.getByLabel('Optional string (optional)').fill('Foo')
+  //Remove prefilled optional string
+  await page.getByLabel('Optional string (optional)').fill('')
 
   //Fill out required string
   await page.getByTestId('form-submit').click()
   await expect(page.getByText('required', { exact: true })).toBeVisible()
-  await page.getByLabel('Required string').fill('Bar')
+  await page.getByLabel('Required string').fill('Foo')
 
   //Fill out number field
   await page.getByLabel('Numbers only (optional)').fill('Text')
   await expect(page.getByText('Only digits allowed')).toBeVisible()
-  await page.getByLabel('Numbers only (optional)').fill('123')
+  await page.getByLabel('Numbers only (optional)').fill('3.14')
+
+  //Fill out integer field
+  //await page.getByLabel('Integer only (optional)').fill('3.14') //Known bug (itemid:31708452)
+  //await expect(page.getByText('Only integer allowed')).toBeVisible()
+  await page.getByLabel('Integer only (optional)').fill('123')
+
+  //Check checkbox
+  await page.getByLabel('An optional checkbox (optional)').check()
+  //await page.getByTestId('form-submit').click()
+  //await expect(page.getByText('<Field is mandatory>')).toBeVisible() //Known bug (itemid:31708452)
+  await page
+    .getByLabel('A required checbox (e.g. for confirmation purposes)')
+    .check()
 
   //Submitting form
   await page.getByTestId('form-submit').click()
   await expect(page.getByTestId('form-submit')).toHaveText(['Submit'])
 
-  // //Reloading form, expecting entered values to be stored
+  //Reloading form, expecting entered values to be stored
   await page.reload()
   await page.getByText('plugins', { exact: true }).click()
   await page.getByText('form').click()
   await page.getByText('simple', { exact: true }).click()
   await page.getByText('DemoDataSource/$Simple').click()
-  await expect(page.getByLabel('Optional string (optional)')).toHaveValue('Foo')
-  await expect(page.getByLabel('Required string')).toHaveValue('Bar')
-  await expect(page.getByLabel('Numbers only (optional)')).toHaveValue('123')
+  await expect(page.getByLabel('Optional string (optional)')).toHaveValue('')
+  await expect(page.getByLabel('Required string')).toHaveValue('Foo')
+  await expect(page.getByLabel('Numbers only (optional)')).toHaveValue('3.14')
+  await expect(page.getByLabel('Integer only (optional)')).toHaveValue('123')
+  await expect(page.getByLabel('An optional checkbox (optional)')).toBeChecked()
+  await expect(
+    page.getByLabel('A required checbox (e.g. for confirmation purposes)')
+  ).toBeChecked()
 })

--- a/example/app/data/DemoDataSource/plugins/form/simple/blueprints/Simple.json
+++ b/example/app/data/DemoDataSource/plugins/form/simple/blueprints/Simple.json
@@ -27,6 +27,27 @@
       "attributeType": "number",
       "label": "Numbers only",
       "optional": true
+    },
+    {
+      "name": "integer",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "integer",
+      "label": "Integer only",
+      "optional": true
+    },
+    {
+      "name": "optionalCheckbox",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "boolean",
+      "label": "An optional checkbox",
+      "optional": true
+    },
+    {
+      "name": "requiredCheckbox",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "boolean",
+      "label": "A required checbox (e.g. for confirmation purposes)",
+      "optional": false
     }
   ]
 }

--- a/example/app/data/DemoDataSource/plugins/form/simple/simple.json
+++ b/example/app/data/DemoDataSource/plugins/form/simple/simple.json
@@ -2,5 +2,7 @@
   "_id": "Simple",
   "name": "Simple",
   "type": "./blueprints/Simple",
-  "stringOptional": "a prefilled optional string"
+  "stringRequired": "",
+  "stringOptional": "a prefilled optional string",
+  "requiredCheckbox": false
 }

--- a/example/app/data/DemoDataSource/plugins/form/simple/simple.json
+++ b/example/app/data/DemoDataSource/plugins/form/simple/simple.json
@@ -2,5 +2,5 @@
   "_id": "Simple",
   "name": "Simple",
   "type": "./blueprints/Simple",
-  "Firstname": ""
+  "stringOptional": "a prefilled optional string"
 }


### PR DESCRIPTION
## What does this pull request change?
Expanded the simple form plugin to include all types of primitives, with some variations.

The e2e-test have been updated. Note that some lines have been commented out because there is a bug in the form package which will cause the test to fail and we don´t want this test to stop other work for now. See [https://github.com/orgs/equinor/projects/189?pane=issue&itemId=31708452](https://github.com/orgs/equinor/projects/189?pane=issue&itemId=31708452 )

## Why is this pull request needed?

## Issues related to this change

