### PR TITLE
fix: raise warning on missing UiPluginProvider

### DIFF
--- a/packages/dm-core-plugins/src/header/HeaderPlugin.tsx
+++ b/packages/dm-core-plugins/src/header/HeaderPlugin.tsx
@@ -1,22 +1,22 @@
 import {
   IUIPlugin,
   Loading,
-  UiPluginContext,
-  useDocument,
-  useBlueprint,
-  TUiRecipe,
   TGenericObject,
+  TUiRecipe,
+  useBlueprint,
+  useDocument,
+  useUiPlugins,
 } from '@development-framework/dm-core'
-import React, { useContext, useState, useEffect } from 'react'
-import styled from 'styled-components'
 import { Icon, TopBar } from '@equinor/eds-core-react'
+import React, { useEffect, useState } from 'react'
+import styled from 'styled-components'
 
 import { account_circle, grid_on, info_circle } from '@equinor/eds-icons'
 
-import { UserInfoDialog } from './components/UserInfoDialog'
 import { AboutDialog } from './components/AboutDialog'
-import { TApplication } from './types'
 import { RecipeSelector } from './components/RecipeSelector'
+import { UserInfoDialog } from './components/UserInfoDialog'
+import { TApplication } from './types'
 
 const Icons = styled.div`
   display: flex;
@@ -63,7 +63,7 @@ export default (props: IUIPlugin): JSX.Element => {
   const [aboutOpen, setAboutOpen] = useState(false)
   const [visibleUserInfo, setVisibleUserInfo] = useState<boolean>(false)
   const [appSelectorOpen, setAppSelectorOpen] = useState<boolean>(false)
-  const { getUiPlugin } = useContext(UiPluginContext)
+  const { getUiPlugin } = useUiPlugins()
 
   const [selectedRecipe, setSelectedRecipe] = useState<TRecipeConfigAndPlugin>({
     component: (props: IUIPlugin) => <div></div>,

--- a/packages/dm-core/src/components/ViewCreator/InlineRecipeView.tsx
+++ b/packages/dm-core/src/components/ViewCreator/InlineRecipeView.tsx
@@ -1,6 +1,6 @@
+import React from 'react'
+import { ErrorBoundary, IUIPlugin, useUiPlugins } from '../../index'
 import { TInlineRecipeViewConfig } from '../../types'
-import { ErrorBoundary, Loading, UiPluginContext, IUIPlugin } from '../../index'
-import React, { useContext } from 'react'
 
 type TInlineRecipeViewProps = IUIPlugin & {
   viewConfig: TInlineRecipeViewConfig
@@ -8,7 +8,7 @@ type TInlineRecipeViewProps = IUIPlugin & {
 
 export const InlineRecipeView = (props: TInlineRecipeViewProps) => {
   const { idReference, type, viewConfig, onOpen } = props
-  const { getUiPlugin } = useContext(UiPluginContext)
+  const { getUiPlugin } = useUiPlugins()
 
   const UiPlugin = getUiPlugin(viewConfig.recipe.plugin)
   return (

--- a/packages/dm-core/src/context/UiPluginContext.tsx
+++ b/packages/dm-core/src/context/UiPluginContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState } from 'react'
+import React, { createContext, useContext } from 'react'
 import { IUIPlugin, TUiPluginMap } from '../types'
 import { ErrorGroup } from '../utils/ErrorBoundary'
 
@@ -7,21 +7,23 @@ type TUiPluginContext = {
   getUiPlugin: (pluginName: string) => (props: IUIPlugin) => JSX.Element
 }
 
-const emptyContext: TUiPluginContext = {
-  plugins: {},
-  getUiPlugin: () => () => <></>,
+const UiPluginContext = createContext<TUiPluginContext | undefined>(undefined)
+
+export const useUiPlugins = () => {
+  const context = useContext(UiPluginContext)
+  if (context == undefined) {
+    throw new Error('useUiPlugins must be used within a UiPluginProvider')
+  }
+  return context
 }
-export const UiPluginContext = createContext<TUiPluginContext>(emptyContext)
 
 export const UiPluginProvider = ({
-  pluginsToLoad,
+  pluginsToLoad: plugins,
   children,
 }: {
   pluginsToLoad: TUiPluginMap
   children: any
 }) => {
-  const [plugins, setPlugins] = useState<TUiPluginMap>(pluginsToLoad)
-
   function getUiPlugin(pluginName: string): (props: IUIPlugin) => JSX.Element {
     if (Object.keys(plugins).includes(pluginName))
       return plugins[pluginName].component

--- a/packages/dm-core/src/hooks/useRecipe.tsx
+++ b/packages/dm-core/src/hooks/useRecipe.tsx
@@ -1,10 +1,10 @@
-import { useContext, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import {
   ErrorResponse,
   IUIPlugin,
   TUiRecipe,
-  UiPluginContext,
   useBlueprint,
+  useUiPlugins,
 } from '../index'
 
 const findRecipe = (
@@ -96,7 +96,7 @@ export const useRecipe = (
     isLoading: isBlueprintLoading,
     error,
   } = useBlueprint(typeRef)
-  const { getUiPlugin } = useContext(UiPluginContext)
+  const { getUiPlugin } = useUiPlugins()
   const [foundRecipe, setFoundRecipe] = useState<TUiRecipe>()
   const [findRecipeError, setFindRecipeError] = useState<ErrorResponse | null>(
     null


### PR DESCRIPTION
## What does this pull request change?

## Why is this pull request needed?

The UiPluginContext was made so that if the UiPluginProvider was missing, the UiPluginContext would simply return meaningless data. I've rewritten it to make sure it will fail properly.

## Issues related to this change

