### PR TITLE
fix: update reset script to work with dm-cli validation flag

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Start DMSS
         id: dmss
-        run: | 
+        run: |
           docker-compose run --rm dmss cat src/version.txt > dmss_version.txt
           dmss_version=$(tail -n 1 dmss_version.txt)
           docker-compose run --rm job-api cat version.txt > job_version.txt
@@ -70,14 +70,14 @@ jobs:
           python -m venv .venv
           source .venv/bin/activate
           pip install dm-cli
-          ./reset-all.sh
+          ./reset-all.sh validate-entities
           echo "version=$(dm --version)" >> "$GITHUB_OUTPUT"
         working-directory: example/
 
       - name: Install dependencies
         run: |
-           npm install --package-lock-only
-           npm ci
+          npm install --package-lock-only
+          npm ci
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps

--- a/example/README.md
+++ b/example/README.md
@@ -18,66 +18,70 @@
 
    The project uses yarn workspaces to handle dependencies for all three sub-projects.
 
-   - Run `yarn install`
+    - Run `yarn install`
 
    #### Backend
 
    Install dm-cli locally
 
-   - Initialize and activate virtual env
-     - `python3 -m venv .venv`
-     - `source .venv/bin/activate`
-   - Install dm-cli package by running `pip install dm-cli`
+    - Initialize and activate virtual env
+        - `python3 -m venv .venv`
+        - `source .venv/bin/activate`
+    - Install dm-cli package by running `pip install dm-cli`
 
 2. Build the required packages locally (dm-core and dm-core-plugins).
-   - Run `yarn build:dm-core && yarn build:dm-core-plugins`
+    - Run `yarn build:dm-core && yarn build:dm-core-plugins`
 3. Navigate to the `example` folder, then pull and start API services
-   - `docker-compose pull && docker-compose up -d`
-4. Navigate to the `example` folder, then run shell script to load dmss data. If the command fails, try updating dm-cli before retrying.
-   - `./reset-all.sh`
+    - `docker-compose pull && docker-compose up -d`
+4. Navigate to the `example` folder, then run shell script to load dmss data. If the command fails, try updating dm-cli
+   before retrying.
+    - `./reset-all.sh`
 5. Start the test app
-   - `yarn start:example`
+    - `yarn start:example`
 
 ## Running (Windows)
 
-1. Open Powershell and navigate to dm-core-packages and run `yarn install`. 
-2. Navigate to dm-core-packages/example. Make sure docker engine is running, then run these commands: 
-   - `docker-compose down && docker-compose pull && docker-compose up -d`
-   - `docker-compose run --rm dmss reset-app`
-   - `docker-compose run --rm job-api dm -u http://dmss:5000 reset ../app`
-3. Download and open WSL (windows subsystem for linux) terminal and navigate to c disk using the command: `cd /mnt/c`. 
-   1. A useful tip is to download 'Windows Terminal' from the App Store, which is a useful terminal for switching between WSL (Ubuntu) and powershell. 
-4. Make sure you have pip and venv installed in the WSL (Ubuntu) system. 
+1. Open Powershell and navigate to dm-core-packages and run `yarn install`.
+2. Navigate to dm-core-packages/example. Make sure docker engine is running, then run these commands:
+    - `docker-compose down && docker-compose pull && docker-compose up -d`
+    - `docker-compose run --rm dmss reset-app`
+    - `docker-compose run --rm job-api dm -u http://dmss:5000 reset ../app`
+3. Download and open WSL (windows subsystem for linux) terminal and navigate to c disk using the command: `cd /mnt/c`.
+    1. A useful tip is to download 'Windows Terminal' from the App Store, which is a useful terminal for switching
+       between WSL (Ubuntu) and powershell.
+4. Make sure you have pip and venv installed in the WSL (Ubuntu) system.
    ```
    sudo apt-get update &&
    sudo apt-get upgrade && 
    sudo apt install python3-pip &&
    sudo apt install python3-venv
    ```
-5. In the WSL terminal navigate to `dm-core-packages/example` and run 
+5. In the WSL terminal navigate to `dm-core-packages/example` and run
    ```
    python3 -m venv .venv && 
    source .venv/bin/activate
    ```
    This may take a few minutes to run, so now grab a coffee and strech your legs. ☕
-6. Run 
+6. Run
    ```
    pip install dm-cli &&
-   dm reset app &&
+   dm reset app --validate-entities &&
    dm import-plugin-blueprints ../node_modules/@development-framework/dm-core-plugins &&
    dm create-lookup example DemoDataSource/recipes
    ```
-7. Go back to the Powershell terminal and navigate to root in `dm-core-packages/` by typing the command `cd .. ` and start the app with the command `yarn start:example`.
+   (dm reset app can also be run with --no-validate-entities to skip validation)
+7. Go back to the Powershell terminal and navigate to root in `dm-core-packages/` by typing the command `cd .. ` and
+   start the app with the command `yarn start:example`.
 
 ## Naming Convention
 
-In the example app, json files are named according to what type they are. 
+In the example app, json files are named according to what type they are.
 
-- JSON files of type Blueprint are named `<MyBluePrint>.blueprint.json`, using the PascalCase notation. 
-- JSON files of type RecipeLink are named `<MyBluePrint>.recipe.json`, using the PascalCase notation. 
-- JSON files of type Entity are named `<myEntity>.entity.json`, with the camelCase notation. 
+- JSON files of type Blueprint are named `<MyBluePrint>.blueprint.json`, using the PascalCase notation.
+- JSON files of type RecipeLink are named `<MyBluePrint>.recipe.json`, using the PascalCase notation.
+- JSON files of type Entity are named `<myEntity>.entity.json`, with the camelCase notation.
 
-In the example app, folders are named according to the naming convention: 
+In the example app, folders are named according to the naming convention:
 
 - Apps are to have the PascalCase notation
 - All other folders are to have the snake_case notation. 

--- a/example/README.md
+++ b/example/README.md
@@ -35,7 +35,7 @@
     - `docker-compose pull && docker-compose up -d`
 4. Navigate to the `example` folder, then run shell script to load dmss data. If the command fails, try updating dm-cli
    before retrying.
-    - `./reset-all.sh`
+    - `./reset-all.sh validate-entities`
 5. Start the test app
     - `yarn start:example`
 
@@ -65,7 +65,7 @@
 6. Run
    ```
    pip install dm-cli &&
-   dm reset app --validate-entities &&
+   dm reset app validate-entities &&
    dm import-plugin-blueprints ../node_modules/@development-framework/dm-core-plugins &&
    dm create-lookup example DemoDataSource/recipes
    ```

--- a/example/reset-all.sh
+++ b/example/reset-all.sh
@@ -9,9 +9,26 @@ fi
 
 set -e
 
+# $1 is the first argument to the shell script. Valid options are 'no-validate-entities' and 'validate-entities'.
+# If argument is empty, default value will be no-validate-entities.
+if [ -z "$1" ]
+  then
+    VALIDATION_FLAG="validate-entities"
+  else
+    if [ $1 != "no-validate-entities" ] && [ $1 != "validate-entities" ]
+      then
+        echo "validation flag is invalid. valid values are 'no-validate-entities' and 'validate-entities'"
+        exit 1
+    fi
+    VALIDATION_FLAG=$1
+fi
+
+
+
+
 eval $compose run --rm dmss reset-app
 eval $compose run --rm job-api dm -u http://dmss:5000 reset ../app
-dm reset app
 dm import-plugin-blueprints ../node_modules/@development-framework/dm-core-plugins
+dm reset app --$VALIDATION_FLAG
 echo "Creating recipe lookup..."
 dm create-lookup example DemoDataSource/recipes


### PR DESCRIPTION
## What does this pull request change?

add validation as default in the reset all script. Validation can be turned off by adding the flag --no-validate-entities

NB!
after this is merged, you must run dm-cli v 1.0.16 or higher

## Issues related to this change
https://github.com/equinor/dm-cli/issues/103

