### PR TITLE
fix: temp fix for view-selector test

### DIFF
--- a/e2e/tests/plugin-view_selector-car_garage.spec.ts
+++ b/e2e/tests/plugin-view_selector-car_garage.spec.ts
@@ -13,6 +13,7 @@ test('View selector - car garage', async ({ page }) => {
   )
 
   // Collapse and expand sidebar:
+  await page.getByRole('tab', { name: 'Self' }).click()
   await page.getByRole('button').first().click() //Needs improvement, PR made to EDS #3066
   await expect(page.getByRole('tab', { name: 'Self' })).not.toBeVisible()
   await expect(page.getByRole('tab', { name: 'Audi' })).not.toBeVisible()


### PR DESCRIPTION
## What does this pull request change?
Temporary fix that hopefully solves the view selector playwright test from failing.

## Why is this pull request needed?
It looks like a previous tooltip gets in the way when clicking the collapse button. Added an extra click to get the tooltip away.
![image](https://github.com/equinor/dm-core-packages/assets/38418577/7fb8228c-bdee-4d6d-bb59-d326831c8187)

## Issues related to this change
Closes #527 
