### PR TITLE
fix: do not add primitive types as separate nodes in tree

### DIFF
--- a/packages/dm-core/src/domain/Tree.tsx
+++ b/packages/dm-core/src/domain/Tree.tsx
@@ -43,7 +43,8 @@ const createContainedChildren = (
     }
     if (!attribute) return false // If no attribute, there likely where some invalid keys. Ignore those
     // Skip adding nodes for primitives
-    if (!['string', 'number', 'boolean'].includes(attribute.attributeType)) {
+    const PRIMITIVE_TYPES_TO_HIDE = ['string', 'number', 'boolean', 'integer']
+    if (!PRIMITIVE_TYPES_TO_HIDE.includes(attribute.attributeType)) {
       let childNodeId: string
       if (Number.isInteger(Number(key))) {
         // For arrays, bracket syntax is used to construct the node id: [key]


### PR DESCRIPTION
## What does this pull request change?

do not display primitive attributes as sub nodes in the tree. see issue for more details

## Issues related to this change
closes #395 

