### PR TITLE
fix: image platform error

### DIFF
--- a/example/docker-compose.yaml
+++ b/example/docker-compose.yaml
@@ -1,8 +1,9 @@
-version: "3.4"
+version: '3.4'
 
 services:
   dmss:
     image: datamodelingtool.azurecr.io/dmss:latest
+    platform: linux/amd64
     restart: unless-stopped
     environment:
       AUTH_ENABLED: 0
@@ -10,10 +11,10 @@ services:
       MONGO_INITDB_ROOT_USERNAME: maf
       MONGO_INITDB_ROOT_PASSWORD: maf
       SECRET_KEY: sg9aeUM5i1JO4gNN8fQadokJa3_gXQMLBjSGGYcfscs= # Don't reuse this in production...
-#    volumes:
-#      - ../../data-modelling-storage-service/src:/code/src
+    #    volumes:
+    #      - ../../data-modelling-storage-service/src:/code/src
     ports:
-      - "5000:5000"
+      - '5000:5000'
     depends_on:
       - db
 
@@ -28,12 +29,13 @@ services:
 
   job-api:
     image: datamodelingtool.azurecr.io/dm-job
+    platform: linux/amd64
     restart: unless-stopped
     environment:
-      SCHEDULER_ENVS_TO_EXPORT: "PUBLIC_DMSS_API,SIMA_LICENSE"
+      SCHEDULER_ENVS_TO_EXPORT: 'PUBLIC_DMSS_API,SIMA_LICENSE'
       SCHEDULER_REDIS_HOST: job-store
       SCHEDULER_REDIS_PORT: 6379
-      SCHEDULER_REDIS_SSL: "false"
+      SCHEDULER_REDIS_SSL: 'false'
       DMSS_API: http://dmss:5000
       API_DEBUG: 1
       ENVIRONMENT: local
@@ -48,7 +50,7 @@ services:
     volumes:
       - ./job_handlers:/code/src/job_handler_plugins
     ports:
-      - "5001:5000"
+      - '5001:5000'
 
   #  db-ui:
   #    image: mongo-express:1.0.0-alpha
@@ -63,6 +65,6 @@ services:
 
   job-store:
     image: redis:6.2.5-alpine
-    command: "redis-server --save 30 1 --loglevel notice"
+    command: 'redis-server --save 30 1 --loglevel notice'
     #    volumes:
     #     - ./redis_data:/data


### PR DESCRIPTION
## What does this pull request change?
When running "docker compose up" we were receiving two error messages related to image platform:
`! job-api The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested 0.0s`
` ! dmss The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested    0.0s` 

This PR adds `platform: linux/amd64` to the docker-compose file which removes these errors.

## Why is this pull request needed?

## Issues related to this change

