### PR TITLE
feat: allow form field filtering

### DIFF
--- a/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/signals_simple/case.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/signals_simple/case.recipe.json
@@ -85,7 +85,11 @@
       "type": "CORE:UiRecipe",
       "name": "Edit",
       "description": "Default edit",
-      "plugin": "@development-framework/dm-core-plugins/form"
+      "plugin": "@development-framework/dm-core-plugins/form",
+      "config": {
+        "type": "PLUGINS:dm-core-plugins/form/FormInput",
+        "fields": ["name", "description", "duration", "timeStep", "components"]
+      }
     },
     {
       "type": "CORE:UiRecipe",

--- a/example/app/data/DemoDataSource/recipes/plugins/form/nested/carRentalCompany.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/nested/carRentalCompany.recipe.json
@@ -40,7 +40,14 @@
             "uiRecipe": "defaultYaml"
           }
         ],
-        "order": ["owner", "*", "bestCustomer"]
+        "fields": [
+          "owner",
+          "ceo",
+          "accountant",
+          "bestCustomer",
+          "cars",
+          "customers"
+        ]
       }
     }
   ]

--- a/packages/dm-core-plugins/blueprints/form/FormInput.json
+++ b/packages/dm-core-plugins/blueprints/form/FormInput.json
@@ -12,13 +12,13 @@
       "contained": true
     },
     {
-      "name": "order",
+      "name": "fields",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
       "attributeType": "string",
       "dimensions": "*",
       "optional": true,
       "contained": true,
-      "description": "Define the order in which attributes are rendered"
+      "description": "Define which attributes should be shown, and in what order"
     }
   ]
 }

--- a/packages/dm-core-plugins/src/form/Form.test.tsx
+++ b/packages/dm-core-plugins/src/form/Form.test.tsx
@@ -119,7 +119,7 @@ describe('Form', () => {
             widget: 'TextWidget', // TODO TextareaWidget is not implemented it seems like...
           },
         ],
-        order: [],
+        fields: [],
       }
 
       const { container } = render(

--- a/packages/dm-core-plugins/src/form/FormPlugin.tsx
+++ b/packages/dm-core-plugins/src/form/FormPlugin.tsx
@@ -6,7 +6,7 @@ import { TConfig } from './types'
 
 export const defaultConfig: TConfig = {
   attributes: [],
-  order: [],
+  fields: [],
 }
 
 export const FormPlugin = (props: IUIPlugin) => {

--- a/packages/dm-core-plugins/src/form/README.md
+++ b/packages/dm-core-plugins/src/form/README.md
@@ -19,3 +19,11 @@ The form is made up from fields and widgets:
 
 The attribute field selects correct fields for each attribute.
 
+When displaying an entity, the Form plugin will fetch the blueprint for that entity and display all fields. However, it
+is possible to control what fields to show, and in what order,
+inside the Form's UI recipe config:
+
+The `fields` attribute is a list of fields to include in the form. If no `fields` attribute is included in the config,
+all fields will be shown as default. The order or attributes displayed in the Form plugin will be equal to the order of
+attributes defined in the  `fields` list.
+

--- a/packages/dm-core-plugins/src/form/fields/ObjectField.test.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ObjectField.test.tsx
@@ -69,7 +69,7 @@ test('should show foo after bar if order states it', async () => {
   const utils = await setupSimple({
     idReference: 'ds/$1',
     type: 'MyBlueprint',
-    config: { attributes: [], order: ['bar', 'foo'] },
+    config: { attributes: [], fields: ['bar', 'foo'] },
   })
   expect(utils.fooInput.compareDocumentPosition(utils.barInput)).toBe(
     Node.DOCUMENT_POSITION_PRECEDING

--- a/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
@@ -148,13 +148,15 @@ const AttributeList = (props: {
   const filteredAttributes =
     config && config.fields.length
       ? config.fields
-          .map((name: string) => attributes.find((x) => x.name == name))
+          .map((name: string) =>
+            attributes.find((attribute) => attribute.name == name)
+          )
           .filter((attribute): attribute is TAttribute => !!attribute)
       : attributes
 
   const attributeFields = filteredAttributes.map((attribute) => {
     const uiAttribute = config?.attributes.find(
-      (uiAttribute: any) => uiAttribute.name === attribute.name
+      (uiAttribute) => uiAttribute.name === attribute.name
     )
     return (
       <AttributeField

--- a/packages/dm-core-plugins/src/form/types.tsx
+++ b/packages/dm-core-plugins/src/form/types.tsx
@@ -80,7 +80,7 @@ type TAttributeObject = TAttributeBasis & {
 type TAttributeConfig = TAttributeArray | TAttributeObject | TAttributeString
 export type TConfig = {
   attributes: TAttributeConfig[]
-  order: string[]
+  fields: string[]
 }
 
 export type TUiRecipeForm = Omit<TUiRecipe, 'config'> & { config: TConfig }


### PR DESCRIPTION
## What does this pull request change?

Replace the order config with a fields config, that can be used both to order and to filter the form fields. If no config.fields is given, all fields are shown in the order of the blueprint

## Why is this pull request needed?

Blueprints often has a lot of meta info that does not need to be presented in a form. Being able to filter the attributes is important

## Issues related to this change

Refs #276

