### PR TITLE
refactor: remove unused views and defaultViews config

### DIFF
--- a/packages/dm-core-plugins/src/table/types.ts
+++ b/packages/dm-core-plugins/src/table/types.ts
@@ -22,8 +22,6 @@ export type TTablePluginConfig = {
     | TInlineRecipeViewConfig
     | TReferenceViewConfig
   functionality: TTableFunctionalityConfig
-  defaultView: TViewConfig
-  views: TViewConfig[]
 }
 
 export const defaultConfig: TTablePluginConfig = {
@@ -37,8 +35,6 @@ export const defaultConfig: TTablePluginConfig = {
     edit: false,
     delete: false,
   },
-  defaultView: { type: 'ViewConfig', scope: 'self' },
-  views: [],
 }
 
 export type TTableRowItem = {


### PR DESCRIPTION
## What does this pull request change?

## Why is this pull request needed?

The configs were made superfluous when expandableRecipeViewConfig were created, and were decided removed in https://github.com/equinor/dm-core-packages/pull/321#discussion_r1247788461

## Issues related to this change

