### PR TITLE
test: improve view-selector test

### DIFF
--- a/e2e/tests/plugin-view_selector-car_garage.spec.ts
+++ b/e2e/tests/plugin-view_selector-car_garage.spec.ts
@@ -13,30 +13,33 @@ test('View selector - car garage', async ({ page }) => {
   )
 
   // Collapse and expand sidebar:
-  await page.getByRole('button').first().click()
-  await expect(page.locator('a').filter({ hasText: 'Self' })).not.toBeVisible()
-  await expect(page.locator('a').filter({ hasText: 'Audi' })).not.toBeVisible()
-  await expect(page.locator('a').filter({ hasText: 'Volvo' })).not.toBeVisible()
-  await page.locator('a').nth(1).click()
+  await page.getByRole('button').first().click() //Needs improvement, PR made to EDS #3066
+  await expect(page.getByRole('tab', { name: 'Self' })).not.toBeVisible()
+  await expect(page.getByRole('tab', { name: 'Audi' })).not.toBeVisible()
+  await expect(page.getByRole('tab', { name: 'Volvo' })).not.toBeVisible()
+  await page.getByRole('tab').nth(1).click()
   await expect(page.getByRole('tabpanel').locator('#name')).toHaveValue('Audi')
-  await page.locator('a').first().click()
+  await page.getByRole('tab').first().click()
   await expect(page.getByLabel('Name')).toHaveValue('CarGarage')
-  await page.getByRole('button').first().click()
-  await expect(page.locator('a').filter({ hasText: 'Self' })).toBeVisible()
-  await expect(page.locator('a').filter({ hasText: 'Audi' })).toBeVisible()
-  await expect(page.locator('a').filter({ hasText: 'Volvo' })).toBeVisible()
+  await page.getByRole('button').first().click() //Needs improvement, PR made to EDS #3066
+  await expect(page.getByRole('tab', { name: 'Self' })).toBeVisible()
+  await expect(page.getByRole('tab', { name: 'Audi' })).toBeVisible()
+  await expect(page.getByRole('tab', { name: 'Volvo' })).toBeVisible()
 
   // Open a car and verify that tabs opens within the car:
-  await page.locator('a').filter({ hasText: 'Audi' }).click()
-  await expect(page.getByRole('tab', { name: 'home Home' })).toBeVisible()
+  await page.getByRole('tab', { name: 'Audi' }).click()
+  await expect(page.getByRole('tab', { name: 'Home' })).toBeVisible()
+
   await expect(page.getByRole('tabpanel').locator('#name')).toHaveValue('Audi')
-  await page.getByTestId('Owner').getByRole('button', { name: 'Open' }).click()
+
+  await page
+    .getByRole('group', { name: 'View owner details and history' })
+    .getByRole('button', { name: 'Open in tab' })
+    .click()
   await expect(
-    page.getByRole('tab', { name: 'person Owner details' })
+    page.getByRole('tab', { name: 'Owner details' })
   ).toHaveAttribute('aria-selected', 'true')
-  await expect(
-    page.getByRole('tab', { name: 'group Owner history' })
-  ).toBeVisible()
+  await expect(page.getByRole('tab', { name: 'Owner history' })).toBeVisible()
   await expect(
     page.locator('form').filter({ hasText: 'Name of Owner' }).locator('#name')
   ).toHaveValue('Aiden')
@@ -53,17 +56,19 @@ test('View selector - car garage', async ({ page }) => {
   await page.getByRole('button', { name: 'close', exact: true }).click()
 
   // Select "home" and then open "technical". Verify that both owner and techincal tabs are open and selectable. Check also sub-tabs
-  await page.getByRole('tab', { name: 'home Home' }).click()
+  await page.getByRole('tab', { name: 'Home' }).click()
   await page
-    .getByTestId('Technical')
-    .getByRole('button', { name: 'Open' })
+    .getByRole('group', { name: 'View technical information' })
+    .getByRole('button', { name: 'Open in tab' })
     .click()
-  await expect(
-    page.getByRole('tab', { name: 'Technical Close Technical' })
-  ).toHaveAttribute('aria-selected', 'true')
-  await expect(
-    page.getByRole('tab', { name: 'check EU control' })
-  ).toHaveAttribute('aria-selected', 'true')
+  await expect(page.getByRole('tab', { name: 'Technical' })).toHaveAttribute(
+    'aria-selected',
+    'true'
+  )
+  await expect(page.getByRole('tab', { name: 'EU control' })).toHaveAttribute(
+    'aria-selected',
+    'true'
+  )
   await expect(page.getByRole('tab', { name: 'car Dimensions' })).toBeVisible()
 
   await page
@@ -73,66 +78,66 @@ test('View selector - car garage', async ({ page }) => {
   await page.getByRole('button', { name: 'Submit' }).click()
   await expect(page.getByRole('alert')).toHaveText(['Document updated'])
   await page.getByRole('button', { name: 'close', exact: true }).first().click()
-  await page.getByRole('tab', { name: 'car Dimensions' }).click()
+  await page.getByRole('tab', { name: 'Dimensions' }).click()
   await page.getByTestId('length').getByTestId('form-textfield').fill('4250')
   await page.getByRole('button', { name: 'Submit' }).click()
   await expect(page.getByRole('alert')).toHaveText(['Document updated'])
   await page.getByRole('button', { name: 'close', exact: true }).first().click()
 
   // Open another car and se that no other tabs than "home" is open:
-  await page.locator('a').filter({ hasText: 'Volvo' }).click()
-  await expect(page.getByRole('tab', { name: 'home Home' })).toBeVisible()
+  await page.getByRole('tab', { name: 'Volvo' }).click()
+  await expect(page.getByRole('tab', { name: 'Home' })).toBeVisible()
   await expect(
     page.getByRole('tab', { name: 'Owner', exact: true })
   ).not.toBeVisible()
   await expect(
-    page.getByRole('tab', { name: 'person Owner details' })
+    page.getByRole('tab', { name: 'Owner details' })
   ).not.toBeVisible()
   await expect(
-    page.getByRole('tab', { name: 'group Owner history' })
+    page.getByRole('tab', { name: 'Owner history' })
   ).not.toBeVisible()
 
   // Testing that tabs are still open for the first car when going back and forth:
-  await page.locator('a').filter({ hasText: 'Audi' }).click()
-  await expect(
-    page.getByRole('tab', { name: 'Owner Close Owner' })
-  ).toBeVisible()
-  await expect(
-    page.getByRole('tab', { name: 'Technical Close Technical' })
-  ).toHaveAttribute('aria-selected', 'true')
-  await expect(
-    page.getByRole('tab', { name: 'check EU control' })
-  ).toBeVisible()
-  await expect(
-    page.getByRole('tab', { name: 'car Dimensions' })
-  ).toHaveAttribute('aria-selected', 'true')
+  await page.getByRole('tab', { name: 'Audi' }).click()
+  await expect(page.getByRole('tab', { name: 'Owner' })).toBeVisible()
+  await expect(page.getByRole('tab', { name: 'Technical' })).toHaveAttribute(
+    'aria-selected',
+    'true'
+  )
+  await expect(page.getByRole('tab', { name: 'EU control' })).toBeVisible()
+  await expect(page.getByRole('tab', { name: 'Dimensions' })).toHaveAttribute(
+    'aria-selected',
+    'true'
+  )
 
   // Testing that saving one car does not ovveride the other car:
-  await page.locator('a').filter({ hasText: 'Volvo' }).click()
+  await page.getByRole('tab', { name: 'Volvo' }).click()
   await page
-    .getByTestId('Technical')
-    .getByRole('button', { name: 'Open' })
+    .getByRole('group', { name: 'View technical information' })
+    .getByRole('button', { name: 'Open in tab' })
     .click()
 
   await expect(
     page.getByTestId('nextControl').getByRole('textbox')
   ).toHaveValue('2025-06-01')
-  await page.getByRole('tab', { name: 'car Dimensions' }).click()
+  await page.getByRole('tab', { name: 'Dimensions' }).click()
   await expect(page.getByTestId('length').getByRole('textbox')).toHaveValue(
     '4500'
   )
-  await page.getByRole('tab', { name: 'home Home' }).click()
-  await page.getByTestId('Owner').getByRole('button', { name: 'Open' }).click()
-  await page.getByRole('tab', { name: 'group Owner history' }).click()
+  await page.getByRole('tab', { name: 'Home' }).click()
+  await page
+    .getByRole('group', { name: 'View owner details and history' })
+    .getByRole('button', { name: 'Open in tab' })
+    .click()
+  await page.getByRole('tab', { name: 'Owner history' }).click()
   await expect(page.getByRole('textbox').first()).toHaveValue('Jack')
   await expect(page.getByRole('textbox').last()).toHaveValue('Maria')
 
   // Close tabs:
   await page.getByRole('button', { name: 'Close Owner' }).click()
-  await expect(
-    page.getByRole('tab', { name: 'Technical Close Technical', exact: true })
-  ).toHaveAttribute('aria-selected', 'true')
-  await expect(
-    page.getByRole('tab', { name: 'Owner', exact: true })
-  ).not.toBeVisible()
+  await expect(page.getByRole('tab', { name: 'Technical' })).toHaveAttribute(
+    'aria-selected',
+    'true'
+  )
+  await expect(page.getByRole('tab', { name: 'Owner' })).not.toBeVisible()
 })

--- a/packages/dm-core-plugins/src/view_selector/Sidebar.tsx
+++ b/packages/dm-core-plugins/src/view_selector/Sidebar.tsx
@@ -22,6 +22,7 @@ export const Sidebar = (props: {
                 : EdsIcons.subdirectory_arrow_right
             }
             label={config.label}
+            role="tab"
             onClick={() => setSelectedView(config.viewId)}
             active={selectedView === config.viewId}
           />


### PR DESCRIPTION
## What does this pull request change?
Added "tab" as a role to the sidebar. When used this makes the playwright tests more readable.
Some other improvements to the test.

Chose to use "tab" as a role as that felt as the best fit.

## Why is this pull request needed?

## Issues related to this change

