### PR TITLE
fix: added title to expand-minimize button

### DIFF
--- a/e2e/tests/plugin-form-Nested.spec.ts
+++ b/e2e/tests/plugin-form-Nested.spec.ts
@@ -72,9 +72,7 @@ test('Nested Form', async ({ page }) => {
   await page.getByRole('button', { name: 'Append Add Item' }).click()
   await expect.soft(page.getByText('1 - 3 of 3')).toBeVisible()
   await page.getByRole('button', { name: 'Save' }).click()
-  await page
-    .locator('div:nth-child(5) > div > .Button__ButtonBase-sc-1hs0myn-1')
-    .click()
+  await page.getByRole('button', { name: 'Open item' }).last().click()
   await page.getByLabel('Name').fill('McLaren')
   await page.getByLabel('Plate Number').fill('3000')
   await page.getByRole('button', { name: 'Submit' }).click()
@@ -85,9 +83,7 @@ test('Nested Form', async ({ page }) => {
   await page.getByText('DemoDataSource/$Nested').click()
   await page.getByText('CarsOpen').getByRole('button', { name: 'Open' }).click()
   // await expect(page.getByText('McLaren')).toBeVisible() Does not work because two instances are stored when submitting form... Known bug.
-  await page
-    .locator('div:nth-child(5) > div > .Button__ButtonBase-sc-1hs0myn-1')
-    .click()
+  await page.getByRole('button', { name: 'Open item' }).last().click()
   await expect(page.getByRole('tab', { name: 'McLaren' })).toBeVisible()
   await expect(page.getByLabel('Name')).toHaveValue('McLaren')
   await expect(page.getByLabel('Plate Number')).toHaveValue('3000')
@@ -103,9 +99,7 @@ test('Nested Form', async ({ page }) => {
   await page.getByRole('button', { name: 'Append Add Item' }).click()
   await expect.soft(page.getByText('1 - 3 of 3')).toBeVisible()
   await page.getByRole('button', { name: 'Save' }).click()
-  await page
-    .locator('div:nth-child(5) > div > .Button__ButtonBase-sc-1hs0myn-1')
-    .click()
+  await page.getByRole('button', { name: 'Open item' }).last().click()
   await page.getByLabel('Name').fill('Lewis')
   await page.getByLabel('Phone number (optional)').fill('12345678')
   await page.getByRole('button', { name: 'Submit' }).click()
@@ -119,9 +113,7 @@ test('Nested Form', async ({ page }) => {
     .getByRole('button', { name: 'Open' })
     .click()
   // await expect(page.getByText('Lewis')).toBeVisible() Does not work because two instances are stored when submitting form... Known bug.
-  await page
-    .locator('div:nth-child(5) > div > .Button__ButtonBase-sc-1hs0myn-1')
-    .click()
+  await page.getByRole('button', { name: 'Open item' }).last().click()
   await expect(page.getByRole('tab', { name: 'Lewis' })).toBeVisible()
   await expect(page.getByLabel('Name')).toHaveValue('Lewis')
   await expect(page.getByLabel('Phone number (optional)')).toHaveValue(

--- a/packages/dm-core-plugins/src/list/ListPlugin.tsx
+++ b/packages/dm-core-plugins/src/list/ListPlugin.tsx
@@ -199,7 +199,10 @@ export const ListPlugin = (props: IUIPlugin & { config?: TListConfig }) => {
                       : () => openItemAsTab(item)
                   }
                 >
-                  <Icon data={item.expanded ? minimize : add} />
+                  <Icon
+                    data={item.expanded ? minimize : add}
+                    title={item.expanded ? 'Close item' : 'Open item'}
+                  />
                 </Button>
               </Tooltip>
               {internalConfig.headers.map(


### PR DESCRIPTION
## What does this pull request change?
Added title to the expand and minimize button for list plugin.

Updated e2e-test to utilise changes.

## Why is this pull request needed?
Makes it much easier and prettier when writing e2e-tests where the expand/minimise button is used.

Expand-button is also used when opening in a new tab from list plugin. The changes also apply in this case, as shown in the updated e2e-test.

## Issues related to this change

