### PR TITLE
test(jest): remove validation warning

### DIFF
--- a/packages/dm-core-plugins/jest.config.js
+++ b/packages/dm-core-plugins/jest.config.js
@@ -3,6 +3,5 @@ const base = require('../../jest.config.base')
 module.exports = {
   ...base,
   testEnvironment: 'jsdom',
-  name: packageJson.name,
   displayName: packageJson.name,
 }

--- a/packages/dm-core/jest.config.js
+++ b/packages/dm-core/jest.config.js
@@ -3,6 +3,5 @@ const base = require('../../jest.config.base')
 module.exports = {
   ...base,
   testEnvironment: 'jsdom',
-  name: packageJson.name,
   displayName: packageJson.name,
 }


### PR DESCRIPTION
## What does this pull request change?

Removes the name config, since it doesn't exists, and only serves to give us validation warnings

## Why is this pull request needed?

## Issues related to this change

