### PR TITLE
fix(form): update db when pressing Remove button

### DIFF
--- a/e2e/tests/plugin-form-Nested.spec.ts
+++ b/e2e/tests/plugin-form-Nested.spec.ts
@@ -39,32 +39,26 @@ test('Change owner', async () => {
 
 test('Hiring a CEO', async () => {
   await page
-    .getByText('CEO (optional)Add')
-    .getByRole('button', { name: 'Add' })
+    .getByTestId('ceo')
+    .getByRole('button', { name: 'Add and save' })
     .click()
-  await page
-    .getByText('CEO (optional)RemoveOpen')
-    .getByRole('button', { name: 'Open' })
-    .click()
+  await page.getByTestId('ceo').getByRole('button', { name: 'Open' }).click()
   await page.getByLabel('Name').fill('Donald')
   await page.getByLabel('Phone Number (optional)').fill('99887766')
   await page.getByRole('button', { name: 'Submit' }).click()
   await page.getByRole('tab').nth(2).click()
-  await page
-    .getByText('CEO (optional)RemoveOpen')
-    .getByRole('button', { name: 'Open' })
-    .click()
+  await page.getByTestId('ceo').getByRole('button', { name: 'Open' }).click()
   await expect(page.getByLabel('Name')).toHaveValue('Donald')
   await expect(page.getByLabel('Phone Number (optional)')).toHaveValue(
     '99887766'
   )
   await page.getByRole('tab').nth(2).click()
   await page
-    .getByText('CEO (optional)RemoveOpen')
-    .getByRole('button', { name: 'Remove' })
+    .getByTestId('ceo')
+    .getByRole('button', { name: 'Remove and save' })
     .click()
   await expect(
-    page.getByText('CEO (optional)Add').getByRole('button', { name: 'Add' })
+    page.getByTestId('ceo').getByRole('button', { name: 'Add and save' })
   ).toBeVisible()
 })
 
@@ -80,8 +74,8 @@ test('View accountant yaml', async () => {
 
 test('Adding a trainee', async () => {
   await page
-    .getByText('Trainee (optional)Add')
-    .getByRole('button', { name: 'Add' })
+    .getByTestId('trainee')
+    .getByRole('button', { name: 'Add and save' })
     .click()
   await page.getByTestId('trainee').getByLabel('Name').fill('Peter Pan')
   await page

--- a/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
@@ -98,14 +98,19 @@ const AddObject = (props: {
       data-testid={`add-${namePath}`}
       onClick={handleAdd}
     >
-      Add
+      Add and save
     </Button>
   )
 }
 
-const RemoveObject = (props: { namePath: string; onRemove: () => void }) => {
-  const { namePath, onRemove } = props
+const RemoveObject = (props: {
+  namePath: string
+  onRemove: () => void
+  idReference: string
+}) => {
+  const { namePath, onRemove, idReference } = props
   const { setValue } = useFormContext()
+  const dmssAPI = useDMSS()
 
   const handleAdd = () => {
     // TODO: Fill with default values using createEntity?
@@ -115,8 +120,15 @@ const RemoveObject = (props: { namePath: string; onRemove: () => void }) => {
       shouldDirty: true,
       shouldTouch: true,
     }
-    setValue(namePath, values, options)
-    onRemove()
+    dmssAPI
+      .documentRemove({ address: `${idReference}.${namePath}` })
+      .then(() => {
+        setValue(namePath, values, options)
+        onRemove()
+      })
+      .catch((error: AxiosError<ErrorResponse>) => {
+        console.error(error)
+      })
   }
   return (
     <Button
@@ -124,7 +136,7 @@ const RemoveObject = (props: { namePath: string; onRemove: () => void }) => {
       data-testid={`remove-${namePath}`}
       onClick={handleAdd}
     >
-      Remove
+      Remove and save
     </Button>
   )
 }
@@ -157,6 +169,7 @@ export const ContainedAttribute = (props: TContentProps): JSX.Element => {
           (isDefined ? (
             <RemoveObject
               namePath={namePath}
+              idReference={idReference}
               onRemove={() => {
                 const options = {
                   shouldValidate: false,
@@ -239,6 +252,7 @@ export const UncontainedAttribute = (props: TContentProps): JSX.Element => {
                   <Stack spacing={1}>
                     <RemoveObject
                       namePath={namePath}
+                      idReference={idReference}
                       onRemove={() => {
                         const options = {
                           shouldValidate: false,


### PR DESCRIPTION
## What does this pull request change?

Made pressing the Remove button cause db to be updated. Also fixed button names to make this more obvious to the user

## Why is this pull request needed?

Pressing add caused db to be updated, but that was not the case for remove

## Issues related to this change

#276 

