### PR TITLE
refactor: create util for splitting string

### DIFF
--- a/packages/dm-core/src/utils/stringUtilities.test.ts
+++ b/packages/dm-core/src/utils/stringUtilities.test.ts
@@ -1,0 +1,21 @@
+import { splitString } from './stringUtilities'
+
+test('too many hits', () => {
+  const result = splitString('a_b_c_d', '_', 1)
+  expect(result).toEqual(['a', 'b_c_d'])
+})
+
+test('exact number of hits', () => {
+  const result = splitString('a_b', '_', 1)
+  expect(result).toEqual(['a', 'b'])
+})
+
+test('missing string after split', () => {
+  const result = splitString('a_', '_', 1)
+  expect(result).toEqual(['a', ''])
+})
+
+test('too few hits', () => {
+  const result = splitString('', '_', 1)
+  expect(result).toEqual([''])
+})

--- a/packages/dm-core/src/utils/stringUtilities.ts
+++ b/packages/dm-core/src/utils/stringUtilities.ts
@@ -1,0 +1,16 @@
+/**
+ * Split an array like you would in python
+ * @param target The string you want to split
+ * @param separator Delimiter at which splits occur
+ * @param maxsplit Maximum number of splits
+ * @returns An array of max length maxsplit + 1
+ */
+export const splitString = (
+  target: string,
+  separator: string,
+  maxsplit: number
+) => {
+  const arr = target.split(separator)
+  if (arr.slice(maxsplit).length == 0) return arr
+  return [...arr.slice(0, maxsplit), arr.slice(maxsplit).join(separator)]
+}


### PR DESCRIPTION
## What does this pull request change?

Makes a string split function that equals python built-in function

## Why is this pull request needed?

JS built-in string split has the limit attribute, which basically just removes the last elements in the array so that its length becomes equal to limit. In comparison, python string split has the maxsplit attribute, which can be quite handy sometimes.

## Issues related to this change

