### PR TITLE
Fix/enable job form in create job entity

### DIFF
--- a/example/app/data/DemoDataSource/apps/MySignalApp/instances/exampleRunner.entity.json
+++ b/example/app/data/DemoDataSource/apps/MySignalApp/instances/exampleRunner.entity.json
@@ -1,0 +1,3 @@
+{
+  "type": "dmss://DemoDataSource/apps/MySignalApp/models/SignalGeneratorJob"
+}

--- a/example/src/plugins/job-ui-single/pages/CreateJobEntity.tsx
+++ b/example/src/plugins/job-ui-single/pages/CreateJobEntity.tsx
@@ -29,8 +29,6 @@ type TCreateJobEntityProps = {
 
  * @param jobEntityDestination Where job entity will be uploaded. Must be an address, either to a Package (PROTOCOL://DATA SOURCE/ROOT PACKAGE/SUB PACKAGE) or to an attribute inside an object (PROTOCOL://DATA SOURCE/$123-123-123.list[2].job).
  * @param onCreate Function to run when Job entity is created.
- * @param jobRunnerType Type of job runner to add to the Job entity (for example dmss://DemoDataSource/apps/MySignalApp/models/SignalGeneratorJob)
- * @param applicationInputType Type of applicationInput to add to the Job entity.
  * @param defaultJobEntity An optional default entity.
  * @param defaultJobOutputTarget An optional value for outputTarget in the job entity to create. This value is used in the job handler to specify where results of the job should be uploaded/inserted.
  */

--- a/example/src/plugins/job-ui-single/pages/CreateJobEntity.tsx
+++ b/example/src/plugins/job-ui-single/pages/CreateJobEntity.tsx
@@ -14,7 +14,6 @@ import { JobForm } from './JobForm'
 
 type TCreateJobEntityProps = {
   jobEntityDestination: string
-  applicationInputType: string
   defaultJobEntity?: TJob
   onCreate: (jobEntityId: string) => void
   defaultJobOutputTarget?: string
@@ -40,7 +39,6 @@ export const CreateJobEntity = (props: TCreateJobEntityProps) => {
     jobEntityDestination,
     onCreate,
     defaultJobEntity,
-    applicationInputType,
     defaultJobOutputTarget,
   } = props
 
@@ -85,15 +83,6 @@ export const CreateJobEntity = (props: TCreateJobEntityProps) => {
     }
   }
 
-  if (!defaultJobEntity) {
-    return (
-      <p style={{ color: 'red' }}>
-        Creating a new job entity is not supported. Please supply a
-        defaultJobEntity instead. (The entity picker button needs to be able to
-        pick attributes inside an entity document before entity creation works).
-      </p>
-    )
-  }
   if (createdJobEntity) {
     return (
       <>
@@ -125,7 +114,6 @@ export const CreateJobEntity = (props: TCreateJobEntityProps) => {
             onSubmit={(jobEntityFormData: TJob) => {
               createJobEntity(jobEntityFormData as TJob)
             }}
-            applicationInputType={applicationInputType}
             defaultJobOutputTarget={defaultJobOutputTarget}
           />
         )}

--- a/example/src/plugins/job-ui-single/pages/JobForm.tsx
+++ b/example/src/plugins/job-ui-single/pages/JobForm.tsx
@@ -23,13 +23,11 @@ import React, { ChangeEvent, useState } from 'react'
  *
  * @param onSubmit Function to run when Job is submitted.
  * @param jobRunnerType Type of job runner to add to the Job entity (for example dmss://DemoDataSource/apps/MySignalApp/models/SignalGeneratorJob)
- * @param applicationInputType Type of applicationInput to add to the Job entity.
  * @param defaultJobOutputTarget An optional value for outputTarget in the job entity to create. This value is used in the job handler to specify where results of the job should be uploaded/inserted.
 
  */
 export const JobForm = (props: {
   onSubmit: (job: TJob) => void
-  applicationInputType: string
   defaultJobOutputTarget?: string
 }) => {
   const defaultJobValues: TJob = {

--- a/example/src/plugins/job-ui-single/pages/JobForm.tsx
+++ b/example/src/plugins/job-ui-single/pages/JobForm.tsx
@@ -22,7 +22,6 @@ import React, { ChangeEvent, useState } from 'react'
  * The user must select type for the 'runner' with a BlueprintPicker, and the user must select a reference to use as 'applciationInput'.
  *
  * @param onSubmit Function to run when Job is submitted.
- * @param jobRunnerType Type of job runner to add to the Job entity (for example dmss://DemoDataSource/apps/MySignalApp/models/SignalGeneratorJob)
  * @param defaultJobOutputTarget An optional value for outputTarget in the job entity to create. This value is used in the job handler to specify where results of the job should be uploaded/inserted.
 
  */

--- a/example/src/plugins/job-ui-single/pages/JobPlugin.tsx
+++ b/example/src/plugins/job-ui-single/pages/JobPlugin.tsx
@@ -69,10 +69,9 @@ export const JobPlugin = (props: IUIPlugin) => {
       {/*TODO have a way to check if an entity of type job already exists in 'jobEntityDestination'. Must scan content of entire package if jobEntityDestination is a package, but its simpler to check if jobEntityDestination is refering to an object's attribute. */}
       <CreateJobEntity
         jobEntityDestination={jobEntityDestination}
-        applicationInputType={`dmss://DemoDataSource/apps/MySignalApp/models/CaseInput`}
         onCreate={(jobEntityId: string) => setJobEntityId(jobEntityId)}
         defaultJobOutputTarget={props.idReference + '.signal'}
-        defaultJobEntity={defaultContainerJobEntity}
+        defaultJobEntity={defaultJobEntity}
       />
       {jobEntityId && <JobControl jobEntityId={jobEntityId} />}
     </div>

--- a/packages/dm-core/src/components/Pickers/EntityPickerButton.tsx
+++ b/packages/dm-core/src/components/Pickers/EntityPickerButton.tsx
@@ -72,13 +72,12 @@ export const EntityPickerButton = (props: {
       .fetch()
       .then((doc: any) => {
         setShowModal(false)
-
         onChange(
           returnLinkReference
             ? {
                 type: EBlueprint.REFERENCE,
                 referenceType: 'link',
-                address: `dmss://$${selectedTreeNode.nodeId}`,
+                address: `dmss://${selectedTreeNode.nodeId}`,
               }
             : doc
         )


### PR DESCRIPTION
## What does this pull request change?

- Enable the form for creating a job entity
- fix but in EntityPickerButton
![image](https://github.com/equinor/dm-core-packages/assets/69512295/d6a2e6e2-ec9b-423c-addf-b020550e0a39)


## Issues related to this change
#280 
