### PR TITLE
fix: stable job version

### DIFF
--- a/example/docker-compose.yaml
+++ b/example/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
       MONGO_INITDB_ROOT_PASSWORD: maf
 
   job-api:
-    image: datamodelingtool.azurecr.io/dm-job
+    image: datamodelingtool.azurecr.io/dm-job:v1.0.6
     platform: linux/amd64
     restart: unless-stopped
     environment:


### PR DESCRIPTION
## What does this pull request change?

Locks dm-job version to 1.0.6

## Why is this pull request needed?

## Issues related to this change

