### PR TITLE
fix(form): show remove button

### DIFF
--- a/e2e/tests/plugin-form-Nested.spec.ts
+++ b/e2e/tests/plugin-form-Nested.spec.ts
@@ -29,7 +29,7 @@ test('Nested Form', async ({ page }) => {
     .getByRole('button', { name: 'Add' })
     .click()
   await page
-    .getByText('CEO (optional)Open')
+    .getByText('CEO (optional)RemoveOpen')
     .getByRole('button', { name: 'Open' })
     .click()
   await page.getByLabel('Name').fill('Donald')
@@ -37,7 +37,7 @@ test('Nested Form', async ({ page }) => {
   await page.getByRole('button', { name: 'Submit' }).click()
   await page.getByRole('tab').nth(2).click()
   await page
-    .getByText('CEO (optional)Open')
+    .getByText('CEO (optional)RemoveOpen')
     .getByRole('button', { name: 'Open' })
     .click()
   await expect(page.getByLabel('Name')).toHaveValue('Donald')

--- a/e2e/tests/plugin-form-Nested.spec.ts
+++ b/e2e/tests/plugin-form-Nested.spec.ts
@@ -45,6 +45,13 @@ test('Nested Form', async ({ page }) => {
     '99887766'
   )
   await page.getByRole('tab').nth(2).click()
+  await page
+    .getByText('CEO (optional)RemoveOpen')
+    .getByRole('button', { name: 'Remove' })
+    .click()
+  await expect(
+    page.getByText('CEO (optional)Add').getByRole('button', { name: 'Add' })
+  ).toBeVisible()
 
   //Replacing accountant
   await page

--- a/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
@@ -140,14 +140,10 @@ export const ContainedAttribute = (props: TContentProps): JSX.Element => {
   const { getValues, setValue } = useFormContext()
   const { idReference, onOpen } = useRegistryContext()
   const [isDefined, setIsDefined] = useState(
-    namePath == ''
-      ? getValues() !== undefined
-      : getValues(namePath) !== undefined &&
-          Object.keys(getValues(namePath)).length > 0
+    getValues(namePath) !== undefined &&
+      Object.keys(getValues(namePath)).length > 0
   )
   const hasOpen = onOpen !== undefined
-  const isRoot = namePath == ''
-  const shouldOpen = hasOpen && !isRoot
 
   const attributePath = idReference.split('.', 2).slice(1)
 
@@ -155,15 +151,29 @@ export const ContainedAttribute = (props: TContentProps): JSX.Element => {
     <div>
       <Stack spacing={0.25} alignItems="flex-start">
         <Typography bold={true}>{displayLabel}</Typography>
-        {!isDefined && (
-          <AddObject
-            idReference={idReference}
-            namePath={namePath}
-            type={type}
-            onAdd={() => setIsDefined(true)}
-          />
-        )}
-        {shouldOpen && isDefined && (
+        {optional &&
+          (isDefined ? (
+            <RemoveObject
+              namePath={namePath}
+              onRemove={() => {
+                const options = {
+                  shouldValidate: false,
+                  shouldDirty: true,
+                  shouldTouch: true,
+                }
+                setValue(namePath, undefined, options)
+                setIsDefined(false)
+              }}
+            />
+          ) : (
+            <AddObject
+              idReference={idReference}
+              namePath={namePath}
+              type={type}
+              onAdd={() => setIsDefined(true)}
+            />
+          ))}
+        {hasOpen && isDefined && (
           <OpenObjectButton
             viewId={namePath}
             idReference={idReference}
@@ -174,40 +184,26 @@ export const ContainedAttribute = (props: TContentProps): JSX.Element => {
             }
           />
         )}
+        {!hasOpen && isDefined && (
+          <>
+            {uiRecipe && uiRecipe.plugin !== 'form' && (
+              <EntityView
+                idReference={`${idReference}.${namePath}`}
+                type={type}
+                onOpen={onOpen}
+              />
+            )}
+            {(uiRecipe === undefined ||
+              (uiRecipe && uiRecipe.plugin === 'form')) && (
+              <AttributeList
+                namePath={namePath}
+                config={uiRecipe?.config}
+                blueprint={blueprint}
+              />
+            )}
+          </>
+        )}
       </Stack>
-      {!shouldOpen && isDefined && (
-        <>
-          {!isRoot && optional && (
-            <RemoveObject
-              namePath={namePath}
-              onRemove={() => {
-                const options = {
-                  shouldValidate: false,
-                  shouldDirty: true,
-                  shouldTouch: true,
-                }
-                setValue(namePath, null, options)
-              }}
-            />
-          )}
-          {uiRecipe && uiRecipe.plugin !== 'form' && (
-            <EntityView
-              idReference={`${idReference}.${namePath}`}
-              type={type}
-              onOpen={onOpen}
-            />
-          )}
-          {(isRoot ||
-            uiRecipe === undefined ||
-            (uiRecipe && uiRecipe.plugin === 'form')) && (
-            <AttributeList
-              namePath={namePath}
-              config={uiRecipe?.config}
-              blueprint={blueprint}
-            />
-          )}
-        </>
-      )}
     </div>
   )
 }


### PR DESCRIPTION
## What does this pull request change?

Ensure the remove button is visible both for inline object form and in tab

## Why is this pull request needed?

You should always be able to remove an optional attribute. 

## Issues related to this change

#276
