### PR TITLE
refactor(entityPicker): update return value

### DIFF
--- a/example/src/plugins/job-ui-single/pages/JobForm.tsx
+++ b/example/src/plugins/job-ui-single/pages/JobForm.tsx
@@ -1,14 +1,14 @@
 import {
   EBlueprint,
-  TJob,
-  Stack,
-  useBlueprint,
-  Loading,
-  TAttribute,
   EntityPickerButton,
   JobStatus,
-  TGenericObject,
+  Loading,
+  Stack,
+  TAttribute,
+  TJob,
   TLinkReference,
+  TValidEntity,
+  useBlueprint,
 } from '@development-framework/dm-core'
 import { Button, TextField } from '@equinor/eds-core-react'
 
@@ -74,9 +74,8 @@ export const JobForm = (props: {
               <>
                 <p>Pick job runner entity:</p>
                 <EntityPickerButton
-                  returnLinkReference={false}
-                  onChange={(chosenRunnerEntity: TGenericObject) => {
-                    setFormData({ ...formData, runner: chosenRunnerEntity })
+                  onChange={(address: string, entity: TValidEntity) => {
+                    setFormData({ ...formData, runner: entity })
                   }}
                 />
                 <p>
@@ -98,11 +97,15 @@ export const JobForm = (props: {
                   </p>
                 </div>
                 <EntityPickerButton
-                  returnLinkReference={true}
-                  onChange={(linkReferenceEntity: TLinkReference) => {
+                  onChange={(address: string, entity: TValidEntity) => {
+                    const ref: TLinkReference = {
+                      type: EBlueprint.REFERENCE,
+                      referenceType: 'link',
+                      address: address,
+                    }
                     setFormData({
                       ...formData,
-                      applicationInput: linkReferenceEntity,
+                      applicationInput: ref,
                     })
                   }}
                 />

--- a/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
@@ -4,10 +4,10 @@ import {
   EntityView,
   ErrorResponse,
   Loading,
-  NewEntityButton,
   Stack,
   TBlueprint,
   TLinkReference,
+  TValidEntity,
   getKey,
   resolveRelativeAddress,
   splitAddress,
@@ -30,11 +30,11 @@ const AddUncontained = (props: {
   namePath: string
   onChange: (event: any) => void
 }) => {
-  const onChange = (entity: any) => {
+  const onChange = (address: string, entity: TValidEntity) => {
     const reference: TLinkReference = {
       type: EBlueprint.REFERENCE,
       referenceType: 'link',
-      address: entity['address'],
+      address: address,
     }
     props.onChange(reference)
   }
@@ -43,14 +43,7 @@ const AddUncontained = (props: {
     <Stack direction="row" spacing={1}>
       <EntityPickerButton
         data-testid={`select-${props.namePath}`}
-        returnLinkReference={true}
         onChange={onChange}
-      />
-      {/*TODO fix hook error and add support for updated reference type in NewEntityButton  component*/}
-      <NewEntityButton
-        data-testid={`new-entity-${props.namePath}`}
-        onCreated={onChange}
-        type={props.type}
       />
     </Stack>
   )

--- a/packages/dm-core/src/components/NewEntityButton.tsx
+++ b/packages/dm-core/src/components/NewEntityButton.tsx
@@ -1,18 +1,18 @@
-import React, { useContext, useEffect, useState } from 'react'
 import { Button, Input, Label, Progress } from '@equinor/eds-core-react'
+import { AxiosError, AxiosResponse } from 'axios'
+import React, { useEffect, useState } from 'react'
 import { Dialog } from './Dialog'
 // @ts-ignore
 import { NotificationManager } from 'react-notifications'
+import styled from 'styled-components'
+import { useDMSS } from '../context/DMSSContext'
+import { TGenericObject, TReference, TValidEntity } from '../types'
+import { INPUT_FIELD_WIDTH } from '../utils/variables'
 import {
   BlueprintPicker,
   DestinationPicker,
   EntityPickerButton,
 } from './Pickers'
-import { AxiosError, AxiosResponse } from 'axios'
-import styled from 'styled-components'
-import { TGenericObject, TReference } from '../types'
-import { INPUT_FIELD_WIDTH } from '../utils/variables'
-import { useDMSS } from '../context/DMSSContext'
 
 const DialogWrapper = styled.div`
   display: flex;
@@ -183,8 +183,9 @@ export function NewEntityButton(props: {
                 buttonVariant="outlined"
                 typeFilter={typeToCreate}
                 alternativeButtonText="Copy existing"
-                returnLinkReference={false}
-                onChange={(ref) => setDocumentToCopy(ref as TGenericObject)}
+                onChange={(address: string, entity: TValidEntity) =>
+                  setDocumentToCopy(entity)
+                }
               />
             ) : (
               <Button

--- a/packages/dm-core/src/components/Pickers/EntityPickerButton.tsx
+++ b/packages/dm-core/src/components/Pickers/EntityPickerButton.tsx
@@ -3,14 +3,14 @@ import React, { useContext, useEffect, useState } from 'react'
 import { Button, Progress } from '@equinor/eds-core-react'
 // @ts-ignore
 import { NotificationManager } from 'react-notifications'
-import { TGenericObject, TLinkReference } from '../../types'
+import { EBlueprint } from '../../Enums'
 import { ApplicationContext } from '../../context/ApplicationContext'
 import { Tree, TreeNode } from '../../domain/Tree'
-import { Dialog } from '../Dialog'
-import { TREE_DIALOG_HEIGHT, TREE_DIALOG_WIDTH } from '../../utils/variables'
-import { TreeView } from '../TreeView'
+import { TValidEntity } from '../../types'
 import { truncatePathString } from '../../utils/truncatePathString'
-import { EBlueprint } from '../../Enums'
+import { TREE_DIALOG_HEIGHT, TREE_DIALOG_WIDTH } from '../../utils/variables'
+import { Dialog } from '../Dialog'
+import { TreeView } from '../TreeView'
 
 /**
  * A component for selecting an Entity or an attribute of an entity.
@@ -28,21 +28,14 @@ import { EBlueprint } from '../../Enums'
  * @param scope: optional attribute to define scope for tree view. The scope will be a path to a folder.
  */
 export const EntityPickerButton = (props: {
-  onChange: (value: TGenericObject | TLinkReference) => void
-  returnLinkReference?: boolean
+  onChange: (address: string, entity: TValidEntity) => void
   typeFilter?: string
   alternativeButtonText?: string
   buttonVariant?: 'contained' | 'outlined' | 'ghost' | 'ghost_icon'
   scope?: string
 }) => {
-  const {
-    onChange,
-    typeFilter,
-    alternativeButtonText,
-    buttonVariant,
-    scope,
-    returnLinkReference = false,
-  } = props
+  const { onChange, typeFilter, alternativeButtonText, buttonVariant, scope } =
+    props
   const appConfig = useContext(ApplicationContext)
   const [showModal, setShowModal] = useState<boolean>(false)
   const [loading, setLoading] = useState<boolean>(true)
@@ -72,15 +65,7 @@ export const EntityPickerButton = (props: {
       .fetch()
       .then((doc: any) => {
         setShowModal(false)
-        onChange(
-          returnLinkReference
-            ? {
-                type: EBlueprint.REFERENCE,
-                referenceType: 'link',
-                address: `dmss://${selectedTreeNode.nodeId}`,
-              }
-            : doc
-        )
+        onChange(`dmss://${selectedTreeNode.nodeId}`, doc)
       })
       .catch((error: any) => {
         console.error(error)


### PR DESCRIPTION
## What does this pull request change?

Changes the input values of EntityPicker

## Why is this pull request needed?

Getting both the address and the entity can be nice, for instance if you want to insert a reference (ie need address), but also want to ensure that the entity type is correct.

## Issues related to this change

