### PR TITLE
chore: make prettier ignore manifest

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ build
 coverage
 node_modules
 dist
+.release-please-manifest.json


### PR DESCRIPTION
## What does this pull request change?

## Why is this pull request needed?

release-please autogenerate the content of the manifest file in a way that prettier does not like. 

## Issues related to this change

