### PR TITLE
fix: change ui-click name to reflect updated name on json file

### DIFF
--- a/e2e/tests/plugin-form-Simple.spec.ts
+++ b/e2e/tests/plugin-form-Simple.spec.ts
@@ -13,7 +13,7 @@ test('Simple form', async ({ page }) => {
 
   //Fill out required string
   await page.getByTestId('form-submit').click()
-  await expect(page.getByText('required', { exact: true })).toBeVisible()
+  await expect(page.getByText('A required string', { exact: true })).toBeVisible()
   await page.getByLabel('Required string').fill('Foo')
 
   //Fill out number field
@@ -44,7 +44,7 @@ test('Simple form', async ({ page }) => {
   await page.getByText('form').click()
   await page.getByText('simple', { exact: true }).click()
   await page.getByText('Simple').click()
-  await expect(page.getByLabel('Optional string (optional)')).toHaveValue('')
+  await expect(page.getByLabel('An optional string (optional)')).toHaveValue('')
   await expect(page.getByLabel('Required string')).toHaveValue('Foo')
   await expect(page.getByLabel('Numbers only (optional)')).toHaveValue('3.14')
   await expect(page.getByLabel('Integer only (optional)')).toHaveValue('123')

--- a/e2e/tests/plugin-form-Simple.spec.ts
+++ b/e2e/tests/plugin-form-Simple.spec.ts
@@ -4,9 +4,9 @@ test('Simple form', async ({ page }) => {
   //Open simple form
   await page.goto('http://localhost:3000/')
   await page.getByText('plugins', { exact: true }).click()
-  await page.getByText('form').click()
+  await page.getByText('form', { exact: true }).click()
   await page.getByText('simple', { exact: true }).click()
-  await page.getByText('DemoDataSource/$Simple').click()
+  await page.getByText('Simple', { exact: true }).click()
 
   //Remove prefilled optional string
   await page.getByLabel('An optional string (optional)').fill('')

--- a/e2e/tests/plugin-form-Simple.spec.ts
+++ b/e2e/tests/plugin-form-Simple.spec.ts
@@ -43,7 +43,7 @@ test('Simple form', async ({ page }) => {
   await page.getByText('plugins', { exact: true }).click()
   await page.getByText('form').click()
   await page.getByText('simple', { exact: true }).click()
-  await page.getByText('DemoDataSource/$Simple').click()
+  await page.getByText('Simple').click()
   await expect(page.getByLabel('Optional string (optional)')).toHaveValue('')
   await expect(page.getByLabel('Required string')).toHaveValue('Foo')
   await expect(page.getByLabel('Numbers only (optional)')).toHaveValue('3.14')

--- a/example/app/data/DemoDataSource/plugins/form/simple/blueprints/Simple.json
+++ b/example/app/data/DemoDataSource/plugins/form/simple/blueprints/Simple.json
@@ -8,6 +8,11 @@
       "name": "type"
     },
     {
+      "attributeType": "string",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "name": "name"
+    },
+    {
       "name": "stringOptional",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "string",


### PR DESCRIPTION
## What does this pull request change?

Change name of document to click on so that the test will work. 
as well as adding exact true to make it case sensitive for more precise testign. 

## Why is this pull request needed?

## Issues related to this change

