### PR TITLE
refactor(tree): switch html structure from div to ul

### DIFF
--- a/e2e/tests/plugin-form-Nested.spec.ts
+++ b/e2e/tests/plugin-form-Nested.spec.ts
@@ -19,10 +19,11 @@ test.afterAll(async () => {
 })
 
 const navigate = async () => {
-  await page.getByText('plugins', { exact: true }).click()
-  await page.getByText('form').click()
-  await page.getByText('nested', { exact: true }).click()
-  await page.getByText('DemoDataSource/$Nested').click()
+  await page.getByRole('button', { name: 'DemoDataSource' }).click()
+  await page.getByRole('button', { name: 'plugins' }).click()
+  await page.getByRole('button', { name: 'form' }).click()
+  await page.getByRole('button', { name: 'nested' }).click()
+  await page.getByRole('button', { name: 'DemoDataSource/$Nested' }).click()
 }
 
 test('Change owner', async () => {

--- a/e2e/tests/plugin-form-ReadOnlyPrimitives.spec.ts
+++ b/e2e/tests/plugin-form-ReadOnlyPrimitives.spec.ts
@@ -2,10 +2,11 @@ import { expect, test } from '@playwright/test'
 
 test('Read only primitives', async ({ page }) => {
   await page.goto('http://localhost:3000/')
-  await page.getByText('plugins', { exact: true }).click()
-  await page.getByText('form').click()
-  await page.getByText('read_only_primitives').click()
-  await page.getByText('ReadOnlyPrimitives').click()
+  await page.getByRole('button', { name: 'DemoDataSource' }).click()
+  await page.getByRole('button', { name: 'plugins' }).click()
+  await page.getByRole('button', { name: 'form' }).click()
+  await page.getByRole('button', { name: 'read_only_primitives' }).click()
+  await page.getByRole('button', { name: 'ReadOnlyPrimitives' }).click()
 
   await expect(page.getByLabel('A required string')).not.toBeEditable()
 

--- a/e2e/tests/plugin-form-Simple.spec.ts
+++ b/e2e/tests/plugin-form-Simple.spec.ts
@@ -1,12 +1,17 @@
 import { expect, test } from '@playwright/test'
 
 test('Simple form', async ({ page }) => {
+  const navigate = async () => {
+    await page.getByRole('button', { name: 'DemoDataSource' }).click()
+    await page.getByRole('button', { name: 'plugins' }).click()
+    await page.getByRole('button', { name: 'form' }).click()
+    await page.getByRole('button', { name: 'simple' }).click()
+    await page.getByRole('button', { name: 'DemoDataSource/$Simple' }).click()
+  }
+
   //Open simple form
   await page.goto('http://localhost:3000/')
-  await page.getByText('plugins', { exact: true }).click()
-  await page.getByText('form').click()
-  await page.getByText('simple', { exact: true }).click()
-  await page.getByText('DemoDataSource/$Simple').click()
+  await navigate()
 
   //Remove prefilled optional string
   await page.getByLabel('An optional string (optional)').fill('')
@@ -40,10 +45,7 @@ test('Simple form', async ({ page }) => {
 
   //Reloading form, expecting entered values to be stored
   await page.reload()
-  await page.getByText('plugins', { exact: true }).click()
-  await page.getByText('form').click()
-  await page.getByText('simple', { exact: true }).click()
-  await page.getByText('DemoDataSource/$Simple').click()
+  await navigate()
   await expect(page.getByLabel('Optional string (optional)')).toHaveValue('')
   await expect(page.getByLabel('Required string')).toHaveValue('Foo')
   await expect(page.getByLabel('Numbers only (optional)')).toHaveValue('3.14')

--- a/e2e/tests/plugin-form-UncontainedObject.spec.ts
+++ b/e2e/tests/plugin-form-UncontainedObject.spec.ts
@@ -2,19 +2,29 @@ import { expect, test } from '@playwright/test'
 
 test('uncontainedObject', async ({ page }) => {
   await page.goto('http://localhost:3000/')
-  await page.getByText('plugins', { exact: true }).click()
-  await page.getByText('form').click()
-  await page.getByText('uncontained_object', { exact: true }).click()
-  await page.getByText('UncontainedObject').click()
+  await page.getByRole('button', { name: 'DemoDataSource' }).click()
+  await page.getByRole('button', { name: 'plugins' }).click()
+  await page.getByRole('button', { name: 'form' }).click()
+  await page.getByRole('button', { name: 'uncontained_object' }).click()
+  await page.getByRole('button', { name: 'UncontainedObject' }).click()
 
   const dialog = page.getByRole('dialog')
-  const navigateDialog = async () => {
+  const selectJohn = async () => {
     await expect(dialog).toBeVisible()
-    await dialog.getByText('plugins', { exact: true }).click()
-    await dialog.getByText('form', { exact: true }).click()
-    await dialog.getByText('uncontained_object', { exact: true }).click()
-    await dialog.getByText('UncontainedObject', { exact: true }).click()
-    await dialog.getByText('employees', { exact: true }).click()
+    await dialog.getByRole('button', { name: 'DemoDataSource' }).click()
+    await dialog.getByRole('button', { name: 'plugins' }).click()
+    await dialog.getByRole('button', { name: 'form' }).click()
+    await dialog.getByRole('button', { name: 'uncontained_object' }).click()
+    await dialog.getByRole('button', { name: 'UncontainedObject' }).click()
+    await dialog.getByRole('button', { name: 'employees' }).click()
+    await dialog
+      .getByRole('listitem')
+      .filter({ hasText: /^employees/ })
+      .getByRole('button', { name: 'John' })
+      .click()
+    await expect(dialog.getByText('Selected: John')).toBeVisible()
+    await dialog.getByRole('button', { name: 'Select', exact: true }).click()
+    await expect(dialog).not.toBeVisible()
   }
 
   await page.getByTestId('ceo').getByRole('button', { name: 'Open' }).click()
@@ -32,11 +42,7 @@ test('uncontainedObject', async ({ page }) => {
     .getByTestId('assistant')
     .getByRole('button', { name: 'Add and save' })
     .click()
-  await navigateDialog()
-  await dialog.getByText('John').click()
-  await expect(dialog.getByText('Selected: John')).toBeVisible()
-  await dialog.getByRole('button', { name: 'Select', exact: true }).click()
-  await expect(dialog).not.toBeVisible()
+  await selectJohn()
 
   await page
     .getByTestId('assistant')
@@ -51,13 +57,7 @@ test('uncontainedObject', async ({ page }) => {
     .getByTestId('trainee')
     .getByRole('button', { name: 'Add and save' })
     .click()
-  await navigateDialog()
-  await expect(dialog.getByText('John')).toHaveCount(2)
-  await dialog.getByText('John').first().click()
-  await expect(dialog.getByText('Selected: John')).toBeVisible()
-  await dialog.getByRole('button', { name: 'Select', exact: true }).click()
-
-  await expect(dialog).not.toBeVisible()
+  await selectJohn()
   await expect(
     page.getByTestId('trainee').getByRole('code').getByText('John')
   ).toBeVisible()
@@ -70,12 +70,7 @@ test('uncontainedObject', async ({ page }) => {
     .getByTestId('accountant')
     .getByRole('button', { name: 'Edit and save' })
     .click()
-  await navigateDialog()
-  await expect(dialog.getByText('John')).toHaveCount(3)
-  await dialog.getByText('John').first().click()
-  await expect(dialog.getByText('Selected: John')).toBeVisible()
-  await dialog.getByRole('button', { name: 'Select', exact: true }).click()
-  await expect(dialog).not.toBeVisible()
+  await selectJohn()
   await expect(
     page.getByTestId('accountant').getByRole('code').getByText('John')
   ).toBeVisible()

--- a/e2e/tests/plugin-list-task_list.spec.ts
+++ b/e2e/tests/plugin-list-task_list.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, Page } from '@playwright/test'
+import { Page, expect, test } from '@playwright/test'
 
 //As the tests are building on each other, we need to run in serial mode.
 test.describe.configure({ mode: 'serial' })
@@ -6,22 +6,22 @@ test.describe.configure({ mode: 'serial' })
 //Open the TaskList plugin before each test
 test.beforeEach(async ({ page }) => {
   await page.goto('http://localhost:3000/')
-  await page.getByText('plugins', { exact: true }).click()
-  await page.getByText('form').click()
-  await page.getByText('list').click()
-  await page.getByText('task_list').click()
-  await page.getByText('TaskList').click()
+  await page.getByRole('button', { name: 'DemoDataSource' }).click()
+  await page.getByRole('button', { name: 'plugins' }).click()
+  await page.getByRole('button', { name: 'list' }).click()
+  await page.getByRole('button', { name: 'task_list' }).click()
+  await page.getByRole('button', { name: 'TaskList' }).click()
   await page.getByRole('tab', { name: 'task list' }).click()
 })
 
 //TODO REMOVE: Temporary function to reload page as we currently need to reload page to view saved itmes... (#153)
 async function reloadPage(page: Page) {
   await page.reload()
-  await page.getByText('plugins', { exact: true }).click()
-  await page.getByText('form').click()
-  await page.getByText('list').click()
-  await page.getByText('task_list').click()
-  await page.getByText('TaskList').click()
+  await page.getByRole('button', { name: 'DemoDataSource' }).click()
+  await page.getByRole('button', { name: 'plugins' }).click()
+  await page.getByRole('button', { name: 'list' }).click()
+  await page.getByRole('button', { name: 'task_list' }).click()
+  await page.getByRole('button', { name: 'TaskList' }).click()
   await page.getByRole('tab', { name: 'task list' }).click()
 }
 

--- a/e2e/tests/plugin-table-car_list.spec.ts
+++ b/e2e/tests/plugin-table-car_list.spec.ts
@@ -1,13 +1,17 @@
 import { expect, test } from '@playwright/test'
 
 test('Table car list example', async ({ page }) => {
+  const navigate = async () => {
+    await page.getByRole('button', { name: 'DemoDataSource' }).click()
+    await page.getByRole('button', { name: 'plugins' }).click()
+    await page.getByRole('button', { name: 'table' }).click()
+    await page.getByRole('button', { name: 'car_list' }).click()
+    await page.getByRole('button', { name: 'CarList' }).click()
+  }
+
   //Open form
   await page.goto('http://localhost:3000/')
-  await page.getByText('plugins', { exact: true }).click()
-  await page.getByText('form').click()
-  await page.getByText('table').click()
-  await page.getByText('car_list').click()
-  await page.getByText('CarList').click()
+  await navigate()
 
   //Add a new car by using expand (not "open")
   await page.getByRole('button', { name: 'Add row' }).click()
@@ -22,11 +26,7 @@ test('Table car list example', async ({ page }) => {
 
   //Currently we need to reload application to view saved values...
   await page.reload()
-  await page.getByText('plugins', { exact: true }).click()
-  await page.getByText('form').click()
-  await page.getByText('table').click()
-  await page.getByText('car_list').click()
-  await page.getByText('CarList').click()
+  await navigate()
   await expect(page.getByText('1 - 2 of 2')).toBeVisible()
   await expect(page.getByText('Audi')).toBeVisible()
   await expect(page.getByText('e-tron')).toBeVisible()
@@ -43,11 +43,7 @@ test('Table car list example', async ({ page }) => {
 
   //Currently we need to reload application to view saved values...
   await page.reload()
-  await page.getByText('plugins', { exact: true }).click()
-  await page.getByText('form').click()
-  await page.getByText('table').click()
-  await page.getByText('car_list').click()
-  await page.getByText('CarList').click()
+  await navigate()
   await expect(page.getByText('1 - 2 of 2')).toBeVisible()
   await expect(page.getByText('Polestar')).toBeVisible()
   await expect(page.getByText('2023')).toBeVisible()
@@ -59,11 +55,7 @@ test('Table car list example', async ({ page }) => {
   await page.getByRole('button', { name: 'Move row up' }).last().click()
   await page.getByRole('button', { name: 'Save' }).click()
   await page.reload()
-  await page.getByText('plugins', { exact: true }).click()
-  await page.getByText('form').click()
-  await page.getByText('table').click()
-  await page.getByText('car_list').click()
-  await page.getByText('CarList').click()
+  await navigate()
   await expect(page.locator('tr').nth(1)).toContainText('Polestar')
   await expect(page.locator('tr').nth(2)).toContainText('Volvo')
 
@@ -71,11 +63,7 @@ test('Table car list example', async ({ page }) => {
   await page.getByRole('button', { name: 'Move row down' }).first().click()
   await page.getByRole('button', { name: 'Save' }).click()
   await page.reload()
-  await page.getByText('plugins', { exact: true }).click()
-  await page.getByText('form').click()
-  await page.getByText('table').click()
-  await page.getByText('car_list').click()
-  await page.getByText('CarList').click()
+  await navigate()
   await expect(page.locator('tr').nth(1)).toContainText('Volvo')
   await expect(page.locator('tr').nth(2)).toContainText('Polestar')
 
@@ -83,11 +71,7 @@ test('Table car list example', async ({ page }) => {
   await page.getByRole('button', { name: 'Delete row' }).last().click()
   await page.getByRole('button', { name: 'Save' }).click()
   await page.reload()
-  await page.getByText('plugins', { exact: true }).click()
-  await page.getByText('form').click()
-  await page.getByText('table').click()
-  await page.getByText('car_list').click()
-  await page.getByText('CarList').click()
+  await navigate()
   await expect(page.getByText('1 - 1 of 1')).toBeVisible()
 
   //Adding several cars to test pagination

--- a/e2e/tests/plugin-view_selector-car_garage.spec.ts
+++ b/e2e/tests/plugin-view_selector-car_garage.spec.ts
@@ -3,10 +3,11 @@ import { expect, test } from '@playwright/test'
 test('View selector - car garage', async ({ page }) => {
   // Open self and verify page content and the sidebar:
   await page.goto('http://localhost:3000/')
-  await page.getByText('plugins', { exact: true }).click()
-  await page.getByText('view_selector').click()
-  await page.getByText('car_garage').click()
-  await page.getByText('carGarage').click()
+  await page.getByRole('button', { name: 'DemoDataSource' }).click()
+  await page.getByRole('button', { name: 'plugins' }).click()
+  await page.getByRole('button', { name: 'view_selector' }).click()
+  await page.getByRole('button', { name: 'car_garage' }).click()
+  await page.getByRole('button', { name: 'carGarage' }).click()
   await expect(page.getByLabel('Name')).toHaveValue('CarGarage')
   await expect(page.getByLabel('Description')).toHaveValue(
     'Here you will find detailed information about the cars in our garage'
@@ -14,7 +15,11 @@ test('View selector - car garage', async ({ page }) => {
 
   // Collapse and expand sidebar:
   await page.getByRole('tab', { name: 'Self' }).click()
-  await page.getByRole('button').first().click() //Needs improvement, PR made to EDS #3066
+  await page
+    .locator(
+      '.SideBarToggle__ToggleContainer-sc-1w5e44y-0 > .Button__ButtonBase-sc-1hs0myn-1'
+    )
+    .click() //Needs improvement, PR made to EDS #3066
   await expect(page.getByRole('tab', { name: 'Self' })).not.toBeVisible()
   await expect(page.getByRole('tab', { name: 'Audi' })).not.toBeVisible()
   await expect(page.getByRole('tab', { name: 'Volvo' })).not.toBeVisible()
@@ -22,7 +27,11 @@ test('View selector - car garage', async ({ page }) => {
   await expect(page.getByRole('tabpanel').locator('#name')).toHaveValue('Audi')
   await page.getByRole('tab').first().click()
   await expect(page.getByLabel('Name')).toHaveValue('CarGarage')
-  await page.getByRole('button').first().click() //Needs improvement, PR made to EDS #3066
+  await page
+    .locator(
+      '.SideBarToggle__ToggleContainer-sc-1w5e44y-0 > .Button__ButtonBase-sc-1hs0myn-1'
+    )
+    .click() //Needs improvement, PR made to EDS #3066
   await expect(page.getByRole('tab', { name: 'Self' })).toBeVisible()
   await expect(page.getByRole('tab', { name: 'Audi' })).toBeVisible()
   await expect(page.getByRole('tab', { name: 'Volvo' })).toBeVisible()

--- a/e2e/tests/signalApp.spec.ts
+++ b/e2e/tests/signalApp.spec.ts
@@ -2,9 +2,10 @@ import { expect, test } from '@playwright/test'
 
 test.beforeEach(async ({ page }) => {
   await page.goto('http://localhost:3000/')
-  await page.getByText('apps').click()
-  await page.getByText('MySignalApp').click()
-  await page.getByText('signalApp', { exact: true }).click()
+  await page.getByRole('button', { name: 'DemoDataSource' }).click()
+  await page.getByRole('button', { name: 'apps' }).click()
+  await page.getByRole('button', { name: 'MySignalApp' }).click()
+  await page.getByRole('button', { name: 'signalApp', exact: true }).click()
 })
 
 test('Start SignalApp', async ({ page }) => {

--- a/packages/dm-core/src/components/Pickers/EntityPickerDialog.tsx
+++ b/packages/dm-core/src/components/Pickers/EntityPickerDialog.tsx
@@ -96,7 +96,7 @@ export const EntityPickerDialog = (props: {
           </div>
         ) : (
           <div>
-            <div style={{ height: '40vh' }}>
+            <div style={{ height: '40vh', overflow: 'auto' }}>
               <TreeView
                 ignoredTypes={[EBlueprint.BLUEPRINT]}
                 nodes={treeNodes}

--- a/packages/dm-core/src/domain/Tree.tsx
+++ b/packages/dm-core/src/domain/Tree.tsx
@@ -432,15 +432,8 @@ export class Tree {
   // "*" describes a generator function
   // See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/iterator
   *[Symbol.iterator]() {
-    function* recursiveYieldChildren(node: TreeNode): any {
-      yield node
-      for (const child of Object.values<TreeNode>(node?.children || {})) {
-        yield* recursiveYieldChildren(child)
-      }
-    }
-
     for (const node of Object.values<TreeNode>(this.index)) {
-      yield* recursiveYieldChildren(node)
+      yield node
     }
   }
 }


### PR DESCRIPTION
## What does this pull request change?

Before, the tree used divs upon divs. But actually, a nested list with buttons is a more correct approach, so I fixed that. I've also kept further improvements in mind while working with this, so I hope I easily can add new functionality on top of this.

## Why is this pull request needed?

Makes it easier to navigate in tests and increases accessibility. Hopefully, the code is easier to maintain too.

## Issues related to this change

ref #534

