### PR TITLE
test: e2e for nested form

### DIFF
--- a/e2e/tests/plugin-form-Nested.spec.ts
+++ b/e2e/tests/plugin-form-Nested.spec.ts
@@ -8,9 +8,12 @@ test('Nested Form', async ({ page }) => {
   await page.getByText('nested', { exact: true }).click()
   await page.getByText('DemoDataSource/$Nested').click()
 
-  //A nested object
+  //Change owner
   await expect(page.getByText('Owner', { exact: true })).toBeVisible
-  await page.getByRole('button', { name: 'Open' }).first().click()
+  await page
+    .getByText('OwnerOpen')
+    .getByRole('button', { name: 'Open' })
+    .click()
   await page.getByLabel('Name').fill('Jacob')
   await page.getByLabel('Phone Number (optional)').fill('1234')
   await page.getByRole('button', { name: 'Submit' }).click()
@@ -18,4 +21,112 @@ test('Nested Form', async ({ page }) => {
   await page.getByRole('button', { name: 'Open' }).first().click()
   await expect(page.getByLabel('Name')).toHaveValue('Jacob')
   await expect(page.getByLabel('Phone Number (optional)')).toHaveValue('1234')
+  await page.getByRole('tab').nth(2).click()
+
+  //Hiring a CEO
+  await page
+    .getByText('CEO (optional)Add')
+    .getByRole('button', { name: 'Add' })
+    .click()
+  await page
+    .getByText('CEO (optional)Open')
+    .getByRole('button', { name: 'Open' })
+    .click()
+  await page.getByLabel('Name').fill('Donald')
+  await page.getByLabel('Phone Number (optional)').fill('99887766')
+  await page.getByRole('button', { name: 'Submit' }).click()
+  await page.getByRole('tab').nth(2).click()
+  await page
+    .getByText('CEO (optional)Open')
+    .getByRole('button', { name: 'Open' })
+    .click()
+  await expect(page.getByLabel('Name')).toHaveValue('Donald')
+  await expect(page.getByLabel('Phone Number (optional)')).toHaveValue(
+    '99887766'
+  )
+  await page.getByRole('tab').nth(2).click()
+
+  //Replacing accountant
+  await page
+    .getByText('AccountantOpen')
+    .getByRole('button', { name: 'Open' })
+    .click()
+  await page.getByLabel('Name').fill('Richie')
+  await page.getByLabel('Phone Number (optional)').fill('11223344')
+  await page.getByRole('button', { name: 'Submit' }).click()
+  await page.getByText('self').first().click()
+  await page.getByRole('tab').nth(2).click()
+  await page
+    .getByText('AccountantOpen')
+    .getByRole('button', { name: 'Open' })
+    .click()
+  await expect(page.getByLabel('Name')).toHaveValue('Richie')
+  await expect(page.getByLabel('Phone Number (optional)')).toHaveValue(
+    '11223344'
+  )
+  await page.getByRole('tab').nth(2).click()
+
+  //New car
+  await page.getByText('CarsOpen').getByRole('button', { name: 'Open' }).click()
+  await expect.soft(page.getByText('1 - 2 of 2')).toBeVisible()
+  await page.getByRole('button', { name: 'Append Add Item' }).click()
+  await expect.soft(page.getByText('1 - 3 of 3')).toBeVisible()
+  await page.getByRole('button', { name: 'Save' }).click()
+  await page
+    .locator('div:nth-child(5) > div > .Button__ButtonBase-sc-1hs0myn-1')
+    .click()
+  await page.getByLabel('Name').fill('McLaren')
+  await page.getByLabel('Plate Number').fill('3000')
+  await page.getByRole('button', { name: 'Submit' }).click()
+  await page.reload()
+  await page.getByText('plugins', { exact: true }).click()
+  await page.getByText('form').click()
+  await page.getByText('nested').click()
+  await page.getByText('DemoDataSource/$Nested').click()
+  await page.getByText('CarsOpen').getByRole('button', { name: 'Open' }).click()
+  // await expect(page.getByText('McLaren')).toBeVisible() Does not work because two instances are stored when submitting form... Known bug.
+  await page
+    .locator('div:nth-child(5) > div > .Button__ButtonBase-sc-1hs0myn-1')
+    .click()
+  await expect(page.getByRole('tab', { name: 'McLaren' })).toBeVisible()
+  await expect(page.getByLabel('Name')).toHaveValue('McLaren')
+  await expect(page.getByLabel('Plate Number')).toHaveValue('3000')
+  await page.getByRole('tab').last().click()
+  await page.getByRole('tab').last().click()
+
+  //New customer
+  await page
+    .getByText('CustomersOpen')
+    .getByRole('button', { name: 'Open' })
+    .click()
+  await expect.soft(page.getByText('1 - 2 of 2')).toBeVisible()
+  await page.getByRole('button', { name: 'Append Add Item' }).click()
+  await expect.soft(page.getByText('1 - 3 of 3')).toBeVisible()
+  await page.getByRole('button', { name: 'Save' }).click()
+  await page
+    .locator('div:nth-child(5) > div > .Button__ButtonBase-sc-1hs0myn-1')
+    .click()
+  await page.getByLabel('Name').fill('Lewis')
+  await page.getByLabel('Phone number (optional)').fill('12345678')
+  await page.getByRole('button', { name: 'Submit' }).click()
+  await page.reload()
+  await page.getByText('plugins', { exact: true }).click()
+  await page.getByText('form').click()
+  await page.getByText('nested').click()
+  await page.getByText('DemoDataSource/$Nested').click()
+  await page
+    .getByText('CustomersOpen')
+    .getByRole('button', { name: 'Open' })
+    .click()
+  // await expect(page.getByText('Lewis')).toBeVisible() Does not work because two instances are stored when submitting form... Known bug.
+  await page
+    .locator('div:nth-child(5) > div > .Button__ButtonBase-sc-1hs0myn-1')
+    .click()
+  await expect(page.getByRole('tab', { name: 'Lewis' })).toBeVisible()
+  await expect(page.getByLabel('Name')).toHaveValue('Lewis')
+  await expect(page.getByLabel('Phone number (optional)')).toHaveValue(
+    '12345678'
+  )
+  await page.getByRole('tab').last().click()
+  await page.getByRole('tab').last().click()
 })

--- a/example/app/data/DemoDataSource/plugins/form/nested/blueprints/Car.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/form/nested/blueprints/Car.blueprint.json
@@ -6,7 +6,7 @@
     {
       "name": "plateNumber",
       "type": "CORE:BlueprintAttribute",
-      "attributeType": "number",
+      "attributeType": "string",
       "label": "Plate Number",
       "optional": false
     }

--- a/example/app/data/DemoDataSource/plugins/form/nested/myCarRentalCompany.entity.json
+++ b/example/app/data/DemoDataSource/plugins/form/nested/myCarRentalCompany.entity.json
@@ -19,12 +19,12 @@
   "cars": [
     {
       "type": "./blueprints/Car",
-      "plateNumber": 1337,
+      "plateNumber": "1337",
       "name": "Volvo"
     },
     {
       "type": "./blueprints/Car",
-      "plateNumber": 1337,
+      "plateNumber": "F1337",
       "name": "Ferrari"
     }
   ],

--- a/example/app/data/DemoDataSource/recipes/plugins/form/nested/car.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/nested/car.recipe.json
@@ -1,0 +1,9 @@
+{
+  "type": "CORE:RecipeLink",
+  "_blueprintPath_": "/plugins/form/nested/blueprints/Car",
+  "initialUiRecipe": {
+    "name": "form",
+    "type": "CORE:UiRecipe",
+    "plugin": "@development-framework/dm-core-plugins/form"
+  }
+}

--- a/example/app/data/DemoDataSource/recipes/plugins/form/nested/customer.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/nested/customer.recipe.json
@@ -1,0 +1,9 @@
+{
+  "type": "CORE:RecipeLink",
+  "_blueprintPath_": "/plugins/form/nested/blueprints/Customer",
+  "initialUiRecipe": {
+    "name": "form",
+    "type": "CORE:UiRecipe",
+    "plugin": "@development-framework/dm-core-plugins/form"
+  }
+}


### PR DESCRIPTION
## What does this pull request change?
Added e2e-test for nested form example.
Added recipe for car and customer.
Some minor changes to blueprint and entity.

## Why is this pull request needed?

## Issues related to this change
There is a known bug when saving the form, which causes an item to be saved twice when creating/editing. Some lines of the e2e-test have therefore been commented out.

