### PR TITLE
fix: bugs in generic list plugin

### DIFF
--- a/example/app/data/DemoDataSource/recipes/plugins/generic-list/orderItem.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/generic-list/orderItem.json
@@ -21,113 +21,6 @@
             },
             "scope": "self"
           }
-        },
-        {
-          "type": "PLUGINS:dm-core-plugins/attribute-selector/AttributeSelectorItem",
-          "label": "List",
-          "view": {
-            "type": "CORE:InlineRecipeViewConfig",
-            "recipe": {
-              "name": "List",
-              "type": "CORE:UiRecipe",
-              "plugin": "@development-framework/dm-core-plugins/generic-list",
-              "dimensions": "*",
-              "config": {
-                "type": "PLUGINS:dm-core-plugins/generic-list/GenericListPluginConfig",
-                "headers": ["name", "quantity", "type"],
-                "functionality": {
-                  "type": "PLUGINS:dm-core-plugins/generic-list/FunctionalityConfig",
-                  "delete": true
-                },
-                "defaultView": {
-                  "type": "CORE:InlineRecipeViewConfig",
-                  "recipe": {
-                    "type": "CORE:UiRecipe",
-                    "name": "Edit",
-                    "description": "Default edit",
-                    "plugin": "@development-framework/dm-core-plugins/form"
-                  },
-                  "scope": "self"
-                },
-                "views": [
-                  {
-                    "type": "CORE:ViewConfig",
-                    "scope": "product"
-                  },
-                  {
-                    "type": "CORE:InlineRecipeViewConfig",
-                    "recipe": {
-                      "type": "CORE:UiRecipe",
-                      "name": "Edit",
-                      "description": "Default edit",
-                      "plugin": "@development-framework/dm-core-plugins/form"
-                    },
-                    "scope": "self"
-                  },
-                  {
-                    "type": "CORE:InlineRecipeViewConfig",
-                    "recipe": {
-                      "type": "CORE:UiRecipe",
-                      "name": "Yaml",
-                      "description": "Yaml view",
-                      "plugin": "@development-framework/dm-core-plugins/yaml"
-                    },
-                    "scope": "self"
-                  }
-                ]
-              }
-            },
-            "scope": "self"
-          }
-        },
-        {
-          "type": "PLUGINS:dm-core-plugins/attribute-selector/AttributeSelectorItem",
-          "label": "Table Edit",
-          "view": {
-            "type": "CORE:InlineRecipeViewConfig",
-            "recipe": {
-              "name": "Table Edit",
-              "type": "CORE:UiRecipe",
-              "plugin": "@development-framework/dm-core-plugins/table",
-              "dimensions": "*",
-              "config": {
-                "type": "PLUGINS:dm-core-plugins/table/TablePluginConfig",
-                "columns": ["name", "quantity", "type"],
-                "editableColumns": ["name", "quantity"],
-                "functionality": {
-                  "type": "PLUGINS:dm-core-plugins/table/TableFunctionalityConfig",
-                  "openAsTab": false,
-                  "delete": true,
-                  "add": true,
-                  "edit": true,
-                  "sort": true
-                }
-              }
-            },
-            "scope": "self"
-          }
-        },
-        {
-          "type": "PLUGINS:dm-core-plugins/attribute-selector/AttributeSelectorItem",
-          "label": "Table View",
-          "view": {
-            "type": "CORE:InlineRecipeViewConfig",
-            "recipe": {
-              "name": "Table View",
-              "type": "CORE:UiRecipe",
-              "plugin": "@development-framework/dm-core-plugins/table",
-              "dimensions": "*",
-              "config": {
-                "type": "PLUGINS:dm-core-plugins/table/TablePluginConfig",
-                "columns": ["name", "quantity", "type"],
-                "functionality": {
-                  "type": "PLUGINS:dm-core-plugins/table/TableFunctionalityConfig",
-                  "openAsTab": false
-                }
-              },
-              "scope": "self"
-            }
-          }
         }
       ]
     }
@@ -147,16 +40,10 @@
       "name": "List",
       "type": "CORE:UiRecipe",
       "plugin": "@development-framework/dm-core-plugins/generic-list",
-      "dimensions": "*"
-    },
-    {
-      "name": "List",
-      "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/generic-list",
       "dimensions": "*",
       "config": {
         "type": "PLUGINS:dm-core-plugins/generic-list/GenericListPluginConfig",
-        "headers": ["name", "description"],
+        "headers": ["quantity", "type"],
         "functionality": {
           "type": "PLUGINS:dm-core-plugins/generic-list/FunctionalityConfig",
           "delete": true,

--- a/example/app/data/DemoDataSource/recipes/plugins/grid/orderItem.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/grid/orderItem.json
@@ -21,114 +21,6 @@
             },
             "scope": "self"
           }
-        },
-        {
-          "type": "PLUGINS:dm-core-plugins/attribute-selector/AttributeSelectorItem",
-          "label": "List",
-          "view": {
-            "type": "CORE:InlineRecipeViewConfig",
-            "recipe": {
-              "name": "List",
-              "type": "CORE:UiRecipe",
-              "plugin": "@development-framework/dm-core-plugins/generic-list",
-              "dimensions": "*",
-              "config": {
-                "type": "PLUGINS:dm-core-plugins/generic-list/GenericListPluginConfig",
-                "headers": ["name", "quantity", "type"],
-                "functionality": {
-                  "type": "PLUGINS:dm-core-plugins/generic-list/FunctionalityConfig",
-                  "delete": true
-                },
-                "expanded": false,
-                "defaultView": {
-                  "type": "CORE:InlineRecipeViewConfig",
-                  "recipe": {
-                    "type": "CORE:UiRecipe",
-                    "name": "Edit",
-                    "description": "Default edit",
-                    "plugin": "@development-framework/dm-core-plugins/form"
-                  },
-                  "scope": "self"
-                },
-                "views": [
-                  {
-                    "type": "CORE:ViewConfig",
-                    "scope": "product"
-                  },
-                  {
-                    "type": "CORE:InlineRecipeViewConfig",
-                    "recipe": {
-                      "type": "CORE:UiRecipe",
-                      "name": "Edit",
-                      "description": "Default edit",
-                      "plugin": "@development-framework/dm-core-plugins/form"
-                    },
-                    "scope": "self"
-                  },
-                  {
-                    "type": "CORE:InlineRecipeViewConfig",
-                    "recipe": {
-                      "type": "CORE:UiRecipe",
-                      "name": "Yaml",
-                      "description": "Yaml view",
-                      "plugin": "@development-framework/dm-core-plugins/yaml"
-                    },
-                    "scope": "self"
-                  }
-                ]
-              }
-            },
-            "scope": "self"
-          }
-        },
-        {
-          "type": "PLUGINS:dm-core-plugins/attribute-selector/AttributeSelectorItem",
-          "label": "Table Edit",
-          "view": {
-            "type": "CORE:InlineRecipeViewConfig",
-            "recipe": {
-              "name": "Table Edit",
-              "type": "CORE:UiRecipe",
-              "plugin": "@development-framework/dm-core-plugins/table",
-              "dimensions": "*",
-              "config": {
-                "type": "PLUGINS:dm-core-plugins/table/TablePluginConfig",
-                "columns": ["name", "quantity", "type"],
-                "editableColumns": ["name", "quantity"],
-                "functionality": {
-                  "type": "PLUGINS:dm-core-plugins/table/TableFunctionalityConfig",
-                  "openAsTab": false,
-                  "delete": true,
-                  "add": true,
-                  "edit": true,
-                  "sort": true
-                }
-              }
-            },
-            "scope": "self"
-          }
-        },
-        {
-          "type": "PLUGINS:dm-core-plugins/attribute-selector/AttributeSelectorItem",
-          "label": "Table View",
-          "view": {
-            "type": "CORE:InlineRecipeViewConfig",
-            "recipe": {
-              "name": "Table View",
-              "type": "CORE:UiRecipe",
-              "plugin": "@development-framework/dm-core-plugins/table",
-              "dimensions": "*",
-              "config": {
-                "type": "PLUGINS:dm-core-plugins/table/TablePluginConfig",
-                "columns": ["name", "quantity", "type"],
-                "functionality": {
-                  "type": "PLUGINS:dm-core-plugins/table/TableFunctionalityConfig",
-                  "openAsTab": false
-                }
-              },
-              "scope": "self"
-            }
-          }
         }
       ]
     }
@@ -148,18 +40,14 @@
       "name": "List",
       "type": "CORE:UiRecipe",
       "plugin": "@development-framework/dm-core-plugins/generic-list",
-      "dimensions": "*"
-    },
-    {
-      "name": "List",
-      "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/generic-list",
       "dimensions": "*",
       "config": {
         "type": "PLUGINS:dm-core-plugins/generic-list/GenericListPluginConfig",
-        "headers": ["name", "description"],
-        "showDelete": true,
-        "expanded": false
+        "headers": ["name", "quantity", "type"],
+        "functionality": {
+          "type": "PLUGINS:dm-core-plugins/generic-list/FunctionalityConfig",
+          "delete": true
+        }
       }
     }
   ]

--- a/packages/dm-core-plugins/src/generic-list/GenericListPlugin.tsx
+++ b/packages/dm-core-plugins/src/generic-list/GenericListPlugin.tsx
@@ -117,7 +117,6 @@ export const GenericListPlugin = (
         entity: { type: type },
       })
       .then((newEntity: AxiosResponse<object, TGenericObject>) => {
-        console.log('created', newEntity)
         setItems([
           ...items,
           {

--- a/packages/dm-core-plugins/src/table/TablePlugin.tsx
+++ b/packages/dm-core-plugins/src/table/TablePlugin.tsx
@@ -54,6 +54,13 @@ export const TablePlugin = (props: IUIPlugin) => {
 
   useEffect(() => {
     if (loading || !document) return
+    else if (!Array.isArray(document)) {
+      throw new Error(
+        `Generic table plugin cannot be used on document that is not an array! Got document ${JSON.stringify(
+          document
+        )} `
+      )
+    }
     const itemsWithIds = document
       ? Object.values(document)?.map((data, index) => ({
           data,

--- a/packages/dm-core-plugins/src/table/TablePlugin.tsx
+++ b/packages/dm-core-plugins/src/table/TablePlugin.tsx
@@ -94,7 +94,7 @@ export const TablePlugin = (props: IUIPlugin) => {
           {
             key: crypto.randomUUID(),
             data: newEntity.data,
-            index: Object.keys(items).length,
+            index: items?.length,
             expanded: false,
             isSaved: false,
           },
@@ -247,7 +247,7 @@ export const TablePlugin = (props: IUIPlugin) => {
                         color="danger"
                         variant="ghost_icon"
                         onClick={() =>
-                          deleteItem(`${idReference}.${index}`, item.key)
+                          deleteItem(`${idReference}[${index}]`, item.key)
                         }
                       >
                         <Icon data={delete_to_trash} aria-hidden />

--- a/packages/dm-core-plugins/src/table/types.ts
+++ b/packages/dm-core-plugins/src/table/types.ts
@@ -1,4 +1,4 @@
-import { TViewConfig } from '@development-framework/dm-core'
+import { TGenericObject, TViewConfig } from '@development-framework/dm-core'
 
 export type TTablePluginConfig = {
   editMode: boolean
@@ -36,7 +36,7 @@ export const defaultConfig: TTablePluginConfig = {
 
 export type TTableItemRow = {
   key: string
-  data: any
+  data: TGenericObject
   index: number
   expanded: boolean
   isSaved: boolean


### PR DESCRIPTION
## What does this pull request change?

fix some issues with the generic list plugin and the generic list example:

- the recipe for orderitem was wrong. Before, we tried to use the generic list plugin on a document that was NOT a list (the generic list plugin was used on an entity of type OrderItem)
-  update generic list plugin to have similar behaviour as the generic table plugin: do not call dmss when adding a row (instead, only call dmss when pressing save) and also add the `isSaved` attribute to ItemRow type

## Issues related to this change
#220 
