### PR TITLE
ci: correct output variable name from release please

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   workflow_call:
     outputs:
-      release_created:
+      releases_created:
         description: "If true, a release PR has been merged"
         value: ${{ jobs.release-please.outputs.releases_created }}
       tag_name:
@@ -37,6 +37,6 @@ jobs:
             ]
 
     outputs:
-      release_created: ${{ steps.release.outputs.releases_created }}
+      releases_created: ${{ steps.release.outputs.releases_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
 


### PR DESCRIPTION
## What does this pull request change?

* The output variable from release-please had a different name than publish-packages expected (spelling error)

## Why is this pull request needed?

## Issues related to this change

