### PR TITLE
ci: handle concurrency

### DIFF
--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -7,6 +7,10 @@ on:
     tags-ignore:
       - v*
 
+concurrency:
+  group: on-push-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     uses: ./.github/workflows/tests.yaml

--- a/.github/workflows/publish-integration-tests-report.yaml
+++ b/.github/workflows/publish-integration-tests-report.yaml
@@ -22,6 +22,8 @@ jobs:
     name: Publish HTML Report
     # using always() is not ideal here, because it would also run if the workflow was cancelled
     runs-on: ubuntu-latest
+    concurrency:
+      group: publish-integration-tests-report-publish_report
     continue-on-error: true
     env:
       # Unique URL path for each workflow run attempt


### PR DESCRIPTION
## What does this pull request change?

- Add concurrency to on-push. Result is that if I push two times with little time in between, the first job will be cancelled when the second push is done.
- Add concurrency to the publish_report step in publish-integration-tests-report. If the job is running two at the same time, the second will have to wait until the first completes. If three runs at the same time, the first will complete, the second will be cancelled and the third will be pending. This is due to there being no way to have more than one pending job at the time https://github.com/orgs/community/discussions/5435

## Why is this pull request needed?

This issue https://github.com/equinor/dm-core-packages/actions/runs/5412414296/jobs/9836726844

## Issues related to this change

Refs #319 

