### PR TITLE
test(form): add required number field to example

### DIFF
--- a/example/app/data/DemoDataSource/plugins/form/simple/blueprints/Simple.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/form/simple/blueprints/Simple.blueprint.json
@@ -22,6 +22,13 @@
       "optional": false
     },
     {
+      "name": "numberRequired",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "number",
+      "label": "A required number",
+      "optional": false
+    },
+    {
       "name": "number",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "number",

--- a/example/app/data/DemoDataSource/plugins/form/simple/simple.entity.json
+++ b/example/app/data/DemoDataSource/plugins/form/simple/simple.entity.json
@@ -2,6 +2,7 @@
   "_id": "Simple",
   "type": "./blueprints/Simple",
   "stringRequired": "",
+  "numberRequired": 2,
   "stringOptional": "a prefilled optional string",
   "requiredCheckbox": false
 }


### PR DESCRIPTION
## What does this pull request change?

## Why is this pull request needed?

I found a bug in the number field that would have been found earlier had we had a proper example of the input field for mandatory numbers

## Issues related to this change

