### PR TITLE
fix: remove all edit buttons when in readOnly mode

### DIFF
--- a/example/app/data/DemoDataSource/recipes/plugins/form/read_only/carRentalCompany.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/read_only/carRentalCompany.recipe.json
@@ -36,6 +36,12 @@
             "uiRecipe": "defaultForm"
           },
           {
+            "name": "ceo",
+            "type": "PLUGINS:dm-core-plugins/form/fields/ObjectField",
+            "showInline": false,
+            "uiRecipe": "defaultForm"
+          },
+          {
             "name": "trainee",
             "type": "PLUGINS:dm-core-plugins/form/fields/ObjectField",
             "showInline": true,
@@ -56,6 +62,11 @@
             "name": "locations",
             "type": "PLUGINS:dm-core-plugins/form/fields/ArrayField",
             "showInline": true
+          },
+          {
+            "name": "customers",
+            "type": "PLUGINS:dm-core-plugins/form/fields/ArrayField",
+            "showInline": false
           }
         ],
         "fields": [
@@ -68,8 +79,7 @@
           "customers",
           "isBankrupt"
         ],
-        "readOnly": true,
-        "editToggle": true
+        "readOnly": true
       }
     }
   ]

--- a/example/app/data/DemoDataSource/recipes/plugins/form/read_only/customer.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/read_only/customer.recipe.json
@@ -4,7 +4,11 @@
   "initialUiRecipe": {
     "name": "form",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/form"
+    "plugin": "@development-framework/dm-core-plugins/form",
+    "config": {
+      "type": "PLUGINS:dm-core-plugins/form/FormInput",
+      "readOnly": true
+    }
   },
   "uiRecipes": [
     {

--- a/packages/dm-core-plugins/blueprints/form/FormInput.json
+++ b/packages/dm-core-plugins/blueprints/form/FormInput.json
@@ -32,14 +32,6 @@
       "optional": true,
       "contained": true,
       "default": false
-    },
-    {
-      "name": "editToggle",
-      "type": "dmss://system/SIMOS/BlueprintAttribute",
-      "attributeType": "boolean",
-      "optional": true,
-      "contained": true,
-      "default": false
     }
   ]
 }

--- a/packages/dm-core-plugins/src/form/components/AttributeList.tsx
+++ b/packages/dm-core-plugins/src/form/components/AttributeList.tsx
@@ -1,8 +1,7 @@
-import { Stack, TAttribute, TBlueprint } from '@development-framework/dm-core'
-import React, { useState } from 'react'
+import { TAttribute, TBlueprint } from '@development-framework/dm-core'
+import React from 'react'
 import { AttributeField } from '../fields/AttributeField'
 import { TConfig } from '../types'
-import { Button } from '@equinor/eds-core-react'
 
 export const AttributeList = (props: {
   namePath: string
@@ -10,14 +9,6 @@ export const AttributeList = (props: {
   blueprint: TBlueprint | undefined
 }) => {
   const { namePath, config, blueprint } = props
-
-  const [readOnly, setReadOnly] = useState<boolean | undefined>(
-    config?.readOnly
-  )
-  const toggleHandler = () => {
-    setReadOnly(!readOnly)
-  }
-
   const prefix = namePath === '' ? `` : `${namePath}.`
 
   const attributes = blueprint?.attributes ?? []
@@ -43,18 +34,11 @@ export const AttributeList = (props: {
           namePath={`${prefix}${attribute.name}`}
           attribute={attribute}
           uiAttribute={uiAttribute}
-          readOnly={readOnly}
+          readOnly={config?.readOnly}
         />
       </div>
     )
   })
 
-  return (
-    <Stack spacing={1}>
-      {config?.editToggle && (
-        <Button onClick={toggleHandler}>{readOnly ? 'Edit' : 'View'}</Button>
-      )}
-      {attributeFields}
-    </Stack>
-  )
+  return <>{attributeFields}</>
 }

--- a/packages/dm-core-plugins/src/form/components/Form.tsx
+++ b/packages/dm-core-plugins/src/form/components/Form.tsx
@@ -54,13 +54,15 @@ export const Form = (props: TFormProps) => {
                 config={config}
                 blueprint={blueprint}
               />
-              <Button
-                type="submit"
-                data-testid="form-submit"
-                style={{ alignSelf: 'flex-start' }}
-              >
-                Submit
-              </Button>
+              {!config?.readOnly && (
+                <Button
+                  type="submit"
+                  data-testid="form-submit"
+                  style={{ alignSelf: 'flex-start' }}
+                >
+                  Submit
+                </Button>
+              )}
             </Stack>
           </form>
         </RegistryProvider>

--- a/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
@@ -111,32 +111,34 @@ export default function ArrayField(props: TArrayFieldProps) {
                 readOnly={readOnly}
               />
             </Stack>
-            <Button
-              disabled={readOnly}
-              variant="outlined"
-              type="button"
-              onClick={() => remove(index)}
-            >
-              Remove
-            </Button>
+            {!readOnly && (
+              <Button
+                variant="outlined"
+                type="button"
+                onClick={() => remove(index)}
+              >
+                Remove
+              </Button>
+            )}
           </Stack>
         )
       })}
-      <Button
-        disabled={readOnly}
-        variant="outlined"
-        data-testid={`add-${namePath}`}
-        onClick={() => {
-          if (isPrimitiveType(type)) {
-            const defaultValue = isPrimitive(type) ? ' ' : {}
-            append(defaultValue)
-          } else {
-            handleAddObject()
-          }
-        }}
-      >
-        Add
-      </Button>
+      {!readOnly && (
+        <Button
+          variant="outlined"
+          data-testid={`add-${namePath}`}
+          onClick={() => {
+            if (isPrimitiveType(type)) {
+              const defaultValue = isPrimitive(type) ? ' ' : {}
+              append(defaultValue)
+            } else {
+              handleAddObject()
+            }
+          }}
+        >
+          Add
+        </Button>
+      )}
     </Stack>
   )
 }

--- a/packages/dm-core-plugins/src/form/fields/AttributeField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/AttributeField.tsx
@@ -65,6 +65,7 @@ export const AttributeField = (props: TAttributeFieldProps) => {
           optional={attribute.optional ?? false}
           uiAttribute={uiAttribute}
           defaultValue={attribute.default}
+          readOnly={readOnly}
         />
       )
 

--- a/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
@@ -167,16 +167,17 @@ export const ContainedAttribute = (props: TContentProps): JSX.Element => {
     uiRecipe,
     blueprint,
     defaultValue,
+    readOnly,
   } = props
   const { watch } = useFormContext()
   const { idReference, onOpen } = useRegistryContext()
   const value = watch(namePath)
   const isDefined = value && Object.keys(value).length > 0
-
   return (
     <Stack spacing={0.25} alignItems="flex-start">
       <Typography bold={true}>{displayLabel}</Typography>
       {optional &&
+        !readOnly &&
         (isDefined ? (
           <RemoveObject namePath={namePath} />
         ) : (
@@ -247,8 +248,15 @@ const Indent = styled.div`
 `
 
 export const UncontainedAttribute = (props: TContentProps): JSX.Element => {
-  const { type, namePath, displayLabel, uiAttribute, uiRecipe, optional } =
-    props
+  const {
+    type,
+    namePath,
+    displayLabel,
+    uiAttribute,
+    uiRecipe,
+    optional,
+    readOnly,
+  } = props
   const { watch } = useFormContext()
   const { idReference, onOpen } = useRegistryContext()
   const value = watch(namePath)
@@ -263,8 +271,10 @@ export const UncontainedAttribute = (props: TContentProps): JSX.Element => {
       <Typography bold={true}>{displayLabel}</Typography>
       {address && <Typography>Address: {value.address}</Typography>}
       <Stack direction="row" spacing={0.5}>
-        <SelectReference type={type} namePath={namePath} />
-        {optional && address && <RemoveObject namePath={namePath} />}
+        {!readOnly && <SelectReference type={type} namePath={namePath} />}
+        {optional && address && !readOnly && (
+          <RemoveObject namePath={namePath} />
+        )}
         {address && onOpen && !uiAttribute?.showInline && (
           <OpenObjectButton
             viewId={namePath}
@@ -321,6 +331,7 @@ export const ObjectTypeSelector = (props: TObjectFieldProps): JSX.Element => {
     contained,
     uiAttribute,
     defaultValue,
+    readOnly,
   } = props
 
   const { blueprint, uiRecipes, isLoading, error } = useBlueprint(type)
@@ -345,6 +356,7 @@ export const ObjectTypeSelector = (props: TObjectFieldProps): JSX.Element => {
       uiRecipe={uiRecipe}
       uiAttribute={uiAttribute}
       defaultValue={defaultValue}
+      readOnly={readOnly}
     />
   )
 }

--- a/packages/dm-core-plugins/src/form/types.tsx
+++ b/packages/dm-core-plugins/src/form/types.tsx
@@ -99,7 +99,6 @@ export type TConfig = {
   attributes: TAttributeConfig[]
   fields: string[]
   readOnly?: boolean
-  editToggle?: boolean
 }
 
 export type TUiRecipeForm = Omit<TUiRecipe, 'config'> & { config: TConfig }


### PR DESCRIPTION
## What does this pull request change?
Removes the [Add and Save], [Select and Save], [Add], [Remove] and [Add Item] (ListPlugin) buttons when in read only mode.

## Why is this pull request needed?
It should not be possible to delete or add objects when in read only mode.

## Issues related to this change
Closes #496
