### PR TITLE
Refactor/easier plugin import v2

### DIFF
--- a/example/src/plugins.js
+++ b/example/src/plugins.js
@@ -1,6 +1,6 @@
-import { plugins as dmCorePlugins } from '@development-framework/dm-core-plugins'
-import { plugins as jobPlugin } from './plugins/job-ui-single'
-import { plugins as marmoPlugins } from './plugins/marmo-ui'
+import dmCorePlugins from '@development-framework/dm-core-plugins'
+import jobPlugin from './plugins/job-ui-single'
+import marmoPlugins from './plugins/marmo-ui'
 
 export default {
   ...dmCorePlugins,

--- a/example/src/plugins.js
+++ b/example/src/plugins.js
@@ -1,5 +1,9 @@
-export default [
-  import('@development-framework/dm-core-plugins'),
-  import('./plugins/job-ui-single'),
-  import('./plugins/marmo-ui'),
-]
+import { plugins as dmCorePlugins } from '@development-framework/dm-core-plugins'
+import { plugins as jobPlugin } from './plugins/job-ui-single'
+import { plugins as marmoPlugins } from './plugins/marmo-ui'
+
+export default {
+  ...dmCorePlugins,
+  ...jobPlugin,
+  ...marmoPlugins,
+}

--- a/example/src/plugins/job-ui-single/index.tsx
+++ b/example/src/plugins/job-ui-single/index.tsx
@@ -1,8 +1,8 @@
 import { TUiPluginMap } from '@development-framework/dm-core'
 import { JobPlugin } from './pages/JobPlugin'
 
-export const plugins: TUiPluginMap = {
+export default {
   'signal-job-single': {
     component: JobPlugin,
   },
-}
+} as TUiPluginMap

--- a/example/src/plugins/job-ui-single/index.tsx
+++ b/example/src/plugins/job-ui-single/index.tsx
@@ -1,9 +1,9 @@
-import { TPlugin } from '@development-framework/dm-core'
+import { TUiPluginMap } from '@development-framework/dm-core'
 import { JobPlugin } from './pages/JobPlugin'
 
-export const plugins: TPlugin[] = [
-  {
+export const plugins: TUiPluginMap = {
+  'signal-job-single': {
     pluginName: 'signal-job-single',
     component: JobPlugin,
   },
-]
+}

--- a/example/src/plugins/job-ui-single/index.tsx
+++ b/example/src/plugins/job-ui-single/index.tsx
@@ -3,7 +3,6 @@ import { JobPlugin } from './pages/JobPlugin'
 
 export const plugins: TUiPluginMap = {
   'signal-job-single': {
-    pluginName: 'signal-job-single',
     component: JobPlugin,
   },
 }

--- a/example/src/plugins/marmo-ui/index.tsx
+++ b/example/src/plugins/marmo-ui/index.tsx
@@ -6,11 +6,9 @@ import { SignalTable } from './containers/views/SignalTable/SignalTable'
 
 export const plugins: TUiPluginMap = {
   'marmo-ess-plot-view': {
-    pluginName: 'marmo-ess-plot-view',
     component: SignalPlot,
   },
   'marmo-ess-table-view': {
-    pluginName: 'marmo-ess-table-view',
     component: SignalTable,
   },
 }

--- a/example/src/plugins/marmo-ui/index.tsx
+++ b/example/src/plugins/marmo-ui/index.tsx
@@ -4,11 +4,11 @@ import { TUiPluginMap } from '@development-framework/dm-core'
 import { SignalPlot } from './containers/views/SignalPlot'
 import { SignalTable } from './containers/views/SignalTable/SignalTable'
 
-export const plugins: TUiPluginMap = {
+export default {
   'marmo-ess-plot-view': {
     component: SignalPlot,
   },
   'marmo-ess-table-view': {
     component: SignalTable,
   },
-}
+} as TUiPluginMap

--- a/example/src/plugins/marmo-ui/index.tsx
+++ b/example/src/plugins/marmo-ui/index.tsx
@@ -1,17 +1,16 @@
-import { TPlugin } from '@development-framework/dm-core'
+import { TUiPluginMap } from '@development-framework/dm-core'
 
 //views
 import { SignalPlot } from './containers/views/SignalPlot'
 import { SignalTable } from './containers/views/SignalTable/SignalTable'
 
-export const plugins: TPlugin[] = [
-  {
+export const plugins: TUiPluginMap = {
+  'marmo-ess-plot-view': {
     pluginName: 'marmo-ess-plot-view',
     component: SignalPlot,
   },
-
-  {
+  'marmo-ess-table-view': {
     pluginName: 'marmo-ess-table-view',
     component: SignalTable,
   },
-]
+}

--- a/packages/dm-core-plugins/src/header/HeaderPlugin.tsx
+++ b/packages/dm-core-plugins/src/header/HeaderPlugin.tsx
@@ -63,7 +63,7 @@ export default (props: IUIPlugin): JSX.Element => {
   const [aboutOpen, setAboutOpen] = useState(false)
   const [visibleUserInfo, setVisibleUserInfo] = useState<boolean>(false)
   const [appSelectorOpen, setAppSelectorOpen] = useState<boolean>(false)
-  const { loading: isContextLoading, getUiPlugin } = useContext(UiPluginContext)
+  const { getUiPlugin } = useContext(UiPluginContext)
 
   const [selectedRecipe, setSelectedRecipe] = useState<TRecipeConfigAndPlugin>({
     component: (props: IUIPlugin) => <div></div>,
@@ -83,7 +83,7 @@ export default (props: IUIPlugin): JSX.Element => {
   }
 
   useEffect(() => {
-    if (!isContextLoading && !isBlueprintLoading) {
+    if (!isBlueprintLoading) {
       const defaultRecipe: TUiRecipe =
         config.uiRecipesList.length > 0
           ? uiRecipes.find(
@@ -92,15 +92,10 @@ export default (props: IUIPlugin): JSX.Element => {
           : uiRecipes[0]
       setSelectedRecipe(getRecipeConfigAndPlugin(defaultRecipe.name))
     }
-  }, [isBlueprintLoading, isContextLoading])
+  }, [isBlueprintLoading])
 
   const UIPlugin: (props: IUIPlugin) => JSX.Element = selectedRecipe.component
-  if (
-    isApplicationLoading ||
-    !entity ||
-    isContextLoading ||
-    isBlueprintLoading
-  ) {
+  if (isApplicationLoading || !entity || isBlueprintLoading) {
     return <Loading />
   }
 

--- a/packages/dm-core-plugins/src/index.tsx
+++ b/packages/dm-core-plugins/src/index.tsx
@@ -1,4 +1,4 @@
-import { TPlugin } from '@development-framework/dm-core'
+import { TUiPluginMap } from '@development-framework/dm-core'
 
 import { YamlPlugin } from './yaml/YamlPlugin'
 import { ViewSelectorPlugin } from './view_selector/ViewSelectorPlugin'
@@ -16,64 +16,64 @@ import { ListPlugin } from './list/ListPlugin'
 import { TablePlugin } from './table/TablePlugin'
 import { FilePlugin } from './file/FilePlugin'
 
-export const plugins: { [key: string]: TPlugin } = {
-  explorer: {
+export const plugins: TUiPluginMap = {
+  '@development-framework/dm-core-plugins/explorer': {
     pluginName: '@development-framework/dm-core-plugins/explorer',
     component: ExplorerPlugin,
   },
-  list: {
+  '@development-framework/dm-core-plugins/list': {
     pluginName: '@development-framework/dm-core-plugins/list',
     component: ListPlugin,
   },
-  table: {
+  '@development-framework/dm-core-plugins/table': {
     pluginName: '@development-framework/dm-core-plugins/table',
     component: TablePlugin,
   },
-  yaml: {
+  '@development-framework/dm-core-plugins/yaml': {
     pluginName: '@development-framework/dm-core-plugins/yaml',
     component: YamlPlugin,
   },
-  file: {
+  '@development-framework/dm-core-plugins/file': {
     pluginName: '@development-framework/dm-core-plugins/file',
     component: FilePlugin,
   },
-  grid: {
+  '@development-framework/dm-core-plugins/grid': {
     pluginName: '@development-framework/dm-core-plugins/grid',
     component: GridPlugin,
   },
-  view_selector: {
+  '@development-framework/dm-core-plugins/view_selector': {
     pluginName: '@development-framework/dm-core-plugins/view_selector',
     component: ViewSelectorPlugin,
   },
-  'blueprint-hierachy': {
+  '@development-framework/dm-core-plugins/blueprint-hierarchy': {
     pluginName: '@development-framework/dm-core-plugins/blueprint-hierarchy',
     component: BlueprintHierarchyPlugin,
   },
-  jobControl: {
+  '@development-framework/dm-core-plugins/jobControl': {
     pluginName: '@development-framework/dm-core-plugins/jobControl',
     component: JobControlPlugin,
   },
-  jobInputEdit: {
+  '@development-framework/dm-core-plugins/jobInputEdit': {
     pluginName: '@development-framework/dm-core-plugins/jobInputEdit',
     component: JobInputEditPlugin,
   },
-  form: {
+  '@development-framework/dm-core-plugins/form': {
     pluginName: '@development-framework/dm-core-plugins/form',
     component: FormPlugin,
   },
-  header: {
+  '@development-framework/dm-core-plugins/header': {
     pluginName: '@development-framework/dm-core-plugins/header',
     component: HeaderPlugin,
   },
-  json: {
+  '@development-framework/dm-core-plugins/json': {
     pluginName: '@development-framework/dm-core-plugins/json',
     component: JsonPlugin,
   },
-  pdf: {
+  '@development-framework/dm-core-plugins/pdf': {
     pluginName: '@development-framework/dm-core-plugins/pdf',
     component: PdfPlugin,
   },
-  blueprint: {
+  '@development-framework/dm-core-plugins/blueprint': {
     pluginName: '@development-framework/dm-core-plugins/blueprint',
     component: BlueprintPlugin,
   },

--- a/packages/dm-core-plugins/src/index.tsx
+++ b/packages/dm-core-plugins/src/index.tsx
@@ -18,63 +18,48 @@ import { FilePlugin } from './file/FilePlugin'
 
 export const plugins: TUiPluginMap = {
   '@development-framework/dm-core-plugins/explorer': {
-    pluginName: '@development-framework/dm-core-plugins/explorer',
     component: ExplorerPlugin,
   },
   '@development-framework/dm-core-plugins/list': {
-    pluginName: '@development-framework/dm-core-plugins/list',
     component: ListPlugin,
   },
   '@development-framework/dm-core-plugins/table': {
-    pluginName: '@development-framework/dm-core-plugins/table',
     component: TablePlugin,
   },
   '@development-framework/dm-core-plugins/yaml': {
-    pluginName: '@development-framework/dm-core-plugins/yaml',
     component: YamlPlugin,
   },
   '@development-framework/dm-core-plugins/file': {
-    pluginName: '@development-framework/dm-core-plugins/file',
     component: FilePlugin,
   },
   '@development-framework/dm-core-plugins/grid': {
-    pluginName: '@development-framework/dm-core-plugins/grid',
     component: GridPlugin,
   },
   '@development-framework/dm-core-plugins/view_selector': {
-    pluginName: '@development-framework/dm-core-plugins/view_selector',
     component: ViewSelectorPlugin,
   },
   '@development-framework/dm-core-plugins/blueprint-hierarchy': {
-    pluginName: '@development-framework/dm-core-plugins/blueprint-hierarchy',
     component: BlueprintHierarchyPlugin,
   },
   '@development-framework/dm-core-plugins/jobControl': {
-    pluginName: '@development-framework/dm-core-plugins/jobControl',
     component: JobControlPlugin,
   },
   '@development-framework/dm-core-plugins/jobInputEdit': {
-    pluginName: '@development-framework/dm-core-plugins/jobInputEdit',
     component: JobInputEditPlugin,
   },
   '@development-framework/dm-core-plugins/form': {
-    pluginName: '@development-framework/dm-core-plugins/form',
     component: FormPlugin,
   },
   '@development-framework/dm-core-plugins/header': {
-    pluginName: '@development-framework/dm-core-plugins/header',
     component: HeaderPlugin,
   },
   '@development-framework/dm-core-plugins/json': {
-    pluginName: '@development-framework/dm-core-plugins/json',
     component: JsonPlugin,
   },
   '@development-framework/dm-core-plugins/pdf': {
-    pluginName: '@development-framework/dm-core-plugins/pdf',
     component: PdfPlugin,
   },
   '@development-framework/dm-core-plugins/blueprint': {
-    pluginName: '@development-framework/dm-core-plugins/blueprint',
     component: BlueprintPlugin,
   },
 }

--- a/packages/dm-core-plugins/src/index.tsx
+++ b/packages/dm-core-plugins/src/index.tsx
@@ -16,7 +16,7 @@ import { ListPlugin } from './list/ListPlugin'
 import { TablePlugin } from './table/TablePlugin'
 import { FilePlugin } from './file/FilePlugin'
 
-export const plugins: TUiPluginMap = {
+export default {
   '@development-framework/dm-core-plugins/explorer': {
     component: ExplorerPlugin,
   },
@@ -62,4 +62,4 @@ export const plugins: TUiPluginMap = {
   '@development-framework/dm-core-plugins/blueprint': {
     component: BlueprintPlugin,
   },
-}
+} as TUiPluginMap

--- a/packages/dm-core-plugins/src/index.tsx
+++ b/packages/dm-core-plugins/src/index.tsx
@@ -16,65 +16,65 @@ import { ListPlugin } from './list/ListPlugin'
 import { TablePlugin } from './table/TablePlugin'
 import { FilePlugin } from './file/FilePlugin'
 
-export const plugins: TPlugin[] = [
-  {
+export const plugins: { [key: string]: TPlugin } = {
+  explorer: {
     pluginName: '@development-framework/dm-core-plugins/explorer',
     component: ExplorerPlugin,
   },
-  {
+  list: {
     pluginName: '@development-framework/dm-core-plugins/list',
     component: ListPlugin,
   },
-  {
+  table: {
     pluginName: '@development-framework/dm-core-plugins/table',
     component: TablePlugin,
   },
-  {
+  yaml: {
     pluginName: '@development-framework/dm-core-plugins/yaml',
     component: YamlPlugin,
   },
-  {
+  file: {
     pluginName: '@development-framework/dm-core-plugins/file',
     component: FilePlugin,
   },
-  {
+  grid: {
     pluginName: '@development-framework/dm-core-plugins/grid',
     component: GridPlugin,
   },
-  {
+  view_selector: {
     pluginName: '@development-framework/dm-core-plugins/view_selector',
     component: ViewSelectorPlugin,
   },
-  {
+  'blueprint-hierachy': {
     pluginName: '@development-framework/dm-core-plugins/blueprint-hierarchy',
     component: BlueprintHierarchyPlugin,
   },
-  {
+  jobControl: {
     pluginName: '@development-framework/dm-core-plugins/jobControl',
     component: JobControlPlugin,
   },
-  {
+  jobInputEdit: {
     pluginName: '@development-framework/dm-core-plugins/jobInputEdit',
     component: JobInputEditPlugin,
   },
-  {
+  form: {
     pluginName: '@development-framework/dm-core-plugins/form',
     component: FormPlugin,
   },
-  {
+  header: {
     pluginName: '@development-framework/dm-core-plugins/header',
     component: HeaderPlugin,
   },
-  {
+  json: {
     pluginName: '@development-framework/dm-core-plugins/json',
     component: JsonPlugin,
   },
-  {
+  pdf: {
     pluginName: '@development-framework/dm-core-plugins/pdf',
     component: PdfPlugin,
   },
-  {
+  blueprint: {
     pluginName: '@development-framework/dm-core-plugins/blueprint',
     component: BlueprintPlugin,
   },
-]
+}

--- a/packages/dm-core-plugins/src/pdf/PdfPlugin.tsx
+++ b/packages/dm-core-plugins/src/pdf/PdfPlugin.tsx
@@ -5,7 +5,6 @@ import {
   IUIPlugin,
   Loading,
   TGenericObject,
-  TPlugin,
 } from '@development-framework/dm-core'
 import { useDocument } from '@development-framework/dm-core'
 

--- a/packages/dm-core/src/components/ViewCreator/InlineRecipeView.tsx
+++ b/packages/dm-core/src/components/ViewCreator/InlineRecipeView.tsx
@@ -8,9 +8,7 @@ type TInlineRecipeViewProps = IUIPlugin & {
 
 export const InlineRecipeView = (props: TInlineRecipeViewProps) => {
   const { idReference, type, viewConfig, onOpen } = props
-  const { loading, getUiPlugin } = useContext(UiPluginContext)
-
-  if (loading) return <Loading />
+  const { getUiPlugin } = useContext(UiPluginContext)
 
   const UiPlugin = getUiPlugin(viewConfig.recipe.plugin)
   return (

--- a/packages/dm-core/src/context/UiPluginContext.tsx
+++ b/packages/dm-core/src/context/UiPluginContext.tsx
@@ -24,7 +24,7 @@ export const UiPluginProvider = ({
 
   function getUiPlugin(pluginName: string): (props: IUIPlugin) => JSX.Element {
     if (Object.keys(plugins).includes(pluginName))
-      return plugins[pluginName]['component']
+      return plugins[pluginName].component
     return () => <ErrorGroup>Did not find the plugin: {pluginName}</ErrorGroup>
   }
 

--- a/packages/dm-core/src/context/UiPluginContext.tsx
+++ b/packages/dm-core/src/context/UiPluginContext.tsx
@@ -1,72 +1,35 @@
-import React, { createContext, useEffect, useState } from 'react'
-import { IUIPlugin, TPlugin } from '../types'
+import React, { createContext, useState } from 'react'
+import { IUIPlugin, TUiPluginMap } from '../types'
 import { ErrorGroup } from '../utils/ErrorBoundary'
-
-type TUiPluginMap = {
-  [pluginName: string]: (props: IUIPlugin) => JSX.Element
-}
-
-export interface ILoadedPlugin {
-  plugins: TPlugin[]
-}
 
 type TUiPluginContext = {
   plugins: TUiPluginMap
-  loading: boolean
   getUiPlugin: (pluginName: string) => (props: IUIPlugin) => JSX.Element
 }
 
 const emptyContext: TUiPluginContext = {
-  loading: false,
   plugins: {},
   getUiPlugin: () => () => <></>,
 }
 export const UiPluginContext = createContext<TUiPluginContext>(emptyContext)
 
-export const UiPluginProvider = ({ pluginsToLoad, children }: any) => {
-  const [loading, setLoading] = useState<boolean>(true)
-  const [plugins, setPlugins] = useState<TUiPluginMap>({})
-
-  // Async load all the javascript packages defined in packages.json
-  // Iterate every package, and adding all the UiPlugins contained in each package to the context
-  useEffect(() => {
-    // Add builtin plugins
-    let newPluginMap: TUiPluginMap = {}
-
-    Promise.all(
-      pluginsToLoad.map(
-        async (pluginPackage: any) =>
-          await pluginPackage.then((loadedPluginPackage: ILoadedPlugin) =>
-            loadedPluginPackage.plugins.map((plugin: TPlugin) => plugin)
-          )
-      )
-    )
-      .then((pluginPackageList: any[]) => {
-        pluginPackageList.forEach((pluginPackage: TPlugin[]) => {
-          pluginPackage.forEach(
-            (plugin) =>
-              (newPluginMap = {
-                ...newPluginMap,
-                [plugin.pluginName]: plugin.component,
-              })
-          )
-        })
-        setPlugins(newPluginMap)
-      })
-      .catch((e: any) => {
-        console.error(e)
-        return []
-      })
-      .finally(() => setLoading(false))
-  }, [pluginsToLoad])
+export const UiPluginProvider = ({
+  pluginsToLoad,
+  children,
+}: {
+  pluginsToLoad: TUiPluginMap
+  children: any
+}) => {
+  const [plugins, setPlugins] = useState<TUiPluginMap>(pluginsToLoad)
 
   function getUiPlugin(pluginName: string): (props: IUIPlugin) => JSX.Element {
-    if (pluginName in plugins) return plugins[pluginName]
+    if (Object.keys(plugins).includes(pluginName))
+      return plugins[pluginName]['component']
     return () => <ErrorGroup>Did not find the plugin: {pluginName}</ErrorGroup>
   }
 
   return (
-    <UiPluginContext.Provider value={{ plugins, loading, getUiPlugin }}>
+    <UiPluginContext.Provider value={{ plugins, getUiPlugin }}>
       {children}
     </UiPluginContext.Provider>
   )

--- a/packages/dm-core/src/hooks/useRecipe.tsx
+++ b/packages/dm-core/src/hooks/useRecipe.tsx
@@ -101,8 +101,7 @@ export const useRecipe = (
     isLoading: isBlueprintLoading,
     error,
   } = useBlueprint(typeRef)
-  const { loading: isPluginContextLoading, getUiPlugin } =
-    useContext(UiPluginContext)
+  const { getUiPlugin } = useContext(UiPluginContext)
   const [foundRecipe, setFoundRecipe] = useState<TUiRecipe>()
   const [findRecipeError, setFindRecipeError] = useState<ErrorResponse | null>(
     null
@@ -127,7 +126,7 @@ export const useRecipe = (
 
   return {
     recipe: isBlueprintLoading ? undefined : foundRecipe,
-    isLoading: isBlueprintLoading && isPluginContextLoading,
+    isLoading: isBlueprintLoading,
     error: error ?? findRecipeError,
     getUiPlugin,
   }

--- a/packages/dm-core/src/types.ts
+++ b/packages/dm-core/src/types.ts
@@ -97,6 +97,8 @@ export interface IUIPlugin {
   config?: any
 }
 
+export type TUiPluginMap = { [pluginName: string]: TPlugin }
+
 export type TUiRecipe = {
   type: string
   name: string

--- a/packages/dm-core/src/types.ts
+++ b/packages/dm-core/src/types.ts
@@ -111,7 +111,6 @@ export type TUiRecipe = {
 }
 
 export type TPlugin = {
-  pluginName: string
   component: (props: IUIPlugin) => JSX.Element
 }
 


### PR DESCRIPTION
## What does this pull request change?

Make it easier to import plugins, by exporting a dict of plugins instead of a list of plugins. 
This also makes it possible to simplify the logic inside UiPluginContext.tsx for fetching plugins

## Issues related to this change
closes #357 
