### PR TITLE
refactor(form): remove superfluous control argument

### DIFF
--- a/packages/dm-core-plugins/src/form/fields/BooleanField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/BooleanField.tsx
@@ -1,10 +1,9 @@
 import React from 'react'
-import { Controller, useFormContext } from 'react-hook-form'
+import { Controller } from 'react-hook-form'
 import { getWidget } from '../context/WidgetContext'
 import { TBooleanFieldProps } from '../types'
 
 export const BooleanField = (props: TBooleanFieldProps) => {
-  const { control } = useFormContext()
   const { namePath, displayLabel, defaultValue, uiAttribute } = props
 
   // We need to convert default values coming from the API since they are always strings
@@ -17,7 +16,6 @@ export const BooleanField = (props: TBooleanFieldProps) => {
   return (
     <Controller
       name={namePath}
-      control={control}
       defaultValue={usedDefaultValue}
       render={({
         field: { ref, value, ...props },

--- a/packages/dm-core-plugins/src/form/fields/NumberField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/NumberField.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Controller, useFormContext } from 'react-hook-form'
+import { Controller } from 'react-hook-form'
 import { getWidget } from '../context/WidgetContext'
 import { TNumberFieldProps } from '../types'
 
@@ -31,7 +31,6 @@ export const asNumber = (value: string): number | string => {
 }
 
 export const NumberField = (props: TNumberFieldProps) => {
-  const { control } = useFormContext()
   const { namePath, displayLabel, defaultValue, optional, uiAttribute } = props
 
   const defaultWidget = uiAttribute ? uiAttribute.widget : 'TextWidget'
@@ -40,7 +39,6 @@ export const NumberField = (props: TNumberFieldProps) => {
   return (
     <Controller
       name={namePath}
-      control={control}
       rules={{
         required: !optional,
         pattern: { value: /^[0-9]+$/g, message: 'Only digits allowed' },

--- a/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
@@ -258,7 +258,7 @@ export const ContainedAttribute = (props: TContentProps): JSX.Element => {
 
 export const UncontainedAttribute = (props: TContentProps): JSX.Element => {
   const { type, namePath, displayLabel = '' } = props
-  const { getValues, control, setValue } = useFormContext()
+  const { getValues, setValue } = useFormContext()
   const { idReference, onOpen } = useRegistryContext()
   const initialValue = getValues(namePath)
 
@@ -267,7 +267,6 @@ export const UncontainedAttribute = (props: TContentProps): JSX.Element => {
       <Typography bold={true}>{displayLabel}</Typography>
       <Controller
         name={namePath}
-        control={control}
         defaultValue={initialValue}
         render={({
           // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/dm-core-plugins/src/form/fields/StringField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/StringField.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Controller, useFormContext } from 'react-hook-form'
+import { Controller } from 'react-hook-form'
 import { getWidget } from '../context/WidgetContext'
 import { TStringFieldProps } from '../types'
 
@@ -8,7 +8,6 @@ const formatDate = (date: string) => {
 }
 
 export const StringField = (props: TStringFieldProps) => {
-  const { control } = useFormContext()
   const { namePath, displayLabel, defaultValue, optional, uiAttribute } = props
 
   const defaultWidget = uiAttribute ? uiAttribute.widget : 'TextWidget'
@@ -17,7 +16,6 @@ export const StringField = (props: TStringFieldProps) => {
   return (
     <Controller
       name={namePath}
-      control={control}
       rules={{
         required: !optional,
       }}


### PR DESCRIPTION
## What does this pull request change?

Removes the control argument to avoid unnecessary noise

## Why is this pull request needed?

control input is optional when using form provider, which we do

## Issues related to this change

#276

