### PR TITLE
ci: avoid running no-commit-to-branch on PR merge

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,7 @@ repos:
       - id: detect-private-key
       - id: no-commit-to-branch
         args: [--branch, main]
+        stages: [commit-msg]
 
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v2.3.0


### PR DESCRIPTION
## What does this pull request change?

A bit hackish solution to the no-commit-to-branch hook being run after a PR is merged. The commit-msg stage is only run on creating a commit, while the default pre-commit is also run on pre-commit run -a

## Why is this pull request needed?

## Issues related to this change

