### PR TITLE
fix: rename plugin to uiRecipe in widget types

### DIFF
--- a/packages/dm-core-plugins/blueprints/form/fields/ArrayField.json
+++ b/packages/dm-core-plugins/blueprints/form/fields/ArrayField.json
@@ -10,7 +10,7 @@
       "attributeType": "string"
     },
     {
-      "name": "plugin",
+      "name": "uiRecipe",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
       "optional": true,
       "attributeType": "string"

--- a/packages/dm-core-plugins/blueprints/form/fields/ObjectField.json
+++ b/packages/dm-core-plugins/blueprints/form/fields/ObjectField.json
@@ -10,7 +10,7 @@
       "attributeType": "string"
     },
     {
-      "name": "plugin",
+      "name": "uiRecipe",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
       "optional": true,
       "attributeType": "string"

--- a/packages/dm-core-plugins/src/form/types.tsx
+++ b/packages/dm-core-plugins/src/form/types.tsx
@@ -70,12 +70,12 @@ type TAttributeBasis = {
 type TAttributeString = TAttributeBasis & { widget: string; format: string }
 type TAttributeArray = TAttributeBasis & {
   widget?: string
-  plugin?: string
+  uiRecipe?: string
   columns: string[]
 }
 type TAttributeObject = TAttributeBasis & {
   widget?: string
-  plugin?: string
+  uiRecipe?: string
 }
 type TAttributeConfig = TAttributeArray | TAttributeObject | TAttributeString
 export type TConfig = {


### PR DESCRIPTION
## What does this pull request change?

## Why is this pull request needed?

I did a mistake earlier. The string referres to which of the attribute´s recipes should be shown, so "uiRecipe" makes more sense

## Issues related to this change

