### PR TITLE
refactor: remove type since it is already defined in named entity

### DIFF
--- a/example/app/data/DemoDataSource/plugins/view_selector/blueprints/AttributeSelectorSidebar.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/view_selector/blueprints/AttributeSelectorSidebar.blueprint.json
@@ -4,11 +4,6 @@
   "extends": ["CORE:NamedEntity"],
   "attributes": [
     {
-      "attributeType": "string",
-      "type": "dmss://system/SIMOS/BlueprintAttribute",
-      "name": "type"
-    },
-    {
       "attributeType": "./ViewSelectorSidebar",
       "type": "CORE:BlueprintAttribute",
       "name": "firstAttribute",

--- a/example/app/data/DemoDataSource/plugins/view_selector/blueprints/AttributeSelectorTabsDefault.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/view_selector/blueprints/AttributeSelectorTabsDefault.blueprint.json
@@ -4,11 +4,6 @@
   "extends": ["CORE:NamedEntity"],
   "attributes": [
     {
-      "attributeType": "string",
-      "type": "dmss://system/SIMOS/BlueprintAttribute",
-      "name": "type"
-    },
-    {
       "attributeType": "./ViewSelectorTabsDefault",
       "type": "CORE:BlueprintAttribute",
       "name": "firstAttribute",


### PR DESCRIPTION
## What does this pull request change?

* Remove attribute type, since it already defined in named entity

## Why is this pull request needed?

## Issues related to this change

