### PR TITLE
fix(form): use icons for form buttons

### DIFF
--- a/e2e/tests/plugin-form-Nested.spec.ts
+++ b/e2e/tests/plugin-form-Nested.spec.ts
@@ -27,10 +27,7 @@ const navigate = async () => {
 
 test('Change owner', async () => {
   await expect(page.getByText('Owner', { exact: true })).toBeVisible
-  await page
-    .getByText('OwnerOpen')
-    .getByRole('button', { name: 'Open' })
-    .click()
+  await page.getByTestId('owner').getByRole('button', { name: 'Open' }).click()
   await page.getByLabel('Name').fill('Jacob')
   await page.getByLabel('Phone Number (optional)').fill('1234')
   await page.getByRole('button', { name: 'Submit' }).click()
@@ -156,10 +153,8 @@ test('New car', async () => {
 })
 
 test('New customer', async () => {
-  await page
-    .getByText('CustomersOpen')
-    .getByRole('button', { name: 'Open' })
-    .click()
+  const customersDiv = page.getByTestId('customers')
+  await customersDiv.getByRole('button', { name: 'Open' }).click()
   const lastTabPanel = page.getByRole('tabpanel').last()
   await expect(lastTabPanel).toBeVisible()
   await expect.soft(lastTabPanel.getByText('1 - 2 of 2')).toBeVisible()
@@ -174,10 +169,7 @@ test('New customer', async () => {
   await page.getByRole('button', { name: 'close', exact: true }).click()
   await page.reload()
   await navigate()
-  await page
-    .getByText('CustomersOpen')
-    .getByRole('button', { name: 'Open' })
-    .click()
+  await customersDiv.getByRole('button', { name: 'Open' }).click()
   await expect(page.getByText('Lewis')).toBeVisible()
   await page.getByRole('button', { name: 'Open item' }).last().click()
   await expect(page.getByRole('tab', { name: 'Lewis' })).toBeVisible()

--- a/e2e/tests/plugin-form-UncontainedObject.spec.ts
+++ b/e2e/tests/plugin-form-UncontainedObject.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { expect, test } from '@playwright/test'
 
 test('uncontainedObject', async ({ page }) => {
   await page.goto('http://localhost:3000/')
@@ -6,13 +6,6 @@ test('uncontainedObject', async ({ page }) => {
   await page.getByText('form').click()
   await page.getByText('uncontained_object', { exact: true }).click()
   await page.getByText('UncontainedObject').click()
-
-  await expect(
-    page.getByTestId('ceo').getByText('Address: ^.employees[0]')
-  ).toBeVisible()
-  await expect(
-    page.getByTestId('accountant').getByText('Address: ^.employees[0]')
-  ).toBeVisible()
 
   await page.getByTestId('ceo').getByRole('button', { name: 'Open' }).click()
   await expect(page.getByRole('code').getByText('Miranda')).toBeVisible()
@@ -27,7 +20,7 @@ test('uncontainedObject', async ({ page }) => {
   // Add assistant
   await page
     .getByTestId('assistant')
-    .getByRole('button', { name: 'Select and save' })
+    .getByRole('button', { name: 'Add and save' })
     .click()
   await expect(page.getByRole('dialog')).toBeVisible()
   await page.getByRole('dialog').getByText('plugins', { exact: true }).click()
@@ -56,7 +49,7 @@ test('uncontainedObject', async ({ page }) => {
   // Add trainee
   await page
     .getByTestId('trainee')
-    .getByRole('button', { name: 'Select and save' })
+    .getByRole('button', { name: 'Add and save' })
     .click()
   await expect(page.getByRole('dialog')).toBeVisible()
   await page.getByRole('dialog').getByText('plugins', { exact: true }).click()
@@ -84,7 +77,7 @@ test('uncontainedObject', async ({ page }) => {
   // Change accountant
   await page
     .getByTestId('accountant')
-    .getByRole('button', { name: 'Select and save' })
+    .getByRole('button', { name: 'Edit and save' })
     .click()
   await expect(page.getByRole('dialog')).toBeVisible()
   await page.getByRole('dialog').getByText('plugins', { exact: true }).click()
@@ -109,13 +102,10 @@ test('uncontainedObject', async ({ page }) => {
   ).toBeVisible()
 
   //Remove trainee
-  await page.getByTestId('remove-trainee').click()
-  await expect(
-    page.getByTestId('trainee').getByRole('code').getByText('John')
-  ).not.toBeVisible()
-  await expect(
-    page.getByTestId('trainee').getByRole('code').getByText('1234')
-  ).not.toBeVisible()
+  const trainee = page.getByTestId('trainee')
+  await trainee.getByRole('button', { name: 'Remove and save' }).click()
+  await expect(trainee.getByRole('code').getByText('John')).not.toBeVisible()
+  await expect(trainee.getByRole('code').getByText('1234')).not.toBeVisible()
 
   // Submit form
   await page.getByRole('button', { name: 'Submit' }).click()

--- a/e2e/tests/plugin-view_selector-car_garage.spec.ts
+++ b/e2e/tests/plugin-view_selector-car_garage.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { expect, test } from '@playwright/test'
 
 test('View selector - car garage', async ({ page }) => {
   // Open self and verify page content and the sidebar:
@@ -30,10 +30,7 @@ test('View selector - car garage', async ({ page }) => {
   await page.locator('a').filter({ hasText: 'Audi' }).click()
   await expect(page.getByRole('tab', { name: 'home Home' })).toBeVisible()
   await expect(page.getByRole('tabpanel').locator('#name')).toHaveValue('Audi')
-  await page
-    .getByText('View owner details and historyOpen')
-    .getByRole('button', { name: 'Open' })
-    .click()
+  await page.getByTestId('Owner').getByRole('button', { name: 'Open' }).click()
   await expect(
     page.getByRole('tab', { name: 'person Owner details' })
   ).toHaveAttribute('aria-selected', 'true')
@@ -49,7 +46,7 @@ test('View selector - car garage', async ({ page }) => {
   ).toHaveAttribute('aria-selected', 'true')
 
   //Add earlier owner:
-  await page.getByTestId('add-earlierOwners').click()
+  await page.getByRole('button', { name: 'Add' }).click()
   await page.getByRole('textbox').last().fill(' Joanna')
   await page.getByRole('button', { name: 'Submit' }).click()
   await expect(page.getByRole('alert')).toHaveText(['Document updated'])
@@ -58,7 +55,7 @@ test('View selector - car garage', async ({ page }) => {
   // Select "home" and then open "technical". Verify that both owner and techincal tabs are open and selectable. Check also sub-tabs
   await page.getByRole('tab', { name: 'home Home' }).click()
   await page
-    .getByText('View technical informationOpen')
+    .getByTestId('Technical')
     .getByRole('button', { name: 'Open' })
     .click()
   await expect(
@@ -113,7 +110,7 @@ test('View selector - car garage', async ({ page }) => {
   // Testing that saving one car does not ovveride the other car:
   await page.locator('a').filter({ hasText: 'Volvo' }).click()
   await page
-    .getByText('View technical informationOpen')
+    .getByTestId('Technical')
     .getByRole('button', { name: 'Open' })
     .click()
 
@@ -125,10 +122,7 @@ test('View selector - car garage', async ({ page }) => {
     '4500'
   )
   await page.getByRole('tab', { name: 'home Home' }).click()
-  await page
-    .getByText('View owner details and historyOpen')
-    .getByRole('button', { name: 'Open' })
-    .click()
+  await page.getByTestId('Owner').getByRole('button', { name: 'Open' }).click()
   await page.getByRole('tab', { name: 'group Owner history' }).click()
   await expect(page.getByRole('textbox').first()).toHaveValue('Jack')
   await expect(page.getByRole('textbox').last()).toHaveValue('Maria')

--- a/packages/dm-core-plugins/src/common/TooltipButton.tsx
+++ b/packages/dm-core-plugins/src/common/TooltipButton.tsx
@@ -1,4 +1,5 @@
-import { Button, Tooltip } from '@equinor/eds-core-react'
+import { Button, Icon, Tooltip } from '@equinor/eds-core-react'
+import { IconData } from '@equinor/eds-icons'
 import React from 'react'
 
 type Prefix<T, P extends string> = {
@@ -12,8 +13,16 @@ type PrefixedTooltip = Prefix<
   Omit<React.ComponentProps<typeof Tooltip>, 'title' | 'children'>,
   'tooltip'
 >
-type TProps = PrefixedButton &
-  PrefixedTooltip & { title: string; children: React.ReactElement }
+type TContent =
+  | {
+      icon?: IconData
+      buttonText: string
+    }
+  | {
+      icon: IconData
+      buttonText?: string
+    }
+type TProps = PrefixedButton & PrefixedTooltip & TContent & { title: string }
 
 const getProps = (prefix: string, dict: { [k: string]: any }) => {
   return Object.fromEntries(
@@ -25,14 +34,15 @@ const getProps = (prefix: string, dict: { [k: string]: any }) => {
 
 /**
  * Tests can access the components through getByRole('button', { name: title })) or getByLabel(title)
- * @param props Component accepts all props used by EDS Button and EDS Tooltip. However, to avoid interfering with each other, you'll have to prefix the prop with "button-" or "tooltip-". Ex: button-onChange. In addition, it has a mandatory title prop, which is used both as aria-label and tooltip title
+ * @param props Component accepts all props used by EDS Button and EDS Tooltip. However, to avoid interfering with each other, you'll have to prefix the prop with "button-" or "tooltip-". Ex: button-onChange. In addition, it has a mandatory title prop, which is used both as aria-label and tooltip title. You must also supply it with a buttonText and/or an icon.
  * @returns An EDS button with EDS tooltip.
  */
 const TooltipButton = (props: TProps) => {
   return (
     <Tooltip title={props.title} {...getProps('tooltip-', props)}>
       <Button {...getProps('button-', props)} aria-label={props.title}>
-        {props.children}
+        {props.icon && <Icon data={props.icon} />}
+        {props.buttonText}
       </Button>
     </Tooltip>
   )

--- a/packages/dm-core-plugins/src/common/TooltipButton.tsx
+++ b/packages/dm-core-plugins/src/common/TooltipButton.tsx
@@ -1,0 +1,41 @@
+import { Button, Tooltip } from '@equinor/eds-core-react'
+import React from 'react'
+
+type Prefix<T, P extends string> = {
+  [K in keyof T as `${P}-${string & K}`]: T[K]
+}
+type PrefixedButton = Prefix<
+  Omit<React.ComponentProps<typeof Button>, 'aria-label' | 'children'>,
+  'button'
+>
+type PrefixedTooltip = Prefix<
+  Omit<React.ComponentProps<typeof Tooltip>, 'title' | 'children'>,
+  'tooltip'
+>
+type TProps = PrefixedButton &
+  PrefixedTooltip & { title: string; children: React.ReactElement }
+
+const getProps = (prefix: string, dict: { [k: string]: any }) => {
+  return Object.fromEntries(
+    Object.entries(dict)
+      .filter(([k]) => k.startsWith(prefix))
+      .map(([k, v]) => [k.slice(prefix.length), v])
+  )
+}
+
+/**
+ * Tests can access the components through getByRole('button', { name: title })) or getByLabel(title)
+ * @param props Component accepts all props used by EDS Button and EDS Tooltip. However, to avoid interfering with each other, you'll have to prefix the prop with "button-" or "tooltip-". Ex: button-onChange. In addition, it has a mandatory title prop, which is used both as aria-label and tooltip title
+ * @returns An EDS button with EDS tooltip.
+ */
+const TooltipButton = (props: TProps) => {
+  return (
+    <Tooltip title={props.title} {...getProps('tooltip-', props)}>
+      <Button {...getProps('button-', props)} aria-label={props.title}>
+        {props.children}
+      </Button>
+    </Tooltip>
+  )
+}
+
+export default TooltipButton

--- a/packages/dm-core-plugins/src/form/components/OpenObjectButton.tsx
+++ b/packages/dm-core-plugins/src/form/components/OpenObjectButton.tsx
@@ -3,9 +3,10 @@ import {
   TReferenceViewConfig,
   TViewConfig,
 } from '@development-framework/dm-core'
-import { Button, Icon, Tooltip } from '@equinor/eds-core-react'
+import { Icon } from '@equinor/eds-core-react'
 import { external_link } from '@equinor/eds-icons'
 import React from 'react'
+import TooltipButton from '../../common/TooltipButton'
 import { useRegistryContext } from '../context/RegistryContext'
 
 export const OpenObjectButton = ({
@@ -20,14 +21,12 @@ export const OpenObjectButton = ({
   const { onOpen } = useRegistryContext()
 
   return (
-    <Tooltip title="Open in tab">
-      <Button
-        variant="ghost_icon"
-        onClick={() => onOpen?.(viewId, view, idReference)}
-        aria-label="Open in tab"
-      >
-        <Icon data={external_link} />
-      </Button>
-    </Tooltip>
+    <TooltipButton
+      title="Open in tab"
+      button-variant="ghost_icon"
+      button-onClick={() => onOpen?.(viewId, view, idReference)}
+    >
+      <Icon data={external_link} />
+    </TooltipButton>
   )
 }

--- a/packages/dm-core-plugins/src/form/components/OpenObjectButton.tsx
+++ b/packages/dm-core-plugins/src/form/components/OpenObjectButton.tsx
@@ -3,7 +3,6 @@ import {
   TReferenceViewConfig,
   TViewConfig,
 } from '@development-framework/dm-core'
-import { Icon } from '@equinor/eds-core-react'
 import { external_link } from '@equinor/eds-icons'
 import React from 'react'
 import TooltipButton from '../../common/TooltipButton'
@@ -25,8 +24,7 @@ export const OpenObjectButton = ({
       title="Open in tab"
       button-variant="ghost_icon"
       button-onClick={() => onOpen?.(viewId, view, idReference)}
-    >
-      <Icon data={external_link} />
-    </TooltipButton>
+      icon={external_link}
+    />
   )
 }

--- a/packages/dm-core-plugins/src/form/components/OpenObjectButton.tsx
+++ b/packages/dm-core-plugins/src/form/components/OpenObjectButton.tsx
@@ -3,7 +3,8 @@ import {
   TReferenceViewConfig,
   TViewConfig,
 } from '@development-framework/dm-core'
-import { Button } from '@equinor/eds-core-react'
+import { Button, Icon, Tooltip } from '@equinor/eds-core-react'
+import { external_link } from '@equinor/eds-icons'
 import React from 'react'
 import { useRegistryContext } from '../context/RegistryContext'
 
@@ -19,11 +20,14 @@ export const OpenObjectButton = ({
   const { onOpen } = useRegistryContext()
 
   return (
-    <Button
-      variant="outlined"
-      onClick={() => onOpen?.(viewId, view, idReference)}
-    >
-      Open
-    </Button>
+    <Tooltip title="Open in tab">
+      <Button
+        variant="ghost_icon"
+        onClick={() => onOpen?.(viewId, view, idReference)}
+        aria-label="Open in tab"
+      >
+        <Icon data={external_link} />
+      </Button>
+    </Tooltip>
   )
 }

--- a/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
@@ -6,13 +6,15 @@ import {
   getKey,
   useDMSS,
 } from '@development-framework/dm-core'
-import { Button, Typography } from '@equinor/eds-core-react'
+import { Button, Icon, Tooltip, Typography } from '@equinor/eds-core-react'
 import { AxiosError } from 'axios'
 import React from 'react'
 import { useFieldArray, useFormContext } from 'react-hook-form'
 
+import { add, delete_forever } from '@equinor/eds-icons'
 import { OpenObjectButton } from '../components/OpenObjectButton'
 import { useRegistryContext } from '../context/RegistryContext'
+import { ButtonRow } from '../styles'
 import { TArrayFieldProps } from '../types'
 import { isPrimitive } from '../utils'
 import { AttributeField } from './AttributeField'
@@ -59,7 +61,7 @@ export default function ArrayField(props: TArrayFieldProps) {
 
   if (onOpen && !uiAttribute?.showInline && !isPrimitiveType(type)) {
     return (
-      <Stack spacing={0.25} alignItems="flex-start">
+      <ButtonRow>
         <Typography bold={true}>{displayLabel}</Typography>
         <OpenObjectButton
           viewId={namePath}
@@ -69,7 +71,7 @@ export default function ArrayField(props: TArrayFieldProps) {
             recipe: uiRecipeName,
           }}
         />
-      </Stack>
+      </ButtonRow>
     )
   }
 
@@ -90,7 +92,28 @@ export default function ArrayField(props: TArrayFieldProps) {
 
   return (
     <Stack spacing={0.5} alignItems="flex-start">
-      <Typography bold={true}>{displayLabel}</Typography>
+      <ButtonRow>
+        <Typography bold={true}>{displayLabel}</Typography>
+        {!readOnly && (
+          <Tooltip title="Add">
+            <Button
+              variant="ghost_icon"
+              aria-label="Add"
+              data-testid={`add-${namePath}`}
+              onClick={() => {
+                if (isPrimitiveType(type)) {
+                  const defaultValue = isPrimitive(type) ? ' ' : {}
+                  append(defaultValue)
+                } else {
+                  handleAddObject()
+                }
+              }}
+            >
+              <Icon data={add} />
+            </Button>
+          </Tooltip>
+        )}
+      </ButtonRow>
       {fields.map((item: any, index: number) => {
         return (
           <Stack
@@ -98,6 +121,7 @@ export default function ArrayField(props: TArrayFieldProps) {
             direction="row"
             spacing={0.5}
             alignSelf="stretch"
+            alignItems="flex-end"
           >
             <Stack grow={1}>
               <AttributeField
@@ -112,33 +136,20 @@ export default function ArrayField(props: TArrayFieldProps) {
               />
             </Stack>
             {!readOnly && (
-              <Button
-                variant="outlined"
-                type="button"
-                onClick={() => remove(index)}
-              >
-                Remove
-              </Button>
+              <Tooltip title="Remove">
+                <Button
+                  variant="ghost_icon"
+                  type="button"
+                  aria-label="Remove"
+                  onClick={() => remove(index)}
+                >
+                  <Icon data={delete_forever} />
+                </Button>
+              </Tooltip>
             )}
           </Stack>
         )
       })}
-      {!readOnly && (
-        <Button
-          variant="outlined"
-          data-testid={`add-${namePath}`}
-          onClick={() => {
-            if (isPrimitiveType(type)) {
-              const defaultValue = isPrimitive(type) ? ' ' : {}
-              append(defaultValue)
-            } else {
-              handleAddObject()
-            }
-          }}
-        >
-          Add
-        </Button>
-      )}
     </Stack>
   )
 }

--- a/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
@@ -6,12 +6,13 @@ import {
   getKey,
   useDMSS,
 } from '@development-framework/dm-core'
-import { Button, Icon, Tooltip, Typography } from '@equinor/eds-core-react'
+import { Icon, Typography } from '@equinor/eds-core-react'
 import { AxiosError } from 'axios'
 import React from 'react'
 import { useFieldArray, useFormContext } from 'react-hook-form'
 
 import { add, delete_forever } from '@equinor/eds-icons'
+import TooltipButton from '../../common/TooltipButton'
 import { OpenObjectButton } from '../components/OpenObjectButton'
 import { useRegistryContext } from '../context/RegistryContext'
 import { ButtonRow } from '../styles'
@@ -95,23 +96,20 @@ export default function ArrayField(props: TArrayFieldProps) {
       <ButtonRow>
         <Typography bold={true}>{displayLabel}</Typography>
         {!readOnly && (
-          <Tooltip title="Add">
-            <Button
-              variant="ghost_icon"
-              aria-label="Add"
-              data-testid={`add-${namePath}`}
-              onClick={() => {
-                if (isPrimitiveType(type)) {
-                  const defaultValue = isPrimitive(type) ? ' ' : {}
-                  append(defaultValue)
-                } else {
-                  handleAddObject()
-                }
-              }}
-            >
-              <Icon data={add} />
-            </Button>
-          </Tooltip>
+          <TooltipButton
+            title="Add"
+            button-variant="ghost_icon"
+            button-onClick={() => {
+              if (isPrimitiveType(type)) {
+                const defaultValue = isPrimitive(type) ? ' ' : {}
+                append(defaultValue)
+              } else {
+                handleAddObject()
+              }
+            }}
+          >
+            <Icon data={add} />
+          </TooltipButton>
         )}
       </ButtonRow>
       {fields.map((item: any, index: number) => {
@@ -136,16 +134,13 @@ export default function ArrayField(props: TArrayFieldProps) {
               />
             </Stack>
             {!readOnly && (
-              <Tooltip title="Remove">
-                <Button
-                  variant="ghost_icon"
-                  type="button"
-                  aria-label="Remove"
-                  onClick={() => remove(index)}
-                >
-                  <Icon data={delete_forever} />
-                </Button>
-              </Tooltip>
+              <TooltipButton
+                title="Remove"
+                button-variant="ghost_icon"
+                button-onClick={() => remove(index)}
+              >
+                <Icon data={delete_forever} />
+              </TooltipButton>
             )}
           </Stack>
         )

--- a/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
@@ -6,7 +6,7 @@ import {
   getKey,
   useDMSS,
 } from '@development-framework/dm-core'
-import { Icon, Typography } from '@equinor/eds-core-react'
+import { Typography } from '@equinor/eds-core-react'
 import { AxiosError } from 'axios'
 import React from 'react'
 import { useFieldArray, useFormContext } from 'react-hook-form'
@@ -107,9 +107,8 @@ export default function ArrayField(props: TArrayFieldProps) {
                 handleAddObject()
               }
             }}
-          >
-            <Icon data={add} />
-          </TooltipButton>
+            icon={add}
+          />
         )}
       </ButtonRow>
       {fields.map((item: any, index: number) => {
@@ -138,9 +137,8 @@ export default function ArrayField(props: TArrayFieldProps) {
                 title="Remove"
                 button-variant="ghost_icon"
                 button-onClick={() => remove(index)}
-              >
-                <Icon data={delete_forever} />
-              </TooltipButton>
+                icon={delete_forever}
+              />
             )}
           </Stack>
         )

--- a/packages/dm-core-plugins/src/form/fields/ObjectField.test.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ObjectField.test.tsx
@@ -138,6 +138,6 @@ test('should handle optional', async () => {
     // Show optional in label
     expect(screen.getByText('nested (optional)')).toBeDefined()
     // Add button
-    expect(screen.getByTestId('add-nested')).toBeDefined()
+    expect(screen.getByRole('button', { name: 'Add and save' })).toBeDefined()
   })
 })

--- a/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
@@ -13,7 +13,7 @@ import {
   useBlueprint,
   useDMSS,
 } from '@development-framework/dm-core'
-import { Icon, Typography } from '@equinor/eds-core-react'
+import { Typography } from '@equinor/eds-core-react'
 import { add, delete_forever, edit } from '@equinor/eds-icons'
 import { AxiosError, AxiosResponse } from 'axios'
 import React, { useState } from 'react'
@@ -73,9 +73,8 @@ const SelectReference = (props: { type: string; namePath: string }) => {
         title={`${value ? 'Edit' : 'Add'} and save`}
         button-variant="ghost_icon"
         button-onClick={() => setShowModal(true)}
-      >
-        <Icon data={value ? edit : add} />
-      </TooltipButton>
+        icon={value ? edit : add}
+      />
       <EntityPickerDialog
         data-testid={`select-${props.namePath}`}
         onChange={onChange}
@@ -131,9 +130,8 @@ const AddObject = (props: {
       title="Add and save"
       button-variant="ghost_icon"
       button-onClick={handleAdd}
-    >
-      <Icon data={add} />
-    </TooltipButton>
+      icon={add}
+    />
   )
 }
 
@@ -164,9 +162,8 @@ const RemoveObject = (props: { namePath: string }) => {
       title="Remove and save"
       button-variant="ghost_icon"
       button-onClick={onClick}
-    >
-      <Icon data={delete_forever} />
-    </TooltipButton>
+      icon={delete_forever}
+    />
   )
 }
 

--- a/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
@@ -13,7 +13,8 @@ import {
   useBlueprint,
   useDMSS,
 } from '@development-framework/dm-core'
-import { Button, Typography } from '@equinor/eds-core-react'
+import { Button, Icon, Tooltip, Typography } from '@equinor/eds-core-react'
+import { add, delete_forever, edit } from '@equinor/eds-icons'
 import { AxiosError, AxiosResponse } from 'axios'
 import React, { useState } from 'react'
 import { useFormContext } from 'react-hook-form'
@@ -23,6 +24,7 @@ import { AttributeList } from '../components/AttributeList'
 import { OpenObjectButton } from '../components/OpenObjectButton'
 import { useRegistryContext } from '../context/RegistryContext'
 import { getWidget } from '../context/WidgetContext'
+import { ButtonRow } from '../styles'
 import { TContentProps, TObjectFieldProps, TUiRecipeForm } from '../types'
 
 const SelectReference = (props: { type: string; namePath: string }) => {
@@ -66,9 +68,15 @@ const SelectReference = (props: { type: string; namePath: string }) => {
 
   return (
     <>
-      <Button variant="outlined" onClick={() => setShowModal(true)}>
-        Select and save
-      </Button>
+      <Tooltip title={`${value ? 'Edit' : 'Add'} and save`}>
+        <Button
+          variant="ghost_icon"
+          onClick={() => setShowModal(true)}
+          aria-label={`${value ? 'Edit' : 'Add'} and save`}
+        >
+          <Icon data={value ? edit : add} />
+        </Button>
+      </Tooltip>
       <EntityPickerDialog
         data-testid={`select-${props.namePath}`}
         onChange={onChange}
@@ -120,13 +128,16 @@ const AddObject = (props: {
       })
   }
   return (
-    <Button
-      variant="outlined"
-      data-testid={`add-${namePath}`}
-      onClick={handleAdd}
-    >
-      Add and save
-    </Button>
+    <Tooltip title="Add and save">
+      <Button
+        variant="ghost_icon"
+        data-testid={`add-${namePath}`}
+        onClick={handleAdd}
+        aria-label="Add and save"
+      >
+        <Icon data={add} />
+      </Button>
+    </Tooltip>
   )
 }
 
@@ -153,13 +164,16 @@ const RemoveObject = (props: { namePath: string }) => {
       })
   }
   return (
-    <Button
-      variant="outlined"
-      data-testid={`remove-${namePath}`}
-      onClick={onClick}
-    >
-      Remove and save
-    </Button>
+    <Tooltip title="Remove and save">
+      <Button
+        variant="ghost_icon"
+        data-testid={`remove-${namePath}`}
+        onClick={onClick}
+        aria-label="Remove and save"
+      >
+        <Icon data={delete_forever} />
+      </Button>
+    </Tooltip>
   )
 }
 
@@ -181,20 +195,20 @@ export const ContainedAttribute = (props: TContentProps): JSX.Element => {
   const isDefined = value && Object.keys(value).length > 0
   return (
     <Stack spacing={0.25} alignItems="flex-start">
-      <Typography bold={true}>{displayLabel}</Typography>
-      {optional &&
-        !readOnly &&
-        (isDefined ? (
-          <RemoveObject namePath={namePath} />
-        ) : (
-          <AddObject
-            namePath={namePath}
-            type={type}
-            defaultValue={defaultValue}
-          />
-        ))}
-      {isDefined &&
-        (onOpen && !uiAttribute?.showInline ? (
+      <ButtonRow>
+        <Typography bold={true}>{displayLabel}</Typography>
+        {optional &&
+          !readOnly &&
+          (isDefined ? (
+            <RemoveObject namePath={namePath} />
+          ) : (
+            <AddObject
+              namePath={namePath}
+              type={type}
+              defaultValue={defaultValue}
+            />
+          ))}
+        {isDefined && onOpen && !uiAttribute?.showInline && (
           <OpenObjectButton
             viewId={namePath}
             idReference={idReference}
@@ -204,14 +218,16 @@ export const ContainedAttribute = (props: TContentProps): JSX.Element => {
               recipe: uiRecipe?.name,
             }}
           />
-        ) : (
-          <Inline
-            type={type}
-            namePath={namePath}
-            blueprint={blueprint}
-            uiRecipe={uiRecipe}
-          />
-        ))}
+        )}
+      </ButtonRow>
+      {isDefined && !(onOpen && !uiAttribute?.showInline) && (
+        <Inline
+          type={type}
+          namePath={namePath}
+          blueprint={blueprint}
+          uiRecipe={uiRecipe}
+        />
+      )}
     </Stack>
   )
 }
@@ -274,9 +290,8 @@ export const UncontainedAttribute = (props: TContentProps): JSX.Element => {
 
   return (
     <Stack spacing={0.5}>
-      <Typography bold={true}>{displayLabel}</Typography>
-      {address && <Typography>Address: {value.address}</Typography>}
-      <Stack direction="row" spacing={0.5}>
+      <ButtonRow>
+        <Typography bold={true}>{displayLabel}</Typography>
         {!readOnly && <SelectReference type={type} namePath={namePath} />}
         {optional && address && !readOnly && (
           <RemoveObject namePath={namePath} />
@@ -292,7 +307,7 @@ export const UncontainedAttribute = (props: TContentProps): JSX.Element => {
             idReference={address}
           />
         )}
-      </Stack>
+      </ButtonRow>
       {address && !(onOpen && !uiAttribute?.showInline) && (
         <EntityView
           idReference={address}

--- a/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
@@ -13,12 +13,13 @@ import {
   useBlueprint,
   useDMSS,
 } from '@development-framework/dm-core'
-import { Button, Icon, Tooltip, Typography } from '@equinor/eds-core-react'
+import { Icon, Typography } from '@equinor/eds-core-react'
 import { add, delete_forever, edit } from '@equinor/eds-icons'
 import { AxiosError, AxiosResponse } from 'axios'
 import React, { useState } from 'react'
 import { useFormContext } from 'react-hook-form'
 import styled from 'styled-components'
+import TooltipButton from '../../common/TooltipButton'
 import { defaultConfig } from '../FormPlugin'
 import { AttributeList } from '../components/AttributeList'
 import { OpenObjectButton } from '../components/OpenObjectButton'
@@ -68,15 +69,13 @@ const SelectReference = (props: { type: string; namePath: string }) => {
 
   return (
     <>
-      <Tooltip title={`${value ? 'Edit' : 'Add'} and save`}>
-        <Button
-          variant="ghost_icon"
-          onClick={() => setShowModal(true)}
-          aria-label={`${value ? 'Edit' : 'Add'} and save`}
-        >
-          <Icon data={value ? edit : add} />
-        </Button>
-      </Tooltip>
+      <TooltipButton
+        title={`${value ? 'Edit' : 'Add'} and save`}
+        button-variant="ghost_icon"
+        button-onClick={() => setShowModal(true)}
+      >
+        <Icon data={value ? edit : add} />
+      </TooltipButton>
       <EntityPickerDialog
         data-testid={`select-${props.namePath}`}
         onChange={onChange}
@@ -128,16 +127,13 @@ const AddObject = (props: {
       })
   }
   return (
-    <Tooltip title="Add and save">
-      <Button
-        variant="ghost_icon"
-        data-testid={`add-${namePath}`}
-        onClick={handleAdd}
-        aria-label="Add and save"
-      >
-        <Icon data={add} />
-      </Button>
-    </Tooltip>
+    <TooltipButton
+      title="Add and save"
+      button-variant="ghost_icon"
+      button-onClick={handleAdd}
+    >
+      <Icon data={add} />
+    </TooltipButton>
   )
 }
 
@@ -164,16 +160,13 @@ const RemoveObject = (props: { namePath: string }) => {
       })
   }
   return (
-    <Tooltip title="Remove and save">
-      <Button
-        variant="ghost_icon"
-        data-testid={`remove-${namePath}`}
-        onClick={onClick}
-        aria-label="Remove and save"
-      >
-        <Icon data={delete_forever} />
-      </Button>
-    </Tooltip>
+    <TooltipButton
+      title="Remove and save"
+      button-variant="ghost_icon"
+      button-onClick={onClick}
+    >
+      <Icon data={delete_forever} />
+    </TooltipButton>
   )
 }
 

--- a/packages/dm-core-plugins/src/form/styles.tsx
+++ b/packages/dm-core-plugins/src/form/styles.tsx
@@ -1,0 +1,8 @@
+import styled from 'styled-components'
+
+export const ButtonRow = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+  align-items: center;
+`


### PR DESCRIPTION
## What does this pull request change?

Form uses icon buttons with tooltip for opening, adding, editing and removing nested objects and list.
Also created a generic TooltipButton and adapted tests to the new layout

![image](https://github.com/equinor/dm-core-packages/assets/64828956/870152f4-17d9-4f86-a3fa-bf3a92d54d6f)

## Why is this pull request needed?

## Issues related to this change

ref #488