### PR TITLE
style(EntityPicker): remove button styling

### DIFF
--- a/packages/dm-core/src/components/Pickers/EntityPickerButton.tsx
+++ b/packages/dm-core/src/components/Pickers/EntityPickerButton.tsx
@@ -78,9 +78,7 @@ export const EntityPickerButton = (props: {
   }
 
   return (
-    <div
-      style={{ display: 'flex', flexDirection: 'row', margin: '0 10px 10px' }}
-    >
+    <div>
       <Button
         variant={buttonVariant || 'contained'}
         onClick={() => setShowModal(true)}


### PR DESCRIPTION
## What does this pull request change?

## Why is this pull request needed?

If the caller of EntityPickerButton want padding, they can add it themselves

## Issues related to this change

