### PR TITLE
chore: replace js-yaml with yaml

### DIFF
--- a/packages/dm-core-plugins/package.json
+++ b/packages/dm-core-plugins/package.json
@@ -10,11 +10,11 @@
     "@equinor/eds-tokens": "^0.9.0",
     "axios": "^1.4.0",
     "highlight.js": "^11.8.0",
-    "js-yaml": "^4.1.0",
     "mermaid": "^10.0.0",
     "react-contextmenu": "^2.11.0",
     "react-hook-form": "^7.31.2",
-    "react-toastify": "^9.1.3"
+    "react-toastify": "^9.1.3",
+    "yaml": "^2.3.2"
   },
   "devDependencies": {
     "@testing-library/dom": "^9.2.0",

--- a/packages/dm-core-plugins/src/yaml/YamlPlugin.tsx
+++ b/packages/dm-core-plugins/src/yaml/YamlPlugin.tsx
@@ -7,16 +7,16 @@ import {
 import { Button } from '@equinor/eds-core-react'
 import hljs from 'highlight.js'
 import yaml from 'highlight.js/lib/languages/yaml'
-import jsyaml from 'js-yaml'
 import React from 'react'
 import { toast } from 'react-toastify'
+import { stringify } from 'yaml'
 import './index.css'
 
 hljs.registerLanguage('yaml', yaml)
 
 const YamlView = (props: { document: TGenericObject }) => {
   const { document } = props
-  const asYAML: string = jsyaml.dump(document)
+  const asYAML: string = stringify(document)
   const highlighted = hljs.highlight(asYAML, { language: 'yaml' })
 
   return (


### PR DESCRIPTION
## What does this pull request change?

## Why is this pull request needed?

[js-yaml](https://www.npmjs.com/package/js-yaml) hasn't had a release in two years. Meanwhile, [yaml](https://www.npmjs.com/package/yaml) has TS support, recent release and, while not as popular as js-yaml, is still quite popular.

## Issues related to this change

