### PR TITLE
feat(form): use recipe on open

### DIFF
--- a/example/app/data/DemoDataSource/recipes/plugins/form/nested/carRentalCompany.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/nested/carRentalCompany.recipe.json
@@ -31,6 +31,12 @@
         "attributes": [
           {
             "type": "PLUGINS:dm-core-plugins/form/fields/ObjectField",
+            "name": "owner",
+            "showInline": false,
+            "uiRecipe": "defaultForm"
+          },
+          {
+            "type": "PLUGINS:dm-core-plugins/form/fields/ObjectField",
             "name": "trainee",
             "showInline": true,
             "uiRecipe": "defaultForm"

--- a/packages/dm-core-plugins/src/form/components/OpenObjectButton.tsx
+++ b/packages/dm-core-plugins/src/form/components/OpenObjectButton.tsx
@@ -1,14 +1,19 @@
+import {
+  TInlineRecipeViewConfig,
+  TReferenceViewConfig,
+  TViewConfig,
+} from '@development-framework/dm-core'
 import { Button } from '@equinor/eds-core-react'
 import React from 'react'
 import { useRegistryContext } from '../context/RegistryContext'
 
 export const OpenObjectButton = ({
   viewId,
-  namePath,
+  view,
   idReference,
 }: {
   viewId: string
-  namePath: string
+  view: TViewConfig | TReferenceViewConfig | TInlineRecipeViewConfig
   idReference?: string
 }) => {
   const { onOpen } = useRegistryContext()
@@ -16,16 +21,7 @@ export const OpenObjectButton = ({
   return (
     <Button
       variant="outlined"
-      onClick={() =>
-        onOpen?.(
-          viewId || namePath,
-          {
-            type: 'ViewConfig',
-            scope: namePath,
-          },
-          idReference
-        )
-      }
+      onClick={() => onOpen?.(viewId, view, idReference)}
     >
       Open
     </Button>

--- a/packages/dm-core-plugins/src/form/context/RegistryContext.tsx
+++ b/packages/dm-core-plugins/src/form/context/RegistryContext.tsx
@@ -1,9 +1,9 @@
-import { TViewConfig } from '@development-framework/dm-core'
+import { TOnOpen } from '@development-framework/dm-core'
 import React, { createContext, useContext } from 'react'
 
 type Props = {
   idReference: string
-  onOpen?: (key: string, view: TViewConfig, rootId?: string) => void
+  onOpen?: TOnOpen
 }
 
 const RegistryContext = createContext<Props | undefined>(undefined)

--- a/packages/dm-core-plugins/src/form/fields/ArrayField.test.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ArrayField.test.tsx
@@ -1,4 +1,4 @@
-import { TViewConfig } from '@development-framework/dm-core'
+import { TOnOpen } from '@development-framework/dm-core'
 import {
   cleanup,
   fireEvent,
@@ -105,7 +105,7 @@ describe('List of objects', () => {
     onOpen,
   }: {
     config?: TConfig
-    onOpen?: (key: string, view: TViewConfig) => void
+    onOpen?: TOnOpen
   }) => {
     const outer = {
       name: 'Root',

--- a/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
@@ -32,6 +32,7 @@ export default function ArrayField(props: TArrayFieldProps) {
     control,
     name: namePath,
   })
+  const uiRecipeName = getKey<string>(uiAttribute, 'uiRecipe', 'string')
 
   const handleAddObject = () => {
     dmssAPI
@@ -59,7 +60,14 @@ export default function ArrayField(props: TArrayFieldProps) {
     return (
       <Stack spacing={0.25} alignItems="flex-start">
         <Typography bold={true}>{displayLabel}</Typography>
-        <OpenObjectButton viewId={namePath} namePath={namePath} />
+        <OpenObjectButton
+          viewId={namePath}
+          view={{
+            type: 'ReferenceViewConfig',
+            scope: namePath,
+            recipe: uiRecipeName,
+          }}
+        />
       </Stack>
     )
   }
@@ -69,7 +77,7 @@ export default function ArrayField(props: TArrayFieldProps) {
       <Stack spacing={0.5} alignItems="flex-start">
         <Typography bold={true}>{displayLabel}</Typography>
         <EntityView
-          recipeName={getKey<string>(uiAttribute, 'uiRecipe', 'string')}
+          recipeName={uiRecipeName}
           idReference={`${idReference}.${namePath}`}
           type={type}
           onOpen={onOpen}

--- a/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
@@ -186,7 +186,11 @@ export const ContainedAttribute = (props: TContentProps): JSX.Element => {
           <OpenObjectButton
             viewId={namePath}
             idReference={idReference}
-            namePath={namePath}
+            view={{
+              type: 'ReferenceViewConfig',
+              scope: namePath,
+              recipe: uiRecipe?.name,
+            }}
           />
         ) : (
           <Inline
@@ -238,7 +242,7 @@ const Indent = styled.div`
 `
 
 export const UncontainedAttribute = (props: TContentProps): JSX.Element => {
-  const { type, namePath, displayLabel, uiRecipe, uiAttribute } = props
+  const { type, namePath, displayLabel, uiAttribute } = props
   const { watch } = useFormContext()
   const { idReference, onOpen } = useRegistryContext()
   const value = watch(namePath)
@@ -256,13 +260,20 @@ export const UncontainedAttribute = (props: TContentProps): JSX.Element => {
             onRemove={() => undefined}
           />
           {onOpen && !uiAttribute?.showInline ? ( // eslint-disable-line react/prop-types
-            <OpenObjectButton viewId={namePath} namePath="" idReference={id} />
+            <OpenObjectButton
+              viewId={namePath}
+              view={{
+                type: 'ReferenceViewConfig',
+                scope: '',
+                recipe: getKey<string>(uiAttribute, 'uiRecipe', 'string'),
+              }}
+              idReference={id}
+            />
           ) : (
             <EntityView
               idReference={id}
               type={type}
-              // eslint-disable-next-line react/prop-types
-              recipeName={uiRecipe?.name}
+              recipeName={getKey<string>(uiAttribute, 'uiRecipe', 'string')}
               onOpen={onOpen}
             />
           )}

--- a/packages/dm-core-plugins/src/form/types.tsx
+++ b/packages/dm-core-plugins/src/form/types.tsx
@@ -1,8 +1,8 @@
 import {
   TAttribute,
   TBlueprint,
+  TOnOpen,
   TUiRecipe,
-  TViewConfig,
 } from '@development-framework/dm-core'
 
 export type TFormProps = {
@@ -10,7 +10,7 @@ export type TFormProps = {
   type: string
   formData?: any
   config?: TConfig
-  onOpen?: (key: string, view: TViewConfig) => void
+  onOpen?: TOnOpen
   onSubmit?: (data: any) => void
 }
 

--- a/packages/dm-core-plugins/src/table/types.ts
+++ b/packages/dm-core-plugins/src/table/types.ts
@@ -1,6 +1,7 @@
 import {
   TGenericObject,
   TInlineRecipeViewConfig,
+  TOnOpen,
   TReferenceViewConfig,
   TViewConfig,
 } from '@development-framework/dm-core'
@@ -53,6 +54,6 @@ export type TTableRow = {
   items: TTableRowItem[]
   setItems: React.Dispatch<React.SetStateAction<TTableRowItem[]>>
   setDirtyState: React.Dispatch<React.SetStateAction<boolean>>
-  onOpen: any
+  onOpen: TOnOpen
   rowsPerPage: number
 }

--- a/packages/dm-core-plugins/src/view_selector/Content.tsx
+++ b/packages/dm-core-plugins/src/view_selector/Content.tsx
@@ -1,6 +1,6 @@
 import {
   TGenericObject,
-  TViewConfig,
+  TOnOpen,
   ViewCreator,
 } from '@development-framework/dm-core'
 import * as React from 'react'
@@ -18,7 +18,7 @@ export const Content = (props: {
   selectedView: string
   items: TItemData[]
   setFormData: (v: TGenericObject) => void
-  onOpen: (id: string, v: TViewConfig) => void
+  onOpen: TOnOpen
   formData: TGenericObject
 }): JSX.Element => {
   const { selectedView, items, setFormData, formData, onOpen, type } = props

--- a/packages/dm-core-plugins/src/view_selector/ViewSelectorPlugin.tsx
+++ b/packages/dm-core-plugins/src/view_selector/ViewSelectorPlugin.tsx
@@ -2,15 +2,18 @@ import {
   IUIPlugin,
   Loading,
   TGenericObject,
+  TInlineRecipeViewConfig,
+  TOnOpen,
+  TReferenceViewConfig,
   TViewConfig,
   useDocument,
 } from '@development-framework/dm-core'
 import * as React from 'react'
 import { useEffect, useState } from 'react'
+import { Content } from './Content'
 import { Sidebar } from './Sidebar'
 import { Tabs } from './Tabs'
-import { Content } from './Content'
-import { TViewSelectorConfig, TViewSelectorItem, TItemData } from './types'
+import { TItemData, TViewSelectorConfig, TViewSelectorItem } from './types'
 
 export const ViewSelectorPlugin = (
   props: IUIPlugin & { config?: TViewSelectorConfig }
@@ -27,7 +30,11 @@ export const ViewSelectorPlugin = (
   const [views, setViews] = useState<TItemData[]>([])
   const [formData, setFormData] = useState<TGenericObject>({})
 
-  function addView(viewId: string, view: TViewConfig, rootId?: string) {
+  const addView: TOnOpen = (
+    viewId: string,
+    view: TViewConfig | TReferenceViewConfig | TInlineRecipeViewConfig,
+    rootId?: string
+  ) => {
     if (!views.find((view: TItemData) => view.viewId === viewId)) {
       // View does not exist, add it
       const newView: TItemData = {

--- a/packages/dm-core/src/types.ts
+++ b/packages/dm-core/src/types.ts
@@ -93,9 +93,15 @@ export interface IUIPlugin {
   type: string
   idReference: string
   onSubmit?: (data: any) => void
-  onOpen?: (key: string, view: TViewConfig, rootId?: string) => void
+  onOpen?: TOnOpen
   config?: any
 }
+
+export type TOnOpen = (
+  viewId: string,
+  view: TViewConfig | TReferenceViewConfig | TInlineRecipeViewConfig,
+  rootId?: string
+) => void
 
 export type TUiPluginMap = { [pluginName: string]: TPlugin }
 


### PR DESCRIPTION
## What does this pull request change?

- Refactor type of onOpen function to TOnOpen
- Update Form Open button to using recipe to select view
- Add example

## Why is this pull request needed?

Having a TOnOpen makes it less likely that we have different varieties of the type lying around

## Issues related to this change

#276

