### PR TITLE
refactor(tree): remove onselect from wrapper props

### DIFF
--- a/packages/dm-core/src/components/Pickers/DestinationPicker.tsx
+++ b/packages/dm-core/src/components/Pickers/DestinationPicker.tsx
@@ -53,6 +53,31 @@ export const DestinationPicker = (props: TDestinationPickerProps) => {
     setShowModal(false)
   }
 
+  const SelectPackageButton = (props: TNodeWrapperProps) => {
+    const { node, children } = props
+
+    return (
+      <Wrapper>
+        {children}
+        {node.type === EBlueprint.PACKAGE && (
+          <div style={{ padding: '0 5px', backgroundColor: 'white' }}>
+            <Button
+              style={{ height: '22px' }}
+              variant="ghost"
+              onClick={() => {
+                if (onSelect) {
+                  return onSelect(node)
+                }
+              }}
+            >
+              Select
+            </Button>
+          </div>
+        )}
+      </Wrapper>
+    )
+  }
+
   return (
     <div>
       <Label label={label || 'Destination'} />
@@ -90,7 +115,6 @@ export const DestinationPicker = (props: TDestinationPickerProps) => {
               // eslint-disable-next-line @typescript-eslint/no-empty-function
               onSelect={() => {}}
               NodeWrapper={SelectPackageButton}
-              NodeWrapperOnClick={onSelect}
             />
           )}
         </Dialog.CustomContent>
@@ -108,27 +132,3 @@ const Wrapper = styled.div`
     background-color: #acb7da;
   }
 `
-export const SelectPackageButton = (props: TNodeWrapperProps) => {
-  const { node, children, onSelect } = props
-
-  return (
-    <Wrapper>
-      {children}
-      {node.type === EBlueprint.PACKAGE && (
-        <div style={{ padding: '0 5px', backgroundColor: 'white' }}>
-          <Button
-            style={{ height: '22px' }}
-            variant="ghost"
-            onClick={() => {
-              if (onSelect) {
-                return onSelect(node)
-              }
-            }}
-          >
-            Select
-          </Button>
-        </div>
-      )}
-    </Wrapper>
-  )
-}

--- a/packages/dm-core/src/components/TreeView.tsx
+++ b/packages/dm-core/src/components/TreeView.tsx
@@ -44,7 +44,6 @@ export type TNodeWrapperProps = {
   node: TreeNode
   removeNode?: () => void
   children: any
-  onSelect?: (node: TreeNode) => void
 }
 
 const GetIcon = (props: { node: TreeNode; expanded: boolean }) => {
@@ -136,11 +135,9 @@ export const TreeView = (props: {
   nodes: TreeNode[]
   onSelect: (node: TreeNode) => void
   NodeWrapper?: React.FunctionComponent<TNodeWrapperProps>
-  NodeWrapperOnClick?: (node: TreeNode) => void
   ignoredTypes?: string[] // Types to hide in the tree
 }) => {
-  const { nodes, onSelect, NodeWrapper, NodeWrapperOnClick, ignoredTypes } =
-    props
+  const { nodes, onSelect, NodeWrapper, ignoredTypes } = props
 
   // Use a per TreeView state to keep track of expanded nodes.
   // This is so clicking in one tree will not affect other TreeViews
@@ -187,11 +184,7 @@ export const TreeView = (props: {
         if (node?.parent && !expandedNodes[node.parent?.nodeId]) return null
         if (NodeWrapper) {
           return (
-            <NodeWrapper
-              node={node}
-              key={node.nodeId}
-              onSelect={NodeWrapperOnClick}
-            >
+            <NodeWrapper node={node} key={node.nodeId}>
               <TreeNodeComponent
                 node={node}
                 expanded={expandedNodes[node.nodeId]}


### PR DESCRIPTION
## What does this pull request change?

Moves the SelectPackageButton so that it doesn't have to get the onSelect prop through the TreeView. Then remove the now unused NodeWrapperOnClick prop from TreeView

## Why is this pull request needed?

The onSelect function was passed into the TreeView and directly out again to the caller. It was only used in the DestinationPicker

## Issues related to this change

