### PR TITLE
ci: avoid publish test report

### DIFF
--- a/.github/workflows/on-main-push.yaml
+++ b/.github/workflows/on-main-push.yaml
@@ -20,6 +20,7 @@ jobs:
       dmss_version: ${{ needs.integration-tests.outputs.dmss_version }}
       dm_cli_version: ${{ needs.integration-tests.outputs.dm_cli_version }}
       job_version: ${{ needs.integration-tests.outputs.job_version }}
+      update_readme: ${{ needs.integration-tests.result == 'success' }}
 
   release-please:
     needs: tests

--- a/.github/workflows/on-main-push.yaml
+++ b/.github/workflows/on-main-push.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - release
 
 jobs:
   tests:

--- a/.github/workflows/on-main-push.yaml
+++ b/.github/workflows/on-main-push.yaml
@@ -22,7 +22,7 @@ jobs:
       update_readme: ${{ needs.integration-tests.result == 'success' }}
 
   release-please:
-    needs: tests
+    needs: [tests, integration-tests]
     uses: ./.github/workflows/create-release-pr.yaml
 
   publish-packages:

--- a/.github/workflows/publish-integration-tests-report.yaml
+++ b/.github/workflows/publish-integration-tests-report.yaml
@@ -5,17 +5,22 @@ on:
   workflow_call:
     inputs:
       dm_cli_version:
-        description: "DM CLI version used in test"
+        description: 'DM CLI version used in test'
         required: true
         type: string
       dmss_version:
-        description: "DMSS version used in test"
+        description: 'DMSS version used in test'
         required: true
         type: string
       job_version:
-        description: "Job version used in test"
+        description: 'Job version used in test'
         required: true
         type: string
+      update_readme:
+        description: 'If true, update README.md with test details'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   publish_report:
@@ -46,14 +51,14 @@ jobs:
           name: playwright-report
           path: ${{ env.HTML_REPORT_URL_PATH }}
 
-      - name: Add entry to README.md on success
-        if: ${{ success() }} && github.ref == 'refs/heads/main'
+      - name: Add entry to README.md
+        if: inputs.update_readme
         run: |
           echo "* ${{ github.event.head_commit.message }} (${{ github.event.repository.updated_at}})" >> README.md
           echo "  * [Integration tests](https://equinor.github.io/dm-core-packages/$HTML_REPORT_URL_PATH)" >> README.md
           echo "    * **DMSS VERSION**: ${{ inputs.dmss_version }}" >> README.md
           echo "    * **DM CLI VERSION**: ${{ inputs.dm_cli_version }}" >> README.md
-          echo "    * **JOB VERSION**: ${{ inputs.job_version }}" >> README.md          
+          echo "    * **JOB VERSION**: ${{ inputs.job_version }}" >> README.md
 
       - name: Push HTML Report
         timeout-minutes: 3
@@ -97,4 +102,3 @@ jobs:
           echo "- **DMSS VERSION**: ${{ inputs.dmss_version }}" >> $GITHUB_STEP_SUMMARY
           echo "- **DM CLI VERSION**: ${{ inputs.dm_cli_version }}" >> $GITHUB_STEP_SUMMARY
           echo "- **JOB VERSION**: ${{ inputs.job_version }}" >> $GITHUB_STEP_SUMMARY
-


### PR DESCRIPTION
## What does this pull request change?

Fix two bugs in on-main-push
Ensure readme is only updated with the integration test result if it's triggered by push to main and the test is successful

## Why is this pull request needed?

Don't want to spam the readme

## Issues related to this change

Refs #319 

