### PR TITLE
test(form): redefine number field tests

### DIFF
--- a/packages/dm-core-plugins/src/form/fields/NumberField.test.tsx
+++ b/packages/dm-core-plugins/src/form/fields/NumberField.test.tsx
@@ -40,25 +40,28 @@ const setup = async (
     { wrapper }
   )
   return await waitFor(() => {
-    const input = screen.getByLabelText<HTMLInputElement>('number')
-    const submit = screen.getByRole<HTMLButtonElement>('button')
-    return { ...utils, input, submit, onSubmit }
+    const inputElement = screen.getByLabelText<HTMLInputElement>('number')
+    const setValue = (value: string) =>
+      fireEvent.change(inputElement, { target: { value: value } })
+    const submit = () =>
+      fireEvent.submit(screen.getByRole<HTMLButtonElement>('button'))
+    return { ...utils, inputElement, setValue, submit, onSubmit }
   })
 }
 
 test('Input field exists', async () => {
   const utils = await setup('', false, false)
-  expect(utils.input).toBeDefined()
+  expect(utils.inputElement).toBeDefined()
 })
 
 test('Initial value is entered', async () => {
   const utils = await setup('5e2', false, false)
-  expect(utils.input.value).toBe('5e2')
+  expect(utils.inputElement.value).toBe('5e2')
 })
 
 test('Error is raised on text input', async () => {
   const utils = await setup('hei', false, false)
-  fireEvent.submit(utils.submit)
+  utils.submit()
   await waitFor(() => {
     expect(screen.queryByText('Only numbers allowed')).not.toBeNull()
   })
@@ -66,7 +69,7 @@ test('Error is raised on text input', async () => {
 
 test('Error is raised on invalid number', async () => {
   const utils = await setup('1.', false, false)
-  fireEvent.submit(utils.submit)
+  utils.submit()
   await waitFor(() => {
     expect(screen.queryByText('Only numbers allowed')).not.toBeNull()
   })
@@ -74,7 +77,7 @@ test('Error is raised on invalid number', async () => {
 
 test('Error is not raised on exponential', async () => {
   const utils = await setup('1e2', false, false)
-  fireEvent.submit(utils.submit)
+  utils.submit()
   await waitFor(() => {
     expect(screen.queryByText('Only numbers allowed')).toBeNull()
   })
@@ -82,7 +85,7 @@ test('Error is not raised on exponential', async () => {
 
 test('Error is raised on float', async () => {
   const utils = await setup('1.5', false, true)
-  fireEvent.submit(utils.submit)
+  utils.submit()
   await waitFor(() => {
     expect(screen.queryByText('Only integers allowed')).not.toBeNull()
   })
@@ -90,11 +93,11 @@ test('Error is raised on float', async () => {
 
 test('Error disappears immediately after fix', async () => {
   const utils = await setup('hei', false, false)
-  fireEvent.submit(utils.submit)
+  utils.submit()
   await waitFor(() => {
     expect(screen.queryByText('Only numbers allowed')).not.toBeNull()
   })
-  fireEvent.change(utils.input, { target: { value: '1' } })
+  utils.setValue('1')
   await waitFor(() => {
     expect(screen.queryByText('Only numbers allowed')).toBeNull()
   })
@@ -102,7 +105,7 @@ test('Error disappears immediately after fix', async () => {
 
 test('Error is raised on missing, required input', async () => {
   const utils = await setup('', false, false)
-  fireEvent.submit(utils.submit)
+  utils.submit()
   await waitFor(() => {
     expect(screen.queryByText('Required')).not.toBeNull()
   })
@@ -110,7 +113,7 @@ test('Error is raised on missing, required input', async () => {
 
 test('Error is not raised on missing, optional input', async () => {
   const utils = await setup('', true, false)
-  fireEvent.submit(utils.submit)
+  utils.submit()
   await waitFor(() => {
     expect(screen.queryByText('Required')).toBeNull()
   })
@@ -118,7 +121,7 @@ test('Error is not raised on missing, optional input', async () => {
 
 test('Submit is not called when input is invalid', async () => {
   const utils = await setup('hei', false, false)
-  fireEvent.submit(utils.submit)
+  utils.submit()
   await waitFor(() => {
     expect(utils.onSubmit).not.toHaveBeenCalled()
   })
@@ -126,7 +129,7 @@ test('Submit is not called when input is invalid', async () => {
 
 test('Submit is called when input is valid', async () => {
   const utils = await setup('5', false, false)
-  fireEvent.submit(utils.submit)
+  utils.submit()
   await waitFor(() => {
     expect(utils.onSubmit).toHaveBeenCalled()
   })

--- a/packages/dm-core-plugins/src/form/fields/NumberField.test.tsx
+++ b/packages/dm-core-plugins/src/form/fields/NumberField.test.tsx
@@ -11,11 +11,12 @@ import { NumberField } from './NumberField'
 
 afterEach(() => cleanup())
 
-const setup = async (
-  initialValue: string,
-  optional: boolean,
-  isInteger: boolean
-) => {
+const setup = async (props: {
+  initialValue?: string
+  optional?: boolean
+  isInteger?: boolean
+}) => {
+  const { initialValue = '1', optional = false, isInteger = false } = props
   const onSubmit = jest.fn()
   const wrapper = (props: { children: React.ReactNode }) => {
     const methods = useForm()
@@ -50,17 +51,18 @@ const setup = async (
 }
 
 test('Input field exists', async () => {
-  const utils = await setup('', false, false)
+  const utils = await setup({})
   expect(utils.inputElement).toBeDefined()
 })
 
 test('Initial value is entered', async () => {
-  const utils = await setup('5e2', false, false)
+  const utils = await setup({ initialValue: '5e2' })
   expect(utils.inputElement.value).toBe('5e2')
 })
 
 test('Error is raised on text input', async () => {
-  const utils = await setup('hei', false, false)
+  const utils = await setup({})
+  utils.setValue('hei')
   utils.submit()
   await waitFor(() => {
     expect(screen.queryByText('Only numbers allowed')).not.toBeNull()
@@ -68,7 +70,8 @@ test('Error is raised on text input', async () => {
 })
 
 test('Error is raised on invalid number', async () => {
-  const utils = await setup('1.', false, false)
+  const utils = await setup({})
+  utils.setValue('1.')
   utils.submit()
   await waitFor(() => {
     expect(screen.queryByText('Only numbers allowed')).not.toBeNull()
@@ -76,7 +79,8 @@ test('Error is raised on invalid number', async () => {
 })
 
 test('Error is not raised on exponential', async () => {
-  const utils = await setup('1e2', false, false)
+  const utils = await setup({})
+  utils.setValue('1e2')
   utils.submit()
   await waitFor(() => {
     expect(screen.queryByText('Only numbers allowed')).toBeNull()
@@ -84,7 +88,8 @@ test('Error is not raised on exponential', async () => {
 })
 
 test('Error is raised on float', async () => {
-  const utils = await setup('1.5', false, true)
+  const utils = await setup({ isInteger: true })
+  utils.setValue('1.5')
   utils.submit()
   await waitFor(() => {
     expect(screen.queryByText('Only integers allowed')).not.toBeNull()
@@ -92,7 +97,8 @@ test('Error is raised on float', async () => {
 })
 
 test('Error disappears immediately after fix', async () => {
-  const utils = await setup('hei', false, false)
+  const utils = await setup({})
+  utils.setValue('hei')
   utils.submit()
   await waitFor(() => {
     expect(screen.queryByText('Only numbers allowed')).not.toBeNull()
@@ -104,7 +110,8 @@ test('Error disappears immediately after fix', async () => {
 })
 
 test('Error is raised on missing, required input', async () => {
-  const utils = await setup('', false, false)
+  const utils = await setup({})
+  utils.setValue('')
   utils.submit()
   await waitFor(() => {
     expect(screen.queryByText('Required')).not.toBeNull()
@@ -112,7 +119,8 @@ test('Error is raised on missing, required input', async () => {
 })
 
 test('Error is not raised on missing, optional input', async () => {
-  const utils = await setup('', true, false)
+  const utils = await setup({ optional: true })
+  utils.setValue('')
   utils.submit()
   await waitFor(() => {
     expect(screen.queryByText('Required')).toBeNull()
@@ -120,7 +128,8 @@ test('Error is not raised on missing, optional input', async () => {
 })
 
 test('Submit is not called when input is invalid', async () => {
-  const utils = await setup('hei', false, false)
+  const utils = await setup({})
+  utils.setValue('hei')
   utils.submit()
   await waitFor(() => {
     expect(utils.onSubmit).not.toHaveBeenCalled()
@@ -128,7 +137,8 @@ test('Submit is not called when input is invalid', async () => {
 })
 
 test('Submit is called when input is valid', async () => {
-  const utils = await setup('5', false, false)
+  const utils = await setup({})
+  utils.setValue('5')
   utils.submit()
   await waitFor(() => {
     expect(utils.onSubmit).toHaveBeenCalled()


### PR DESCRIPTION
## What does this pull request change?

Complete rewrite of the numberfield tests.

## Why is this pull request needed?

The previous tests were testing a lot of things that were not relevant for the number field it was supposed to test.

## Issues related to this change

