### PR TITLE
refactor(explorer): extract dialogs

### DIFF
--- a/packages/dm-core-plugins/src/explorer/ExplorerPlugin.tsx
+++ b/packages/dm-core-plugins/src/explorer/ExplorerPlugin.tsx
@@ -6,7 +6,7 @@ import {
 import { Progress } from '@equinor/eds-core-react'
 import React, { useContext, useState } from 'react'
 import styled from 'styled-components'
-import { NodeRightClickMenu } from './components/context-menu/ContextMenu'
+import NodeRightClickMenu from './components/context-menu/NodeRightClickMenu'
 
 export const TreeWrapper = styled.div`
   width: 25%;

--- a/packages/dm-core-plugins/src/explorer/components/context-menu/ContextMenu.tsx
+++ b/packages/dm-core-plugins/src/explorer/components/context-menu/ContextMenu.tsx
@@ -1,63 +1,30 @@
-import {
-  BlueprintPicker,
-  Dialog,
-  DmssAPI,
-  EBlueprint,
-  ErrorResponse,
-  INPUT_FIELD_WIDTH,
-  TNodeWrapperProps,
-  TreeNode,
-  useDMSS,
-} from '@development-framework/dm-core'
-import { Button, Input, Label, Menu, Progress } from '@equinor/eds-core-react'
-import { AxiosError } from 'axios'
+import { TNodeWrapperProps } from '@development-framework/dm-core'
+import { Menu } from '@equinor/eds-core-react'
 import React, { useState } from 'react'
-import { toast } from 'react-toastify'
-import {
-  DeleteAction,
-  NewFolderAction,
-  NewRootPackageAction,
-} from './utils/contextMenuActions'
+import AppendEntityDialog from '../dialogs/AppendEntityDialog'
+import DeleteDialog from '../dialogs/DeleteDialog'
+import NewBlueprintDialog from '../dialogs/NewBlueprintDialog'
+import NewEntityDialog from '../dialogs/NewEntityDialog'
+import NewFolderDialog from '../dialogs/NewFolderDialog'
+import NewRootPackageDialog from '../dialogs/NewRootPackageDialog'
 import { createContextMenuItems } from './utils/createContextMenuItmes'
 
-//Component that can be used when a context menu action requires one text (string) input.
+export const STANDARD_DIALOG_WIDTH = '100%'
+export const STANDARD_DIALOG_HEIGHT = '300px'
 
 export const NodeRightClickMenu = (props: TNodeWrapperProps) => {
   const { node, children } = props
-  const dmssAPI = useDMSS()
-  const [scrimToShow, setScrimToShow] = useState<string>('')
+  const [dialogId, setDialogId] = useState<string>('')
   const [formData, setFormData] = useState<any>('')
   const [loading, setLoading] = useState<boolean>(false)
   const [showMenu, setShowMenu] = useState<boolean>(false)
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
 
-  const STANDARD_DIALOG_WIDTH = '100%'
-  const STANDARD_DIALOG_HEIGHT = '300px'
-
-  const menuItems = createContextMenuItems(node, setScrimToShow)
-
-  const handleFormDataSubmit = (
-    node: TreeNode,
-    formData: string,
-    action: (
-      node: TreeNode,
-      formData: string,
-      dmssAPI: DmssAPI,
-      setLoading: (isLoading: boolean) => void
-    ) => void
-  ) => {
-    if (formData) {
-      action(node, formData, dmssAPI, setLoading)
-      setScrimToShow('')
-      setFormData('')
-    } else {
-      toast.error('Form data cannot be empty!')
-    }
-  }
+  const menuItems = createContextMenuItems(node, setDialogId)
 
   //TODO when the tree changes by adding new package or deleting something, the tree should be updated to give consistent UI to user
   return (
-    <div>
+    <>
       <div
         style={{ width: 'fit-content' }}
         ref={setAnchorEl}
@@ -77,274 +44,64 @@ export const NodeRightClickMenu = (props: TNodeWrapperProps) => {
       >
         {menuItems}
       </Menu>
-      <Dialog
-        isDismissable
-        open={scrimToShow === 'new-folder'}
-        width={STANDARD_DIALOG_WIDTH}
-        height={STANDARD_DIALOG_HEIGHT}
-        onClose={() => {
-          setFormData(undefined)
-          setScrimToShow('')
-        }}
-      >
-        <Dialog.Header>
-          <Dialog.Title>Create new folder</Dialog.Title>
-        </Dialog.Header>
-        <Dialog.CustomContent>
-          <Label label={'Folder name'} />
-          <Input
-            type={'string'}
-            style={{ width: INPUT_FIELD_WIDTH }}
-            onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-              setFormData(event.target.value)
-            }
-          />
-        </Dialog.CustomContent>
-        <Dialog.Actions>
-          <Button
-            disabled={formData === undefined || formData === ''}
-            onClick={() => {
-              handleFormDataSubmit(node, formData, NewFolderAction)
-            }}
-          >
-            Create
-          </Button>
-          <Button
-            variant="outlined"
-            onClick={() => {
-              setFormData(undefined)
-              setScrimToShow('')
-            }}
-          >
-            Cancel
-          </Button>
-        </Dialog.Actions>
-      </Dialog>
 
-      <Dialog
-        open={scrimToShow === 'delete'}
-        width={STANDARD_DIALOG_WIDTH}
-        height={STANDARD_DIALOG_HEIGHT}
-        isDismissable
-        onClose={() => setScrimToShow('')}
-      >
-        <Dialog.Header>
-          <Dialog.Title>Confirm Deletion</Dialog.Title>
-        </Dialog.Header>
-        <Dialog.CustomContent>
-          Are you sure you want to delete the entity <b>{node.name}</b> of type{' '}
-          <b>{node.type}</b>?
-        </Dialog.CustomContent>
-        <Dialog.Actions>
-          <Button
-            color="danger"
-            onClick={async () => {
-              await DeleteAction(node, dmssAPI, setLoading)
-              await node.remove()
-              setScrimToShow('')
-            }}
-          >
-            {loading ? <Progress.Dots /> : 'Delete'}
-          </Button>
-          <Button variant="outlined" onClick={() => setScrimToShow('')}>
-            Cancel
-          </Button>
-        </Dialog.Actions>
-      </Dialog>
+      {dialogId === 'new-folder' && (
+        <NewFolderDialog
+          setDialogId={setDialogId}
+          formData={formData}
+          setFormData={setFormData}
+          node={node}
+        />
+      )}
 
-      <Dialog
-        open={scrimToShow === 'new-root-package'}
-        width={STANDARD_DIALOG_WIDTH}
-        height={STANDARD_DIALOG_HEIGHT}
-        isDismissable
-        onClose={() => {
-          setFormData(undefined)
-          setScrimToShow('')
-        }}
-      >
-        <Dialog.Header>
-          <Dialog.Title>New root package</Dialog.Title>
-        </Dialog.Header>
-        <Dialog.CustomContent>
-          <Label label={'Root package name'} />
-          <Input
-            type={'string'}
-            style={{ width: INPUT_FIELD_WIDTH }}
-            onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-              setFormData(event.target.value)
-            }
-          />
-        </Dialog.CustomContent>
-        <Dialog.Actions>
-          <Button
-            disabled={formData === undefined || formData === ''}
-            onClick={() => {
-              handleFormDataSubmit(node, formData, NewRootPackageAction)
-            }}
-          >
-            Create
-          </Button>
-          <Button
-            variant="outlined"
-            onClick={() => {
-              setFormData(undefined)
-              setScrimToShow('')
-            }}
-          >
-            Cancel
-          </Button>
-        </Dialog.Actions>
-      </Dialog>
+      {dialogId == 'delete' && (
+        <DeleteDialog
+          setDialogId={setDialogId}
+          loading={loading}
+          setLoading={setLoading}
+          node={node}
+        />
+      )}
 
-      <Dialog
-        open={scrimToShow === 'append-entity'}
-        isDismissable
-        onClose={() => setScrimToShow('')}
-        width={STANDARD_DIALOG_WIDTH}
-      >
-        <Dialog.Header>
-          <Dialog.Title>Append new entity to list</Dialog.Title>
-        </Dialog.Header>
-        <Dialog.Actions>
-          {loading ? (
-            <Button>
-              <Progress.Dots />
-            </Button>
-          ) : (
-            <Button
-              onClick={() => {
-                setLoading(true)
-                node
-                  .addEntityToPackage(
-                    node.attribute.attributeType,
-                    `${node.entity.length}`
-                  )
-                  .then(() => {
-                    node.expand()
-                    setScrimToShow('')
-                  })
-                  .catch((error: AxiosError<ErrorResponse>) => {
-                    console.error(error)
-                    toast.error('Failed to create entity')
-                  })
-                  .finally(() => setLoading(false))
-              }}
-            >
-              Create
-            </Button>
-          )}
-          <Button variant="outlined" onClick={() => setScrimToShow('')}>
-            Cancel
-          </Button>
-        </Dialog.Actions>
-      </Dialog>
+      {dialogId === 'new-root-package' && (
+        <NewRootPackageDialog
+          setDialogId={setDialogId}
+          formData={formData}
+          setFormData={setFormData}
+          node={node}
+        />
+      )}
 
-      <Dialog
-        open={scrimToShow === 'new-entity'}
-        isDismissable
-        onClose={() => setScrimToShow('')}
-        width={STANDARD_DIALOG_WIDTH}
-        height={STANDARD_DIALOG_HEIGHT}
-      >
-        <Dialog.Header>
-          <Dialog.Title>Create new entity</Dialog.Title>
-        </Dialog.Header>
-        <Dialog.CustomContent>
-          <BlueprintPicker
-            label={'Blueprint'}
-            onChange={(selectedType: string) =>
-              setFormData({ type: selectedType })
-            }
-            formData={formData?.type || ''}
-          />
-        </Dialog.CustomContent>
-        <Dialog.Actions>
-          {loading ? (
-            <Button>
-              <Progress.Dots />
-            </Button>
-          ) : (
-            <Button
-              disabled={formData?.type === undefined}
-              onClick={() => {
-                setLoading(true)
-                node
-                  .addEntityToPackage(
-                    `dmss://${formData?.type}`,
-                    formData?.name || 'Created_entity'
-                  )
-                  .then(() => {
-                    setScrimToShow('')
-                    toast.success(`New entity created`)
-                  })
-                  .catch((error: AxiosError<ErrorResponse>) => {
-                    console.error(error)
-                    toast.error(error.response?.data.message)
-                  })
-                  .finally(() => setLoading(false))
-              }}
-            >
-              Create
-            </Button>
-          )}
-          <Button variant="outlined" onClick={() => setScrimToShow('')}>
-            Cancel
-          </Button>
-        </Dialog.Actions>
-      </Dialog>
+      {dialogId === 'append-entity' && (
+        <AppendEntityDialog
+          setDialogId={setDialogId}
+          loading={loading}
+          setLoading={setLoading}
+          node={node}
+        />
+      )}
 
-      <Dialog
-        open={scrimToShow === 'new-blueprint'}
-        isDismissable
-        onClose={() => setScrimToShow('')}
-        width={STANDARD_DIALOG_WIDTH}
-        height={STANDARD_DIALOG_HEIGHT}
-      >
-        <Dialog.Header>
-          <Dialog.Title>Create new blueprint</Dialog.Title>
-        </Dialog.Header>
-        <Dialog.CustomContent>
-          <Label label={'Name'} />
-          <Input
-            style={{ width: INPUT_FIELD_WIDTH }}
-            type="string"
-            value={formData?.name || ''}
-            onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-              setFormData({ ...formData, name: event.target.value })
-            }
-            placeholder="Name for new blueprint"
-          />
-        </Dialog.CustomContent>
-        <Dialog.Actions>
-          {loading ? (
-            <Button>
-              <Progress.Dots />
-            </Button>
-          ) : (
-            <Button
-              disabled={formData?.name === undefined}
-              onClick={() => {
-                setLoading(true)
-                node
-                  .addEntityToPackage(EBlueprint.BLUEPRINT, formData?.name)
-                  .then(() => {
-                    setScrimToShow('')
-                  })
-                  .catch((error: AxiosError<ErrorResponse>) => {
-                    console.error(error)
-                    toast.error(error.response?.data.message)
-                  })
-                  .finally(() => setLoading(false))
-              }}
-            >
-              Create
-            </Button>
-          )}
-          <Button variant="outlined" onClick={() => setScrimToShow('')}>
-            Cancel
-          </Button>
-        </Dialog.Actions>
-      </Dialog>
-    </div>
+      {dialogId === 'new-entity' && (
+        <NewEntityDialog
+          setDialogId={setDialogId}
+          formData={formData}
+          setFormData={setFormData}
+          loading={loading}
+          setLoading={setLoading}
+          node={node}
+        />
+      )}
+
+      {dialogId === 'new-blueprint' && (
+        <NewBlueprintDialog
+          setDialogId={setDialogId}
+          formData={formData}
+          setFormData={setFormData}
+          loading={loading}
+          setLoading={setLoading}
+          node={node}
+        />
+      )}
+    </>
   )
 }

--- a/packages/dm-core-plugins/src/explorer/components/context-menu/NodeRightClickMenu.tsx
+++ b/packages/dm-core-plugins/src/explorer/components/context-menu/NodeRightClickMenu.tsx
@@ -12,7 +12,7 @@ import { createContextMenuItems } from './utils/createContextMenuItmes'
 export const STANDARD_DIALOG_WIDTH = '100%'
 export const STANDARD_DIALOG_HEIGHT = '300px'
 
-export const NodeRightClickMenu = (props: TNodeWrapperProps) => {
+const NodeRightClickMenu = (props: TNodeWrapperProps) => {
   const { node, children } = props
   const [dialogId, setDialogId] = useState<string>('')
   const [formData, setFormData] = useState<any>('')
@@ -105,3 +105,5 @@ export const NodeRightClickMenu = (props: TNodeWrapperProps) => {
     </>
   )
 }
+
+export default NodeRightClickMenu

--- a/packages/dm-core-plugins/src/explorer/components/context-menu/utils/contextMenuActions.ts
+++ b/packages/dm-core-plugins/src/explorer/components/context-menu/utils/contextMenuActions.ts
@@ -30,9 +30,7 @@ export const DeleteAction = async (
 export const NewFolderAction = (
   node: TreeNode,
   folderName: string,
-  dmssAPI: DmssAPI,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  setLoading: (isLoading: boolean) => void
+  dmssAPI: DmssAPI
 ) => {
   const newFolder = {
     name: folderName,
@@ -56,9 +54,7 @@ export const NewFolderAction = (
 export const NewRootPackageAction = (
   node: TreeNode,
   packageName: string,
-  dmssAPI: DmssAPI,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  setLoading: (isLoading: boolean) => void
+  dmssAPI: DmssAPI
 ) => {
   const newPackage = {
     name: packageName,

--- a/packages/dm-core-plugins/src/explorer/components/dialogs/AppendEntityDialog.tsx
+++ b/packages/dm-core-plugins/src/explorer/components/dialogs/AppendEntityDialog.tsx
@@ -3,7 +3,7 @@ import { Button, Progress } from '@equinor/eds-core-react'
 import { AxiosError } from 'axios'
 import React from 'react'
 import { toast } from 'react-toastify'
-import { STANDARD_DIALOG_WIDTH } from '../context-menu/ContextMenu'
+import { STANDARD_DIALOG_WIDTH } from '../context-menu/NodeRightClickMenu'
 
 type TProps = {
   setDialogId: (id: string) => void

--- a/packages/dm-core-plugins/src/explorer/components/dialogs/AppendEntityDialog.tsx
+++ b/packages/dm-core-plugins/src/explorer/components/dialogs/AppendEntityDialog.tsx
@@ -1,0 +1,63 @@
+import { Dialog, ErrorResponse, TreeNode } from '@development-framework/dm-core'
+import { Button, Progress } from '@equinor/eds-core-react'
+import { AxiosError } from 'axios'
+import React from 'react'
+import { toast } from 'react-toastify'
+import { STANDARD_DIALOG_WIDTH } from '../context-menu/ContextMenu'
+
+type TProps = {
+  setDialogId: (id: string) => void
+  loading: boolean
+  setLoading: (isLoading: boolean) => void
+  node: TreeNode
+}
+
+const AppendEntityDialog = (props: TProps) => {
+  const { setDialogId, loading, setLoading, node } = props
+  return (
+    <Dialog
+      open={true}
+      isDismissable
+      onClose={() => setDialogId('')}
+      width={STANDARD_DIALOG_WIDTH}
+    >
+      <Dialog.Header>
+        <Dialog.Title>Append new entity to list</Dialog.Title>
+      </Dialog.Header>
+      <Dialog.Actions>
+        {loading ? (
+          <Button>
+            <Progress.Dots />
+          </Button>
+        ) : (
+          <Button
+            onClick={() => {
+              setLoading(true)
+              node
+                .addEntityToPackage(
+                  node.attribute.attributeType,
+                  `${node.entity.length}`
+                )
+                .then(() => {
+                  node.expand()
+                  setDialogId('')
+                })
+                .catch((error: AxiosError<ErrorResponse>) => {
+                  console.error(error)
+                  toast.error('Failed to create entity')
+                })
+                .finally(() => setLoading(false))
+            }}
+          >
+            Create
+          </Button>
+        )}
+        <Button variant="outlined" onClick={() => setDialogId('')}>
+          Cancel
+        </Button>
+      </Dialog.Actions>
+    </Dialog>
+  )
+}
+
+export default AppendEntityDialog

--- a/packages/dm-core-plugins/src/explorer/components/dialogs/DeleteDialog.tsx
+++ b/packages/dm-core-plugins/src/explorer/components/dialogs/DeleteDialog.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import {
   STANDARD_DIALOG_HEIGHT,
   STANDARD_DIALOG_WIDTH,
-} from '../context-menu/ContextMenu'
+} from '../context-menu/NodeRightClickMenu'
 import { DeleteAction } from '../context-menu/utils/contextMenuActions'
 
 type TProps = {

--- a/packages/dm-core-plugins/src/explorer/components/dialogs/DeleteDialog.tsx
+++ b/packages/dm-core-plugins/src/explorer/components/dialogs/DeleteDialog.tsx
@@ -1,0 +1,54 @@
+import { Dialog, TreeNode, useDMSS } from '@development-framework/dm-core'
+import { Button, Progress } from '@equinor/eds-core-react'
+import React from 'react'
+import {
+  STANDARD_DIALOG_HEIGHT,
+  STANDARD_DIALOG_WIDTH,
+} from '../context-menu/ContextMenu'
+import { DeleteAction } from '../context-menu/utils/contextMenuActions'
+
+type TProps = {
+  setDialogId: (id: string) => void
+  loading: boolean
+  setLoading: (isLoading: boolean) => void
+  node: TreeNode
+}
+
+const DeleteDialog = (props: TProps) => {
+  const { setDialogId, loading, setLoading, node } = props
+  const dmssAPI = useDMSS()
+  return (
+    <Dialog
+      open={true}
+      width={STANDARD_DIALOG_WIDTH}
+      height={STANDARD_DIALOG_HEIGHT}
+      isDismissable
+      onClose={() => setDialogId('')}
+    >
+      <Dialog.Header>
+        <Dialog.Title>Confirm Deletion</Dialog.Title>
+      </Dialog.Header>
+      <Dialog.CustomContent>
+        Are you sure you want to delete the entity <b>{node.name}</b> of type{' '}
+        <b>{node.type}</b>?
+      </Dialog.CustomContent>
+      <Dialog.Actions>
+        <Button
+          color="danger"
+          onClick={async () => {
+            await DeleteAction(node, dmssAPI, setLoading)
+            await node.remove()
+            setDialogId('')
+          }}
+        >
+          {loading ? <Progress.Dots /> : 'Delete'}
+        </Button>
+        <Button variant="outlined" onClick={() => setDialogId('')}>
+          Cancel
+        </Button>
+      </Dialog.Actions>
+    </Dialog>
+  )
+}
+
+export default DeleteDialog

--- a/packages/dm-core-plugins/src/explorer/components/dialogs/NewBlueprintDialog.tsx
+++ b/packages/dm-core-plugins/src/explorer/components/dialogs/NewBlueprintDialog.tsx
@@ -12,7 +12,7 @@ import { toast } from 'react-toastify'
 import {
   STANDARD_DIALOG_HEIGHT,
   STANDARD_DIALOG_WIDTH,
-} from '../context-menu/ContextMenu'
+} from '../context-menu/NodeRightClickMenu'
 
 type TProps = {
   setDialogId: (id: string) => void

--- a/packages/dm-core-plugins/src/explorer/components/dialogs/NewBlueprintDialog.tsx
+++ b/packages/dm-core-plugins/src/explorer/components/dialogs/NewBlueprintDialog.tsx
@@ -1,0 +1,85 @@
+import {
+  Dialog,
+  EBlueprint,
+  ErrorResponse,
+  INPUT_FIELD_WIDTH,
+  TreeNode,
+} from '@development-framework/dm-core'
+import { Button, Input, Label, Progress } from '@equinor/eds-core-react'
+import { AxiosError } from 'axios'
+import React from 'react'
+import { toast } from 'react-toastify'
+import {
+  STANDARD_DIALOG_HEIGHT,
+  STANDARD_DIALOG_WIDTH,
+} from '../context-menu/ContextMenu'
+
+type TProps = {
+  setDialogId: (id: string) => void
+  formData: any
+  setFormData: (id: any) => void
+  loading: boolean
+  setLoading: (isLoading: boolean) => void
+  node: TreeNode
+}
+
+const NewBlueprintDialog = (props: TProps) => {
+  const { setDialogId, formData, setFormData, loading, setLoading, node } =
+    props
+  return (
+    <Dialog
+      open={true}
+      isDismissable
+      onClose={() => setDialogId('')}
+      width={STANDARD_DIALOG_WIDTH}
+      height={STANDARD_DIALOG_HEIGHT}
+    >
+      <Dialog.Header>
+        <Dialog.Title>Create new blueprint</Dialog.Title>
+      </Dialog.Header>
+      <Dialog.CustomContent>
+        <Label label={'Name'} />
+        <Input
+          style={{ width: INPUT_FIELD_WIDTH }}
+          type="string"
+          value={formData?.name || ''}
+          onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+            setFormData({ ...formData, name: event.target.value })
+          }
+          placeholder="Name for new blueprint"
+        />
+      </Dialog.CustomContent>
+      <Dialog.Actions>
+        {loading ? (
+          <Button>
+            <Progress.Dots />
+          </Button>
+        ) : (
+          <Button
+            disabled={formData?.name === undefined}
+            onClick={() => {
+              setLoading(true)
+              node
+                .addEntityToPackage(EBlueprint.BLUEPRINT, formData?.name)
+                .then(() => {
+                  setDialogId('')
+                })
+                .catch((error: AxiosError<ErrorResponse>) => {
+                  console.error(error)
+                  toast.error(error.response?.data.message)
+                })
+                .finally(() => setLoading(false))
+            }}
+          >
+            Create
+          </Button>
+        )}
+        <Button variant="outlined" onClick={() => setDialogId('')}>
+          Cancel
+        </Button>
+      </Dialog.Actions>
+    </Dialog>
+  )
+}
+
+export default NewBlueprintDialog

--- a/packages/dm-core-plugins/src/explorer/components/dialogs/NewEntityDialog.tsx
+++ b/packages/dm-core-plugins/src/explorer/components/dialogs/NewEntityDialog.tsx
@@ -1,0 +1,85 @@
+import {
+  BlueprintPicker,
+  Dialog,
+  ErrorResponse,
+  TreeNode,
+} from '@development-framework/dm-core'
+import { Button, Progress } from '@equinor/eds-core-react'
+import { AxiosError } from 'axios'
+import React from 'react'
+import { toast } from 'react-toastify'
+import {
+  STANDARD_DIALOG_HEIGHT,
+  STANDARD_DIALOG_WIDTH,
+} from '../context-menu/ContextMenu'
+
+type TProps = {
+  setDialogId: (id: string) => void
+  formData: any
+  setFormData: (id: any) => void
+  loading: boolean
+  setLoading: (isLoading: boolean) => void
+  node: TreeNode
+}
+
+const NewEntityDialog = (props: TProps) => {
+  const { setDialogId, formData, setFormData, loading, setLoading, node } =
+    props
+  return (
+    <Dialog
+      open={true}
+      isDismissable
+      onClose={() => setDialogId('')}
+      width={STANDARD_DIALOG_WIDTH}
+      height={STANDARD_DIALOG_HEIGHT}
+    >
+      <Dialog.Header>
+        <Dialog.Title>Create new entity</Dialog.Title>
+      </Dialog.Header>
+      <Dialog.CustomContent>
+        <BlueprintPicker
+          label={'Blueprint'}
+          onChange={(selectedType: string) =>
+            setFormData({ type: selectedType })
+          }
+          formData={formData?.type || ''}
+        />
+      </Dialog.CustomContent>
+      <Dialog.Actions>
+        {loading ? (
+          <Button>
+            <Progress.Dots />
+          </Button>
+        ) : (
+          <Button
+            disabled={formData?.type === undefined}
+            onClick={() => {
+              setLoading(true)
+              node
+                .addEntityToPackage(
+                  `dmss://${formData?.type}`,
+                  formData?.name || 'Created_entity'
+                )
+                .then(() => {
+                  setDialogId('')
+                  toast.success(`New entity created`)
+                })
+                .catch((error: AxiosError<ErrorResponse>) => {
+                  console.error(error)
+                  toast.error(error.response?.data.message)
+                })
+                .finally(() => setLoading(false))
+            }}
+          >
+            Create
+          </Button>
+        )}
+        <Button variant="outlined" onClick={() => setDialogId('')}>
+          Cancel
+        </Button>
+      </Dialog.Actions>
+    </Dialog>
+  )
+}
+
+export default NewEntityDialog

--- a/packages/dm-core-plugins/src/explorer/components/dialogs/NewEntityDialog.tsx
+++ b/packages/dm-core-plugins/src/explorer/components/dialogs/NewEntityDialog.tsx
@@ -11,7 +11,7 @@ import { toast } from 'react-toastify'
 import {
   STANDARD_DIALOG_HEIGHT,
   STANDARD_DIALOG_WIDTH,
-} from '../context-menu/ContextMenu'
+} from '../context-menu/NodeRightClickMenu'
 
 type TProps = {
   setDialogId: (id: string) => void

--- a/packages/dm-core-plugins/src/explorer/components/dialogs/NewFolderDialog.tsx
+++ b/packages/dm-core-plugins/src/explorer/components/dialogs/NewFolderDialog.tsx
@@ -10,7 +10,7 @@ import { toast } from 'react-toastify'
 import {
   STANDARD_DIALOG_HEIGHT,
   STANDARD_DIALOG_WIDTH,
-} from '../context-menu/ContextMenu'
+} from '../context-menu/NodeRightClickMenu'
 import { NewFolderAction } from '../context-menu/utils/contextMenuActions'
 
 type TProps = {

--- a/packages/dm-core-plugins/src/explorer/components/dialogs/NewFolderDialog.tsx
+++ b/packages/dm-core-plugins/src/explorer/components/dialogs/NewFolderDialog.tsx
@@ -1,0 +1,79 @@
+import {
+  Dialog,
+  INPUT_FIELD_WIDTH,
+  TreeNode,
+  useDMSS,
+} from '@development-framework/dm-core'
+import { Button, Input, Label } from '@equinor/eds-core-react'
+import React from 'react'
+import { toast } from 'react-toastify'
+import {
+  STANDARD_DIALOG_HEIGHT,
+  STANDARD_DIALOG_WIDTH,
+} from '../context-menu/ContextMenu'
+import { NewFolderAction } from '../context-menu/utils/contextMenuActions'
+
+type TProps = {
+  setDialogId: (id: string) => void
+  formData: any
+  setFormData: (id: any) => void
+  node: TreeNode
+}
+
+const NewFolderDialog = (props: TProps) => {
+  const { setDialogId, formData, setFormData, node } = props
+  const dmssAPI = useDMSS()
+  return (
+    <Dialog
+      isDismissable
+      open={true}
+      width={STANDARD_DIALOG_WIDTH}
+      height={STANDARD_DIALOG_HEIGHT}
+      onClose={() => {
+        setFormData(undefined)
+        setDialogId('')
+      }}
+    >
+      <Dialog.Header>
+        <Dialog.Title>Create new folder</Dialog.Title>
+      </Dialog.Header>
+      <Dialog.CustomContent>
+        <Label label={'Folder name'} />
+        <Input
+          type={'string'}
+          style={{ width: INPUT_FIELD_WIDTH }}
+          onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+            setFormData(event.target.value)
+          }
+        />
+      </Dialog.CustomContent>
+      <Dialog.Actions>
+        <Button
+          disabled={formData === undefined || formData === ''}
+          onClick={() => {
+            if (formData) {
+              NewFolderAction(node, formData, dmssAPI)
+              setDialogId('')
+              setFormData('')
+            } else {
+              toast.error('Form data cannot be empty!')
+            }
+          }}
+        >
+          Create
+        </Button>
+        <Button
+          variant="outlined"
+          onClick={() => {
+            setFormData(undefined)
+            setDialogId('')
+          }}
+        >
+          Cancel
+        </Button>
+      </Dialog.Actions>
+    </Dialog>
+  )
+}
+
+export default NewFolderDialog

--- a/packages/dm-core-plugins/src/explorer/components/dialogs/NewRootPackageDialog.tsx
+++ b/packages/dm-core-plugins/src/explorer/components/dialogs/NewRootPackageDialog.tsx
@@ -1,0 +1,79 @@
+import {
+  Dialog,
+  INPUT_FIELD_WIDTH,
+  TreeNode,
+  useDMSS,
+} from '@development-framework/dm-core'
+import { Button, Input, Label } from '@equinor/eds-core-react'
+import React from 'react'
+import { toast } from 'react-toastify'
+import {
+  STANDARD_DIALOG_HEIGHT,
+  STANDARD_DIALOG_WIDTH,
+} from '../context-menu/ContextMenu'
+import { NewRootPackageAction } from '../context-menu/utils/contextMenuActions'
+
+type TProps = {
+  setDialogId: (id: string) => void
+  formData: any
+  setFormData: (id: any) => void
+  node: TreeNode
+}
+
+const NewRootPackageDialog = (props: TProps) => {
+  const { setDialogId, formData, setFormData, node } = props
+  const dmssAPI = useDMSS()
+  return (
+    <Dialog
+      open={true}
+      width={STANDARD_DIALOG_WIDTH}
+      height={STANDARD_DIALOG_HEIGHT}
+      isDismissable
+      onClose={() => {
+        setFormData(undefined)
+        setDialogId('')
+      }}
+    >
+      <Dialog.Header>
+        <Dialog.Title>New root package</Dialog.Title>
+      </Dialog.Header>
+      <Dialog.CustomContent>
+        <Label label={'Root package name'} />
+        <Input
+          type={'string'}
+          style={{ width: INPUT_FIELD_WIDTH }}
+          onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+            setFormData(event.target.value)
+          }
+        />
+      </Dialog.CustomContent>
+      <Dialog.Actions>
+        <Button
+          disabled={formData === undefined || formData === ''}
+          onClick={() => {
+            if (formData) {
+              NewRootPackageAction(node, formData, dmssAPI)
+              setDialogId('')
+              setFormData('')
+            } else {
+              toast.error('Form data cannot be empty!')
+            }
+          }}
+        >
+          Create
+        </Button>
+        <Button
+          variant="outlined"
+          onClick={() => {
+            setFormData(undefined)
+            setDialogId('')
+          }}
+        >
+          Cancel
+        </Button>
+      </Dialog.Actions>
+    </Dialog>
+  )
+}
+
+export default NewRootPackageDialog

--- a/packages/dm-core-plugins/src/explorer/components/dialogs/NewRootPackageDialog.tsx
+++ b/packages/dm-core-plugins/src/explorer/components/dialogs/NewRootPackageDialog.tsx
@@ -10,7 +10,7 @@ import { toast } from 'react-toastify'
 import {
   STANDARD_DIALOG_HEIGHT,
   STANDARD_DIALOG_WIDTH,
-} from '../context-menu/ContextMenu'
+} from '../context-menu/NodeRightClickMenu'
 import { NewRootPackageAction } from '../context-menu/utils/contextMenuActions'
 
 type TProps = {


### PR DESCRIPTION
## What does this pull request change?

The ContextMenu file was long and hard to get a grasp of, so I split it into multiple files. Also noticed that we were rendering 6 dialogs for each node in the tree, which seems a bit excessive, so I added an inline if around each render

## Why is this pull request needed?

## Issues related to this change

