### PR TITLE
test(form): mock uirecipes

### DIFF
--- a/packages/dm-core-plugins/src/form/test-utils.tsx
+++ b/packages/dm-core-plugins/src/form/test-utils.tsx
@@ -10,6 +10,19 @@ export const mockBlueprintGet = (blueprints: Array<any>) => {
         blueprint: blueprints.find(
           (blueprint: any) => blueprint.name == props.typeRef
         ),
+        uiRecipes: [
+          {
+            name: 'Edit',
+            type: 'dmss://system/SIMOS/UiRecipe',
+            plugin: '@development-framework/dm-core-plugins/form',
+          },
+          {
+            name: 'List',
+            type: 'dmss://system/SIMOS/UiRecipe',
+            plugin: '@development-framework/dm-core-plugins/list',
+            dimensions: '*',
+          },
+        ],
       },
     })
   )

--- a/packages/dm-core/src/hooks/useRecipe.tsx
+++ b/packages/dm-core/src/hooks/useRecipe.tsx
@@ -1,10 +1,10 @@
-import React, { useContext, useEffect, useState } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import {
-  useBlueprint,
-  TUiRecipe,
   ErrorResponse,
-  UiPluginContext,
   IUIPlugin,
+  TUiRecipe,
+  UiPluginContext,
+  useBlueprint,
 } from '../index'
 
 const findRecipe = (
@@ -51,12 +51,7 @@ const findRecipe = (
     )
     return noDimensionsRecipes[0]
   }
-  return {
-    type: 'CORE:UIRecipe',
-    name: 'yaml',
-    plugin: 'yaml',
-    config: {},
-  }
+  throw new Error(`No recipe found`)
 }
 
 interface IUseRecipe {
@@ -111,6 +106,7 @@ export const useRecipe = (
   useEffect(() => {
     if (isBlueprintLoading) return
     try {
+      console.log(typeRef, uiRecipes, initialUiRecipe)
       setFoundRecipe(
         findRecipe(uiRecipes, initialUiRecipe, recipeName, dimensions)
       )

--- a/packages/dm-core/src/hooks/useRecipe.tsx
+++ b/packages/dm-core/src/hooks/useRecipe.tsx
@@ -51,7 +51,7 @@ const findRecipe = (
     )
     return noDimensionsRecipes[0]
   }
-  throw new Error(`No recipe found`)
+  throw new Error(`No uiRecipe was found`)
 }
 
 interface IUseRecipe {
@@ -106,7 +106,6 @@ export const useRecipe = (
   useEffect(() => {
     if (isBlueprintLoading) return
     try {
-      console.log(typeRef, uiRecipes, initialUiRecipe)
       setFoundRecipe(
         findRecipe(uiRecipes, initialUiRecipe, recipeName, dimensions)
       )


### PR DESCRIPTION
## What does this pull request change?

## Why is this pull request needed?

default uiRecipes are usually returned from the dmss. Unit tests don't have dmss, so we must mock this, or else it can fail.

## Issues related to this change

#276

