### PR TITLE
ci: change inital versions to start at 1.1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,11 +10,11 @@
   "packages": {
     "packages/dm-core": {
       "package-name": "@development-framework/dm-core",
-      "release-as": "0.1.0"
+      "release-as": "1.1.0"
     },
     "packages/dm-core-plugins": {
       "package-name": "@development-framework/dm-core-plugins",
-      "release-as": "0.1.0"
+      "release-as": "1.1.0"
     }
   }
 }


### PR DESCRIPTION
## What does this pull request change?

* Could not start at 0.1.0, since npm does not allow us to delete old packages, changing to start at 1.1.0

## Why is this pull request needed?

## Issues related to this change

