### PR TITLE
fix: relative reference bug in form

### DIFF
--- a/example/src/plugins/job-ui-single/pages/CreateJobEntity.tsx
+++ b/example/src/plugins/job-ui-single/pages/CreateJobEntity.tsx
@@ -1,15 +1,15 @@
 import {
   EBlueprint,
   ErrorResponse,
-  TJob,
-  TGenericObject,
   Stack,
-  getDataSourceIdFromAddress,
+  TGenericObject,
+  TJob,
+  splitAddress,
   useDMSS,
 } from '@development-framework/dm-core'
 import { Button } from '@equinor/eds-core-react'
-import React, { useState } from 'react'
 import { AxiosError, AxiosResponse } from 'axios'
+import React, { useState } from 'react'
 import { JobForm } from './JobForm'
 
 type TCreateJobEntityProps = {
@@ -47,7 +47,7 @@ export const CreateJobEntity = (props: TCreateJobEntityProps) => {
   const destinationIsAPackage: boolean = !(
     jobEntityDestination.includes('.') || jobEntityDestination.includes('[')
   )
-  const dataSourceId: string = getDataSourceIdFromAddress(jobEntityDestination)
+  const { dataSource: dataSourceId } = splitAddress(jobEntityDestination)
   const [createdJobEntity, setCreatedJobEntity] = useState<TGenericObject>()
 
   const createJobEntity = (jobEntityFormData: TJob) => {

--- a/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
@@ -9,6 +9,8 @@ import {
   TAttribute,
   TBlueprint,
   TLinkReference,
+  resolveRelativeAddress,
+  splitAddress,
   useBlueprint,
   useDMSS,
 } from '@development-framework/dm-core'
@@ -279,7 +281,6 @@ export const UncontainedAttribute = (props: TContentProps): JSX.Element => {
   const { getValues, control, setValue } = useFormContext()
   const { idReference, onOpen } = useRegistryContext()
   const initialValue = getValues(namePath)
-  const dataSourceId = idReference?.split('/', 2)[0]
 
   return (
     <Stack spacing={0.5}>
@@ -292,11 +293,13 @@ export const UncontainedAttribute = (props: TContentProps): JSX.Element => {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           field: { onChange, value },
         }) => {
-          // Note: address using path does not work.
-          // The address needs to use data source ID.
-          const id = `${dataSourceId}/${value?.address}`
-
           if (value && value.address && value.referenceType === 'link') {
+            const { dataSource, documentPath } = splitAddress(idReference)
+            const id = resolveRelativeAddress(
+              value.address,
+              documentPath,
+              dataSource
+            )
             return (
               <div>
                 <Stack spacing={0.25} alignItems="flex-start">

--- a/packages/dm-core/src/utils/addressUtilities.test.ts
+++ b/packages/dm-core/src/utils/addressUtilities.test.ts
@@ -1,0 +1,116 @@
+import { resolveRelativeAddress, splitAddress } from './addressUtilities'
+
+test('split dmss://test_source/complex/myCarRental.cars[0].engine', async () => {
+  const { protocol, dataSource, documentPath, attributePath } = splitAddress(
+    'dmss://test_source/complex/myCarRental.cars[0].engine'
+  )
+  expect(protocol).toBe('dmss')
+  expect(dataSource).toBe('test_source')
+  expect(documentPath).toBe('complex/myCarRental')
+  expect(attributePath).toBe('cars[0].engine')
+})
+
+test('split dmss://test_source/$1.cars[0]', async () => {
+  const { protocol, dataSource, documentPath, attributePath } = splitAddress(
+    'dmss://test_source/$1.cars[0]'
+  )
+  expect(protocol).toBe('dmss')
+  expect(dataSource).toBe('test_source')
+  expect(documentPath).toBe('$1')
+  expect(attributePath).toBe('cars[0]')
+})
+
+test('split dmss://test_source/$1', async () => {
+  const { protocol, dataSource, documentPath, attributePath } = splitAddress(
+    'dmss://test_source/$1'
+  )
+  expect(protocol).toBe('dmss')
+  expect(dataSource).toBe('test_source')
+  expect(documentPath).toBe('$1')
+  expect(attributePath).toBe('')
+})
+
+test('split dmss://test_source', async () => {
+  const { protocol, dataSource, documentPath, attributePath } =
+    splitAddress('dmss://test_source')
+  expect(protocol).toBe('dmss')
+  expect(dataSource).toBe('test_source')
+  expect(documentPath).toBe('')
+  expect(attributePath).toBe('')
+})
+
+test('split /test_source/$1', async () => {
+  const { protocol, dataSource, documentPath, attributePath } =
+    splitAddress('/test_source/$1')
+  expect(protocol).toBe('')
+  expect(dataSource).toBe('test_source')
+  expect(documentPath).toBe('$1')
+  expect(attributePath).toBe('')
+})
+
+test('split test_source/$1', async () => {
+  const { protocol, dataSource, documentPath, attributePath } =
+    splitAddress('test_source/$1')
+  expect(protocol).toBe('')
+  expect(dataSource).toBe('test_source')
+  expect(documentPath).toBe('$1')
+  expect(attributePath).toBe('')
+})
+
+test('resolve address with ^', () => {
+  const resolved = resolveRelativeAddress('^.cars[0]', '$1', 'test_source')
+  expect(resolved).toBe('/test_source/$1.cars[0]')
+})
+
+test('resolve address with multiple attributes', () => {
+  const resolved = resolveRelativeAddress(
+    '$2.cars[0].engine',
+    '$1',
+    'test_source'
+  )
+  expect(resolved).toBe('/test_source/$2.cars[0].engine')
+})
+
+test('resolve address with no attributes', () => {
+  const resolved = resolveRelativeAddress('$2', '$1', 'test_source')
+  expect(resolved).toBe('/test_source/$2')
+})
+
+test('resolve address with id', () => {
+  const resolved = resolveRelativeAddress('$2.cars[0]', '$1', 'test_source')
+  expect(resolved).toBe('/test_source/$2.cars[0]')
+})
+
+test('resolve address with slash and id', () => {
+  const resolved = resolveRelativeAddress('/$2.cars[0]', '$1', 'test_source')
+  expect(resolved).toBe('/test_source/$2.cars[0]')
+})
+
+test('resolve address with query', () => {
+  const resolved = resolveRelativeAddress(
+    '/[(_id=1)].content[(name=myCarRental)].cars[0]',
+    '$1',
+    'test_source'
+  )
+  expect(resolved).toBe(
+    '/test_source/[(_id=1)].content[(name=myCarRental)].cars[0]'
+  )
+})
+
+test('resolve address with package path', () => {
+  const resolved = resolveRelativeAddress(
+    'complex/myCarRental.cars[0]',
+    '$1',
+    'test_source'
+  )
+  expect(resolved).toBe('/test_source/complex/myCarRental.cars[0]')
+})
+
+test('resolve address with data source', () => {
+  const resolved = resolveRelativeAddress(
+    'dmss://other_source/$2.cars[0]',
+    '$1',
+    'test_source'
+  )
+  expect(resolved).toBe('dmss://other_source/$2.cars[0]')
+})

--- a/packages/dm-core/src/utils/addressUtilities.ts
+++ b/packages/dm-core/src/utils/addressUtilities.ts
@@ -1,14 +1,49 @@
+import { splitString } from './stringUtilities'
+
 /**
- * An utility function to find dataSourceId from an address
+ * Splits an address into its respective parts
  *
- * @param address an address on the format: PROTOCOL://DATA SOURCE/<path> or DATA SOURCE/<path> or /DATA SOURCE/<path>
+ * @param address An absolute address. Valid formats include (both DOCUMENT_PATH and ATTRIBUTE_PATH is optional):
+ *  PROTOCOL://DATA_SOURCE/DOCUMENT_PATH.ATTRIBUTE_PATH
+ *  /DATA_SOURCE/DOCUMENT_PATH.ATTRIBUTE_PATH
+ *  DATA_SOURCE/DOCUMENT_PATH.ATTRIBUTE_PATH
  */
-export function getDataSourceIdFromAddress(address: string): string {
-  if (address.includes('://')) {
-    return address.split('/', 3)[2]
-  } else if (address[0] === '/') {
-    return address.split('/', 2)[1]
-  } else {
-    return address.split('/', 2)[0]
-  }
+export const splitAddress = (address: string) => {
+  const protocol = address.includes('://') ? address.split('://', 1)[0] : ''
+  const addressWithoutProtocol = address.includes('://')
+    ? address.split('://', 2)[1]
+    : address.replace(/^[/. ]+|[/. ]+$/g, '')
+  const [dataSource, path] = addressWithoutProtocol.includes('/')
+    ? splitString(addressWithoutProtocol, '/', 1)
+    : [addressWithoutProtocol, '']
+  const [documentPath, attributePath] = path.includes('.')
+    ? splitString(path, '.', 1)
+    : [path, '']
+  return { protocol, dataSource, documentPath, attributePath }
+}
+
+/**
+ *
+ * @param address A relative address. Valid formats include (ATTRIBUTE_PATH is optional):
+ * PROTOCOL://DATA_SOURCE/DOCUMENT_PATH.ATTRIBUTE_PATH
+ * /DOCUMENT_PATH.ATTRIBUTE_PATH
+ * DOCUMENT_PATH.ATTRIBUTE_PATH
+ * ^.ATTRIBUTE_PATH
+ * @param fallbackDocumentPath
+ * @param dataSource
+ * @returns
+ */
+export const resolveRelativeAddress = (
+  address: string,
+  fallbackDocumentPath: string,
+  dataSource: string
+) => {
+  address = address.replace(/^[/. ]+|[/. ]+$/g, '')
+  if (address.includes('://')) return address
+  const [documentPath, attributePath] = address.includes('.')
+    ? splitString(address, '.', 1)
+    : [address, '']
+  return `/${dataSource}/${
+    documentPath == '^' ? fallbackDocumentPath : documentPath
+  }${attributePath ? '.' + attributePath : ''}`
 }


### PR DESCRIPTION
## What does this pull request change?

Adds general utils for splitting an address into its parts and for resolving a relative address into an absolute address
Uses this utils to solve a bug in form. The bug caused issues with opening uncontained references with relative paths

## Why is this pull request needed?

## Issues related to this change

Refs #276

