### PR TITLE
feat: ability to add custom viewrecipe in table expandable row

### DIFF
--- a/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/signals_simple/case.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/signals_simple/case.recipe.json
@@ -108,6 +108,16 @@
           "sort": true,
           "add": true,
           "edit": true
+        },
+        "expandableRecipeViewConfig": {
+          "type": "CORE:InlineRecipeViewConfig",
+          "scope": "self",
+          "recipe": {
+            "type": "CORE:UiRecipe",
+            "name": "Edit",
+            "description": "Default edit",
+            "plugin": "@development-framework/dm-core-plugins/form"
+          }
         }
       }
     }

--- a/packages/dm-core-plugins/blueprints/table/TablePluginConfig.json
+++ b/packages/dm-core-plugins/blueprints/table/TablePluginConfig.json
@@ -21,6 +21,11 @@
       "dimensions": "*"
     },
     {
+      "attributeType": "CORE:ViewConfig",
+      "type": "CORE:BlueprintAttribute",
+      "name": "expandableRecipeViewConfig"
+    },
+    {
       "attributeType": "./TableFunctionalityConfig.json",
       "type": "CORE:BlueprintAttribute",
       "name": "functionality",

--- a/packages/dm-core-plugins/src/table/TablePlugin.tsx
+++ b/packages/dm-core-plugins/src/table/TablePlugin.tsx
@@ -115,13 +115,15 @@ export const TablePlugin = (props: IUIPlugin) => {
       <Table style={{ width: '100%' }}>
         <Table.Head>
           <Table.Row>
-            {(config.functionality?.openAsTab ||
-              config.functionality?.openAsExpandable) && (
+            {config.functionality?.openAsExpandable && (
               <Table.Cell width="80"></Table.Cell>
             )}
             {config.columns.map((attribute: string) => (
               <Table.Cell key={attribute}>{attribute}</Table.Cell>
             ))}
+            {config.functionality?.openAsTab && (
+              <Table.Cell width="48" aria-label="Open in new tab"></Table.Cell>
+            )}
             {config.functionality?.delete && (
               <Table.Cell width="48" aria-label="Delete"></Table.Cell>
             )}

--- a/packages/dm-core-plugins/src/table/TablePlugin.tsx
+++ b/packages/dm-core-plugins/src/table/TablePlugin.tsx
@@ -116,7 +116,10 @@ export const TablePlugin = (props: IUIPlugin) => {
         <Table.Head>
           <Table.Row>
             {config.functionality?.openAsExpandable && (
-              <Table.Cell width="80"></Table.Cell>
+              <Table.Cell
+                width="80"
+                aria-label="Open as expandable"
+              ></Table.Cell>
             )}
             {config.columns.map((attribute: string) => (
               <Table.Cell key={attribute}>{attribute}</Table.Cell>

--- a/packages/dm-core-plugins/src/table/TableRow/TableRow.tsx
+++ b/packages/dm-core-plugins/src/table/TableRow/TableRow.tsx
@@ -10,11 +10,10 @@ import React, { ChangeEvent } from 'react'
 import { TTableRow } from '../types'
 import { TGenericObject, ViewCreator } from '@development-framework/dm-core'
 import {
-  add,
   chevron_down,
   chevron_up,
   delete_to_trash,
-  minimize,
+  open_in_browser,
 } from '@equinor/eds-icons'
 import { moveItem } from '../../generic-list/utils'
 
@@ -74,29 +73,16 @@ export function TableRow(props: TTableRow) {
   return (
     <>
       <Table.Row key={item.key}>
-        {(config.functionality?.openAsTab ||
-          config.functionality.openAsExpandable) && (
+        {config.functionality.openAsExpandable && (
           <Table.Cell>
-            <Tooltip
-              title={
-                config.functionality.openAsExpandable
-                  ? item.expanded
-                    ? 'Minimize'
-                    : 'Expand'
-                  : 'Open in new tab'
-              }
-            >
+            <Tooltip title={item.expanded ? 'Minimize' : 'Expand'}>
               <Button
                 variant="ghost_icon"
                 color="secondary"
                 disabled={!item.isSaved}
-                onClick={
-                  config.functionality.openAsExpandable
-                    ? () => expandItem(index)
-                    : () => openItemAsTab(item, index)
-                }
+                onClick={() => expandItem(index)}
               >
-                <Icon data={item.expanded ? minimize : add} />
+                <Icon data={item.expanded ? chevron_up : chevron_down} />
               </Button>
             </Tooltip>
           </Table.Cell>
@@ -128,6 +114,17 @@ export function TableRow(props: TTableRow) {
             </Table.Cell>
           )
         })}
+        {config.functionality?.openAsTab && (
+          <Table.Cell style={{ textAlign: 'center' }}>
+            <Button
+              title="Open"
+              variant="ghost"
+              onClick={() => openItemAsTab(item, index)}
+            >
+              <Icon data={open_in_browser} aria-hidden /> Open
+            </Button>
+          </Table.Cell>
+        )}
         <EdsProvider density="compact">
           {config.functionality?.delete && (
             <Table.Cell style={{ textAlign: 'center' }}>
@@ -178,7 +175,11 @@ export function TableRow(props: TTableRow) {
           <Table.Cell colSpan={getColumnsLength()}>
             <ViewCreator
               idReference={`${idReference}[${item.index}]`}
-              viewConfig={config.views?.[item.index] ?? config.defaultView}
+              viewConfig={
+                config.expandableRecipeViewConfig
+                  ? config.expandableRecipeViewConfig
+                  : config.views?.[item.index] ?? config.defaultView
+              }
             />
           </Table.Cell>
         </Table.Row>

--- a/packages/dm-core-plugins/src/table/TableRow/TableRow.tsx
+++ b/packages/dm-core-plugins/src/table/TableRow/TableRow.tsx
@@ -75,7 +75,7 @@ export function TableRow(props: TTableRow) {
       <Table.Row key={item.key}>
         {config.functionality.openAsExpandable && (
           <Table.Cell>
-            <Tooltip title={item.expanded ? 'Minimize' : 'Collapse'}>
+            <Tooltip title={item.expanded ? 'Collapse row' : 'Expand row'}>
               <Button
                 aria-label={
                   item.expanded ? 'Close expandable row' : 'Open expandable row'

--- a/packages/dm-core-plugins/src/table/TableRow/TableRow.tsx
+++ b/packages/dm-core-plugins/src/table/TableRow/TableRow.tsx
@@ -75,8 +75,11 @@ export function TableRow(props: TTableRow) {
       <Table.Row key={item.key}>
         {config.functionality.openAsExpandable && (
           <Table.Cell>
-            <Tooltip title={item.expanded ? 'Minimize' : 'Expand'}>
+            <Tooltip title={item.expanded ? 'Minimize' : 'Collapse'}>
               <Button
+                aria-label={
+                  item.expanded ? 'Close expandable row' : 'Open expandable row'
+                }
                 variant="ghost_icon"
                 color="secondary"
                 disabled={!item.isSaved}
@@ -117,7 +120,7 @@ export function TableRow(props: TTableRow) {
         {config.functionality?.openAsTab && (
           <Table.Cell style={{ textAlign: 'center' }}>
             <Button
-              title="Open"
+              disabled={!item.isSaved}
               variant="ghost"
               onClick={() => openItemAsTab(item, index)}
             >
@@ -142,7 +145,7 @@ export function TableRow(props: TTableRow) {
             <Table.Cell style={{ width: '48px' }}>
               <>
                 <Button
-                  title="Move row up"
+                  aria-label="Move row up"
                   disabled={index === 0}
                   variant="ghost_icon"
                   onClick={() => {
@@ -153,7 +156,7 @@ export function TableRow(props: TTableRow) {
                   <Icon data={chevron_up} aria-hidden />
                 </Button>
                 <Button
-                  title="Move row down"
+                  aria-label="Move row down"
                   disabled={
                     index === rowsPerPage - 1 || index === items?.length - 1
                   }
@@ -178,7 +181,7 @@ export function TableRow(props: TTableRow) {
               viewConfig={
                 config.expandableRecipeViewConfig
                   ? config.expandableRecipeViewConfig
-                  : config.views?.[item.index] ?? config.defaultView
+                  : { type: 'ViewConfig', scope: 'self' }
               }
             />
           </Table.Cell>

--- a/packages/dm-core-plugins/src/table/types.ts
+++ b/packages/dm-core-plugins/src/table/types.ts
@@ -1,4 +1,8 @@
-import { TGenericObject, TViewConfig } from '@development-framework/dm-core'
+import {
+  TGenericObject,
+  TInlineRecipeViewConfig,
+  TViewConfig,
+} from '@development-framework/dm-core'
 
 export type TTableFunctionalityConfig = {
   openAsTab: boolean
@@ -14,6 +18,7 @@ export type TTablePluginConfig = {
   columns: string[]
   showDelete: boolean
   editableColumns?: string[]
+  expandableRecipeViewConfig?: TInlineRecipeViewConfig
   functionality: TTableFunctionalityConfig
   defaultView: TViewConfig
   views: TViewConfig[]

--- a/packages/dm-core-plugins/src/table/types.ts
+++ b/packages/dm-core-plugins/src/table/types.ts
@@ -1,6 +1,7 @@
 import {
   TGenericObject,
   TInlineRecipeViewConfig,
+  TReferenceViewConfig,
   TViewConfig,
 } from '@development-framework/dm-core'
 
@@ -14,20 +15,19 @@ export type TTableFunctionalityConfig = {
 }
 
 export type TTablePluginConfig = {
-  editMode: boolean
   columns: string[]
-  showDelete: boolean
   editableColumns?: string[]
-  expandableRecipeViewConfig?: TInlineRecipeViewConfig
+  expandableRecipeViewConfig?:
+    | TViewConfig
+    | TInlineRecipeViewConfig
+    | TReferenceViewConfig
   functionality: TTableFunctionalityConfig
   defaultView: TViewConfig
   views: TViewConfig[]
 }
 
 export const defaultConfig: TTablePluginConfig = {
-  editMode: true,
   columns: ['name', 'type'],
-  showDelete: true,
   editableColumns: [],
   functionality: {
     openAsTab: true,


### PR DESCRIPTION
## What does this pull request change?
- adds expandableRecipeViewConfig to table blueprint
- adds example expandableRecipeViewConfig to case recipe in signal app
- separate openAsTab and openAsExpandable in tableplugin so you can use both at the same time

## Why is this pull request needed?
Want to be able to add custom view in expandable that may differ from view in open/openAsTab

## Issues related to this change
#258 
