### PR TITLE
fix(form): numberfield doesn't display helpertext on missing, required number

### DIFF
--- a/e2e/tests/plugin-form-Simple.spec.ts
+++ b/e2e/tests/plugin-form-Simple.spec.ts
@@ -13,7 +13,7 @@ test('Simple form', async ({ page }) => {
 
   //Fill out required string
   await page.getByTestId('form-submit').click()
-  await expect(page.getByText('required', { exact: true })).toBeVisible()
+  await expect(page.getByText('Required', { exact: true })).toBeVisible()
   await page.getByLabel('Required string').fill('Foo')
 
   //Fill out number field

--- a/packages/dm-core-plugins/src/form/fields/NumberField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/NumberField.tsx
@@ -31,7 +31,7 @@ export const NumberField = (props: TNumberFieldProps) => {
     <Controller
       name={namePath}
       rules={{
-        required: !optional,
+        required: optional ? false : 'Required',
         pattern: {
           value: isInteger ? REGEX_INTEGER : REGEX_FLOAT,
           message: isInteger ? 'Only integers allowed' : 'Only numbers allowed',
@@ -50,7 +50,7 @@ export const NumberField = (props: TNumberFieldProps) => {
             id={namePath}
             label={displayLabel}
             inputRef={ref}
-            helperText={error?.message}
+            helperText={error?.message || error?.type}
             variant={invalid ? 'error' : undefined}
           />
         )

--- a/packages/dm-core-plugins/src/form/fields/StringField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/StringField.tsx
@@ -16,7 +16,7 @@ export const StringField = (props: TStringFieldProps) => {
     <Controller
       name={namePath}
       rules={{
-        required: !optional,
+        required: optional ? false : 'Required',
       }}
       defaultValue={defaultValue ?? ''}
       render={({


### PR DESCRIPTION
## What does this pull request change?

Make helpertext show and improve message

## Why is this pull request needed?

A helpertext should show up if you try to submit a form with an empty, mandatory number. Currently, it only got a red border.

## Issues related to this change

