### PR TITLE
test: readonly primitives

### DIFF
--- a/e2e/tests/plugin-form-ReadOnlyPrimitives.spec.ts
+++ b/e2e/tests/plugin-form-ReadOnlyPrimitives.spec.ts
@@ -1,0 +1,98 @@
+import { expect, test } from '@playwright/test'
+
+test('Read only primitives', async ({ page }) => {
+  await page.goto('http://localhost:3000/')
+  await page.getByText('plugins', { exact: true }).click()
+  await page.getByText('form').click()
+  await page.getByText('read_only_primitives').click()
+  await page.getByText('ReadOnlyPrimitives').click()
+
+  const checkNotEditable = async () => {
+    await expect(
+      page.getByTestId('stringRequired').getByTestId('form-textfield')
+    ).not.toBeEditable()
+
+    await expect(
+      page.getByTestId('stringOptional').getByTestId('form-textfield')
+    ).not.toBeEditable()
+
+    await expect(
+      page.getByTestId('numberRequired').getByTestId('form-textfield')
+    ).not.toBeEditable()
+
+    await expect(
+      page.getByTestId('numberOptional').getByTestId('form-textfield')
+    ).not.toBeEditable()
+
+    await expect(
+      page.getByTestId('integer').getByTestId('form-textfield')
+    ).not.toBeEditable()
+
+    await expect(
+      page.getByTestId('checkboxOptional').getByTestId('form-checkbox')
+    ).not.toBeEditable()
+
+    await expect(
+      page.getByTestId('checkboxRequired').getByTestId('form-checkbox')
+    ).not.toBeEditable()
+  }
+
+  await checkNotEditable()
+
+  await page.getByRole('button', { name: 'Edit' }).click()
+
+  await expect(
+    page.getByTestId('stringRequired').getByTestId('form-textfield')
+  ).toBeEditable()
+  await page
+    .getByTestId('stringRequired')
+    .getByTestId('form-textfield')
+    .fill('Updated required string')
+
+  await expect(
+    page.getByTestId('stringOptional').getByTestId('form-textfield')
+  ).toBeEditable()
+  await page
+    .getByTestId('stringOptional')
+    .getByTestId('form-textfield')
+    .fill('Updated optional string')
+
+  await expect(
+    page.getByTestId('numberRequired').getByTestId('form-textfield')
+  ).toBeEditable()
+  await page
+    .getByTestId('numberRequired')
+    .getByTestId('form-textfield')
+    .fill('2.2')
+
+  await expect(
+    page.getByTestId('numberOptional').getByTestId('form-textfield')
+  ).toBeEditable()
+  await page.getByTestId('numberOptional').getByTestId('form-textfield').clear()
+
+  await expect(
+    page.getByTestId('integer').getByTestId('form-textfield')
+  ).toBeEditable()
+  await page.getByTestId('integer').getByTestId('form-textfield').fill('33')
+
+  await expect(
+    page.getByTestId('checkboxOptional').getByTestId('form-checkbox')
+  ).toBeEditable()
+  await page
+    .getByTestId('checkboxOptional')
+    .getByTestId('form-checkbox')
+    .check()
+
+  await expect(
+    page.getByTestId('checkboxRequired').getByTestId('form-checkbox')
+  ).toBeEditable()
+  await page
+    .getByTestId('checkboxRequired')
+    .getByTestId('form-checkbox')
+    .uncheck()
+
+  await page.getByRole('button', { name: 'Submit' }).click()
+  await expect(page.getByRole('alert')).toHaveText(['Document updated'])
+
+  await checkNotEditable()
+})

--- a/e2e/tests/plugin-form-ReadOnlyPrimitives.spec.ts
+++ b/e2e/tests/plugin-form-ReadOnlyPrimitives.spec.ts
@@ -7,92 +7,23 @@ test('Read only primitives', async ({ page }) => {
   await page.getByText('read_only_primitives').click()
   await page.getByText('ReadOnlyPrimitives').click()
 
-  const checkNotEditable = async () => {
-    await expect(
-      page.getByTestId('stringRequired').getByTestId('form-textfield')
-    ).not.toBeEditable()
-
-    await expect(
-      page.getByTestId('stringOptional').getByTestId('form-textfield')
-    ).not.toBeEditable()
-
-    await expect(
-      page.getByTestId('numberRequired').getByTestId('form-textfield')
-    ).not.toBeEditable()
-
-    await expect(
-      page.getByTestId('numberOptional').getByTestId('form-textfield')
-    ).not.toBeEditable()
-
-    await expect(
-      page.getByTestId('integer').getByTestId('form-textfield')
-    ).not.toBeEditable()
-
-    await expect(
-      page.getByTestId('checkboxOptional').getByTestId('form-checkbox')
-    ).not.toBeEditable()
-
-    await expect(
-      page.getByTestId('checkboxRequired').getByTestId('form-checkbox')
-    ).not.toBeEditable()
-  }
-
-  await checkNotEditable()
-
-  await page.getByRole('button', { name: 'Edit' }).click()
+  await expect(page.getByLabel('A required string')).not.toBeEditable()
 
   await expect(
-    page.getByTestId('stringRequired').getByTestId('form-textfield')
-  ).toBeEditable()
-  await page
-    .getByTestId('stringRequired')
-    .getByTestId('form-textfield')
-    .fill('Updated required string')
+    page.getByLabel('An optional string (optional)')
+  ).not.toBeEditable()
+
+  await expect(page.getByLabel('A required number')).not.toBeEditable()
+
+  await expect(page.getByLabel('Numbers only (optional)')).not.toBeEditable()
+
+  await expect(page.getByLabel('Integer only (optional)')).not.toBeEditable()
 
   await expect(
-    page.getByTestId('stringOptional').getByTestId('form-textfield')
-  ).toBeEditable()
-  await page
-    .getByTestId('stringOptional')
-    .getByTestId('form-textfield')
-    .fill('Updated optional string')
+    page.getByLabel('An optional checkbox (optional)')
+  ).not.toBeEditable()
 
   await expect(
-    page.getByTestId('numberRequired').getByTestId('form-textfield')
-  ).toBeEditable()
-  await page
-    .getByTestId('numberRequired')
-    .getByTestId('form-textfield')
-    .fill('2.2')
-
-  await expect(
-    page.getByTestId('numberOptional').getByTestId('form-textfield')
-  ).toBeEditable()
-  await page.getByTestId('numberOptional').getByTestId('form-textfield').clear()
-
-  await expect(
-    page.getByTestId('integer').getByTestId('form-textfield')
-  ).toBeEditable()
-  await page.getByTestId('integer').getByTestId('form-textfield').fill('33')
-
-  await expect(
-    page.getByTestId('checkboxOptional').getByTestId('form-checkbox')
-  ).toBeEditable()
-  await page
-    .getByTestId('checkboxOptional')
-    .getByTestId('form-checkbox')
-    .check()
-
-  await expect(
-    page.getByTestId('checkboxRequired').getByTestId('form-checkbox')
-  ).toBeEditable()
-  await page
-    .getByTestId('checkboxRequired')
-    .getByTestId('form-checkbox')
-    .uncheck()
-
-  await page.getByRole('button', { name: 'Submit' }).click()
-  await expect(page.getByRole('alert')).toHaveText(['Document updated'])
-
-  await checkNotEditable()
+    page.getByLabel('A required checbox (e.g. for confirmation purposes)')
+  ).not.toBeEditable()
 })

--- a/example/app/data/DemoDataSource/plugins/form/read_only_primitives/blueprints/ReadOnlyPrimitives.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/form/read_only_primitives/blueprints/ReadOnlyPrimitives.blueprint.json
@@ -1,0 +1,65 @@
+{
+  "name": "ReadOnlyPrimitives",
+  "type": "CORE:Blueprint",
+  "attributes": [
+    {
+      "name": "type",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "name",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "stringOptional",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string",
+      "label": "An optional string",
+      "optional": true
+    },
+    {
+      "name": "stringRequired",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string",
+      "label": "A required string",
+      "optional": false
+    },
+    {
+      "name": "numberRequired",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "number",
+      "label": "A required number",
+      "optional": false
+    },
+    {
+      "name": "numberOptional",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "number",
+      "label": "Numbers only",
+      "optional": true
+    },
+    {
+      "name": "integer",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "integer",
+      "label": "Integer only",
+      "optional": true
+    },
+    {
+      "name": "checkboxOptional",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "boolean",
+      "label": "An optional checkbox",
+      "optional": true
+    },
+    {
+      "name": "checkboxRequired",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "boolean",
+      "label": "A required checbox (e.g. for confirmation purposes)",
+      "optional": false
+    }
+  ]
+}

--- a/example/app/data/DemoDataSource/plugins/form/read_only_primitives/readOnlyPrimitives.entity.json
+++ b/example/app/data/DemoDataSource/plugins/form/read_only_primitives/readOnlyPrimitives.entity.json
@@ -1,0 +1,11 @@
+{
+  "_id": "readOnlyPrimitives",
+  "name": "ReadOnlyPrimitives",
+  "type": "./blueprints/ReadOnlyPrimitives",
+  "stringRequired": "A required string",
+  "stringOptional": "an optional string",
+  "numberRequired": 2,
+  "numberOptional": 3.14,
+  "checkboxOptional": false,
+  "checkboxRequired": true
+}

--- a/example/app/data/DemoDataSource/plugins/form/read_only_primitives/readOnlyPrimitives.entity.json
+++ b/example/app/data/DemoDataSource/plugins/form/read_only_primitives/readOnlyPrimitives.entity.json
@@ -4,8 +4,9 @@
   "type": "./blueprints/ReadOnlyPrimitives",
   "stringRequired": "A required string",
   "stringOptional": "an optional string",
-  "numberRequired": 2,
+  "numberRequired": 2.34,
   "numberOptional": 3.14,
+  "integer": 30,
   "checkboxOptional": false,
   "checkboxRequired": true
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/form/read_only_primitives/readOnlyPrimitives.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/read_only_primitives/readOnlyPrimitives.recipe.json
@@ -37,8 +37,7 @@
           "checkboxOptional",
           "checkboxRequired"
         ],
-        "readOnly": true,
-        "editToggle": true
+        "readOnly": true
       }
     }
   ]

--- a/example/app/data/DemoDataSource/recipes/plugins/form/read_only_primitives/readOnlyPrimitives.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/read_only_primitives/readOnlyPrimitives.recipe.json
@@ -1,0 +1,45 @@
+{
+  "type": "CORE:RecipeLink",
+  "_blueprintPath_": "/plugins/form/read_only_primitives/blueprints/ReadOnlyPrimitives",
+  "initialUiRecipe": {
+    "name": "ViewSelector",
+    "type": "CORE:UiRecipe",
+    "plugin": "@development-framework/dm-core-plugins/view_selector",
+    "config": {
+      "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
+      "childTabsOnRender": true,
+      "asSidebar": false,
+      "items": [
+        {
+          "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
+          "view": {
+            "type": "CORE:ReferenceViewConfig",
+            "recipe": "ReadOnly"
+          }
+        }
+      ]
+    }
+  },
+  "uiRecipes": [
+    {
+      "name": "ReadOnly",
+      "type": "CORE:UiRecipe",
+      "plugin": "@development-framework/dm-core-plugins/form",
+      "category": "edit",
+      "config": {
+        "type": "PLUGINS:dm-core-plugins/form/FormInput",
+        "fields": [
+          "stringRequired",
+          "stringOptional",
+          "numberRequired",
+          "numberOptional",
+          "integer",
+          "checkboxOptional",
+          "checkboxRequired"
+        ],
+        "readOnly": true,
+        "editToggle": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What does this pull request change?
Example and test for a readonly form

## Why is this pull request needed?

## Issues related to this change

