### PR TITLE
Refactor: Upgrade Prettier To Reflect What Version Github Actions is Running 🦋

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
     "clear-external-pckgs": "rm -rf node_modules && rm -rf packages/dm-core/node_modules && rm -rf packages/dm-core-plugins/node_modules && rm -rf example/node_modules && rm yarn.lock",
     "build:packages": "yarn workspace @development-framework/dm-core build && yarn workspace @development-framework/dm-core-plugins build",
     "test:packages": "yarn workspace @development-framework/dm-core test && yarn workspace @development-framework/dm-core-plugins test"
+  },
+  "dependencies": {
+    "prettier": "^3.0.0-alpha.6"
   }
 }

--- a/packages/dm-core/package.json
+++ b/packages/dm-core/package.json
@@ -3,11 +3,11 @@
   "version": "1.0.61",
   "license": "MIT",
   "peerDependencies": {
-    "react-router-dom": ">=5.1.2",
+    "@types/react": "^17.0.39",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "styled-components": "^5.2.3",
-    "@types/react": "^17.0.39"
+    "react-router-dom": ">=5.1.2",
+    "styled-components": "^5.2.3"
   },
   "dependencies": {
     "@equinor/eds-core-react": "^0.29.1",
@@ -15,6 +15,7 @@
     "@equinor/eds-tokens": "^0.9.0",
     "axios": "^0.27.2",
     "lodash": "^4.17.19",
+    "prettier": "^3.0.0-alpha.6",
     "react-icons": "3.11.0",
     "react-is": "^17.0.2",
     "react-notifications": "^1.7.4",


### PR DESCRIPTION
## What does this pull request change?

Bumps prettier version to 3.0.0-alpha6, so that it runs locally the same way that it is running in the Github actions.  

Also, the order of some items in package.json was changed due to prettier changing them automatically to be alphabetically sorted. 

## Why is this pull request needed?

Github Actions failed with prettier linting that did not fail locally. After bump to same version the linting was fixed. 

## Issues related to this change

