### PR TITLE
fix: better error handing in attriubte selector

### DIFF
--- a/packages/dm-core-plugins/blueprints/attribute-selector/AttributeSelectorItem.json
+++ b/packages/dm-core-plugins/blueprints/attribute-selector/AttributeSelectorItem.json
@@ -3,6 +3,11 @@
   "name": "AttributeSelectorItem",
   "attributes": [
     {
+      "attributeType": "string",
+      "type": "CORE:BlueprintAttribute",
+      "name": "type"
+    },
+    {
       "attributeType": "CORE:ViewConfig",
       "type": "CORE:BlueprintAttribute",
       "name": "view"

--- a/packages/dm-core-plugins/src/attribute-selector/Content.tsx
+++ b/packages/dm-core-plugins/src/attribute-selector/Content.tsx
@@ -22,7 +22,6 @@ export const Content = (props: {
   formData: TGenericObject
 }): JSX.Element => {
   const { selectedView, items, setFormData, formData, onOpen, type } = props
-
   return (
     <div style={{ width: '100%' }}>
       {items.map((config: TItemData) => (
@@ -30,7 +29,6 @@ export const Content = (props: {
           key={config.viewId}
           hidden={config.viewId !== selectedView}
         >
-          {/*@ts-ignore*/}
           <ViewCreator
             idReference={config.rootEntityId}
             viewConfig={config.view}

--- a/packages/dm-core-plugins/src/attribute-selector/README.md
+++ b/packages/dm-core-plugins/src/attribute-selector/README.md
@@ -17,9 +17,9 @@ An `AttributeSelectorItem` has the following attributes:
 
 * `view` (required): object of type `ViewConfig` for the plugin
 * `label` (optional)
-
-The name of eds icon to display can be specified in the view attribute. List of all EDS icons can be
-found [here](https://eds-storybook-react.azurewebsites.net/?path=/docs/icons--preview).
+* `scope` (optional): can be either set to `self` or one of the attributes defined in the blueprint.
+* `eds_icon` (optional): specify what icon to display in the attribute selector. The name of eds icon to display must be
+  chosen from the list found [here](https://eds-storybook-react.azurewebsites.net/?path=/docs/icons--preview).
 
 Copy blueprints from the attribute-selector plugin like so:
 `cp -R node_modules/@development-framework/dm-core-plugins/blueprints/attribute-selector ./myApplicationBlueprints/`

--- a/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
@@ -214,7 +214,6 @@ export const ContainedAttribute = (props: any): JSX.Element => {
     uiRecipe,
     blueprint,
   } = props
-
   const { getValues, setValue } = useFormContext()
   const { idReference, onOpen } = useRegistryContext()
   const [isDefined, setIsDefined] = useState(

--- a/packages/dm-core/src/components/ViewCreator/ViewCreator.tsx
+++ b/packages/dm-core/src/components/ViewCreator/ViewCreator.tsx
@@ -12,6 +12,7 @@ import { EntityView, Loading, TAttribute, useDMSS } from '../../index'
 import React, { useEffect, useState } from 'react'
 import { InlineRecipeView } from './InlineRecipeView'
 import { getTarget } from './utils'
+import { AxiosResponse } from 'axios'
 
 type TViewCreator = Omit<IUIPlugin, 'type'> & {
   viewConfig: TViewConfig | TInlineRecipeViewConfig | TReferenceViewConfig
@@ -50,7 +51,7 @@ export const ViewCreator = (props: TViewCreator): JSX.Element => {
       .attributeGet({
         reference: reference,
       })
-      .then((response: any) => {
+      .then((response: AxiosResponse) => {
         setAttribute(response.data)
       })
       .catch((error) => setError(error))
@@ -58,11 +59,17 @@ export const ViewCreator = (props: TViewCreator): JSX.Element => {
   }, [])
 
   if (isLoading) return <Loading />
-  if (error) throw error
+  if (error)
+    return (
+      <p>
+        Could not find attribute for document with id {reference} (
+        {error.message})
+      </p>
+    )
   if (attribute === undefined)
     throw new Error('Unable to find type and dimensions for view')
 
-  if (isInlineRecipeViewConfig(viewConfig))
+  if (isInlineRecipeViewConfig(viewConfig)) {
     return (
       <InlineRecipeView
         idReference={reference}
@@ -71,6 +78,7 @@ export const ViewCreator = (props: TViewCreator): JSX.Element => {
         onOpen={onOpen}
       />
     )
+  }
 
   if (isReferenceViewConfig(viewConfig)) {
     return (


### PR DESCRIPTION
## What does this pull request change?

add error handling to attribute selector plugin. 

Do not crash if a single attribute is not found

requires https://github.com/equinor/data-modelling-storage-service/pull/456

## Issues related to this change
#220 
