### PR TITLE
fix: add correct titles to list item buttons

### DIFF
--- a/packages/dm-core-plugins/src/list/Components.tsx
+++ b/packages/dm-core-plugins/src/list/Components.tsx
@@ -36,6 +36,8 @@ export const ListItemButton = (props: {
     up: chevron_up,
     down: chevron_down,
   }
+  const iconTitle =
+    type === 'up' ? 'Move up' : type === 'down' ? 'Move Down' : 'Delete'
   return (
     <EdsProvider density="compact">
       <Button
@@ -44,7 +46,7 @@ export const ListItemButton = (props: {
         variant="ghost_icon"
         onClick={props.onClick}
       >
-        <Icon data={ICONS[type]} title="Move up" />
+        <Icon data={ICONS[type]} title={iconTitle} />
       </Button>
     </EdsProvider>
   )


### PR DESCRIPTION
## What does this pull request change?
Added correct titles to each of the list item buttons.

## Why is this pull request needed?
The "up", "down" and "delete" buttons had the same title ("Move up").

## Issues related to this change

