### PR TITLE
test(form): add example of storage uncontained

### DIFF
--- a/example/app/data/DemoDataSource/plugins/form/storage_uncontained/blueprints/Result.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/form/storage_uncontained/blueprints/Result.blueprint.json
@@ -1,0 +1,14 @@
+{
+  "name": "Result",
+  "type": "CORE:Blueprint",
+  "extends": [
+    "CORE:NamedEntity"
+  ],
+  "attributes": [
+    {
+      "name": "value",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "number"
+    }
+  ]
+}

--- a/example/app/data/DemoDataSource/plugins/form/storage_uncontained/blueprints/Simulation.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/form/storage_uncontained/blueprints/Simulation.blueprint.json
@@ -1,0 +1,15 @@
+{
+  "name": "Simulation",
+  "type": "CORE:Blueprint",
+  "extends": [
+    "CORE:NamedEntity"
+  ],
+  "attributes": [
+    {
+      "name": "bestSimulationResult",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "./Result",
+      "optional": true
+    }
+  ]
+}

--- a/example/app/data/DemoDataSource/plugins/form/storage_uncontained/result.entity.json
+++ b/example/app/data/DemoDataSource/plugins/form/storage_uncontained/result.entity.json
@@ -1,0 +1,7 @@
+{
+  "_id": "bestResult2023",
+  "name": "bestResult2023",
+  "type": "./blueprints/Result",
+  "description": "Example simulation",
+  "value": 10000000000
+}

--- a/example/app/data/DemoDataSource/plugins/form/storage_uncontained/simulation.entity.json
+++ b/example/app/data/DemoDataSource/plugins/form/storage_uncontained/simulation.entity.json
@@ -1,0 +1,11 @@
+{
+  "_id": "simulation1",
+  "name": "simulation1",
+  "type": "./blueprints/Simulation",
+  "description": "Example simulation",
+  "bestSimulationResult": {
+    "type": "CORE:Reference",
+    "address": "./bestResult2023",
+    "referenceType": "storage"
+  }
+}

--- a/example/app/data/DemoDataSource/recipes/plugins/form/storage_uncontained/result.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/storage_uncontained/result.recipe.json
@@ -1,0 +1,21 @@
+{
+  "type": "CORE:RecipeLink",
+  "_blueprintPath_": "/plugins/form/storage_uncontained/blueprints/Result",
+  "initialUiRecipe": {
+    "name": "Edit",
+    "type": "CORE:UiRecipe",
+    "plugin": "@development-framework/dm-core-plugins/form"
+  },
+  "uiRecipes": [
+    {
+      "name": "Form",
+      "type": "CORE:UiRecipe",
+      "plugin": "@development-framework/dm-core-plugins/form"
+    },
+    {
+      "name": "Yaml",
+      "type": "CORE:UiRecipe",
+      "plugin": "@development-framework/dm-core-plugins/yaml"
+    }
+  ]
+}

--- a/example/app/data/DemoDataSource/recipes/plugins/form/storage_uncontained/simulation.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/storage_uncontained/simulation.recipe.json
@@ -1,0 +1,24 @@
+{
+  "type": "CORE:RecipeLink",
+  "_blueprintPath_": "/plugins/form/storage_uncontained/blueprints/Simulation",
+  "initialUiRecipe": {
+    "name": "Edit",
+    "type": "CORE:UiRecipe",
+    "description": "Default edit",
+    "plugin": "@development-framework/dm-core-plugins/form"
+  },
+  "storageRecipes": [
+    {
+      "name": "DEFAULT",
+      "type": "dmss://system/SIMOS/StorageRecipe",
+      "description": "",
+      "attributes": [
+        {
+          "name": "bestSimulationResult",
+          "type": "dmss://system/SIMOS/StorageAttribute",
+          "contained": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What does this pull request change?

Adds simple example

## Why is this pull request needed?

Need to make an example to work with when adapting form to storage uncontained.

## Issues related to this change

