### PR TITLE
fix(tree): allow node wrappers to open/close node

### DIFF
--- a/packages/dm-core-plugins/src/explorer/components/context-menu/NodeRightClickMenu.tsx
+++ b/packages/dm-core-plugins/src/explorer/components/context-menu/NodeRightClickMenu.tsx
@@ -13,7 +13,7 @@ export const STANDARD_DIALOG_WIDTH = '100%'
 export const STANDARD_DIALOG_HEIGHT = '300px'
 
 const NodeRightClickMenu = (props: TNodeWrapperProps) => {
-  const { node, children } = props
+  const { node, children, setNodeOpen } = props
   const [dialogId, setDialogId] = useState<EDialog | undefined>()
   const [showMenu, setShowMenu] = useState<boolean>(false)
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
@@ -42,7 +42,12 @@ const NodeRightClickMenu = (props: TNodeWrapperProps) => {
       </Menu>
 
       {dialogId === EDialog.NewFolder && (
-        <NewFolderDialog setDialogId={setDialogId} node={node} isRoot={false} />
+        <NewFolderDialog
+          setDialogId={setDialogId}
+          node={node}
+          setNodeOpen={setNodeOpen}
+          isRoot={false}
+        />
       )}
 
       {dialogId === EDialog.Delete && (
@@ -50,19 +55,36 @@ const NodeRightClickMenu = (props: TNodeWrapperProps) => {
       )}
 
       {dialogId === EDialog.NewRootPackage && (
-        <NewFolderDialog setDialogId={setDialogId} node={node} isRoot={true} />
+        <NewFolderDialog
+          setDialogId={setDialogId}
+          node={node}
+          setNodeOpen={setNodeOpen}
+          isRoot={true}
+        />
       )}
 
       {dialogId === EDialog.AppendEntity && (
-        <AppendEntityDialog setDialogId={setDialogId} node={node} />
+        <AppendEntityDialog
+          setDialogId={setDialogId}
+          node={node}
+          setNodeOpen={setNodeOpen}
+        />
       )}
 
       {dialogId === EDialog.NewEntity && (
-        <NewEntityDialog setDialogId={setDialogId} node={node} />
+        <NewEntityDialog
+          setDialogId={setDialogId}
+          node={node}
+          setNodeOpen={setNodeOpen}
+        />
       )}
 
       {dialogId === EDialog.NewBlueprint && (
-        <NewBlueprintDialog setDialogId={setDialogId} node={node} />
+        <NewBlueprintDialog
+          setDialogId={setDialogId}
+          node={node}
+          setNodeOpen={setNodeOpen}
+        />
       )}
     </>
   )

--- a/packages/dm-core-plugins/src/explorer/components/dialogs/AppendEntityDialog.tsx
+++ b/packages/dm-core-plugins/src/explorer/components/dialogs/AppendEntityDialog.tsx
@@ -9,10 +9,11 @@ import { STANDARD_DIALOG_WIDTH } from '../context-menu/NodeRightClickMenu'
 type TProps = {
   setDialogId: (id: EDialog | undefined) => void
   node: TreeNode
+  setNodeOpen: (x: boolean) => void
 }
 
 const AppendEntityDialog = (props: TProps) => {
-  const { setDialogId, node } = props
+  const { setDialogId, node, setNodeOpen } = props
   const [loading, setLoading] = useState<boolean>(false)
 
   const handleAppend = () => {
@@ -20,7 +21,7 @@ const AppendEntityDialog = (props: TProps) => {
     node
       .addEntityToPackage(node.attribute.attributeType, `${node.entity.length}`)
       .then(() => {
-        node.expand()
+        setNodeOpen(true)
         toast.success('The new entity has been appended to the list')
       })
       .catch((error: AxiosError<ErrorResponse>) => {

--- a/packages/dm-core-plugins/src/explorer/components/dialogs/NewBlueprintDialog.tsx
+++ b/packages/dm-core-plugins/src/explorer/components/dialogs/NewBlueprintDialog.tsx
@@ -18,10 +18,11 @@ import {
 type TProps = {
   setDialogId: (id: EDialog | undefined) => void
   node: TreeNode
+  setNodeOpen: (x: boolean) => void
 }
 
 const NewBlueprintDialog = (props: TProps) => {
-  const { setDialogId, node } = props
+  const { setDialogId, node, setNodeOpen } = props
   const [blueprintName, setBlueprintName] = useState<string>('')
   const [loading, setLoading] = useState<boolean>(false)
 
@@ -29,7 +30,10 @@ const NewBlueprintDialog = (props: TProps) => {
     setLoading(true)
     node
       .addEntityToPackage(EBlueprint.BLUEPRINT, blueprintName)
-      .then(() => toast.success('Blueprint is created'))
+      .then(() => {
+        setNodeOpen(true)
+        toast.success('Blueprint is created')
+      })
       .catch((error: AxiosError<ErrorResponse>) => {
         console.error(error)
         toast.error(error.response?.data.message)

--- a/packages/dm-core-plugins/src/explorer/components/dialogs/NewEntityDialog.tsx
+++ b/packages/dm-core-plugins/src/explorer/components/dialogs/NewEntityDialog.tsx
@@ -17,10 +17,11 @@ import {
 type TProps = {
   setDialogId: (id: EDialog | undefined) => void
   node: TreeNode
+  setNodeOpen: (x: boolean) => void
 }
 
 const NewEntityDialog = (props: TProps) => {
-  const { setDialogId, node } = props
+  const { setDialogId, node, setNodeOpen } = props
   const [blueprint, setBlueprint] = useState<string>('')
   const [loading, setLoading] = useState<boolean>(false)
 
@@ -28,7 +29,10 @@ const NewEntityDialog = (props: TProps) => {
     setLoading(true)
     node
       .addEntityToPackage(`dmss://${blueprint}`, 'Created_entity')
-      .then(() => toast.success(`Entity is created`))
+      .then(() => {
+        setNodeOpen(true)
+        toast.success(`Entity is created`)
+      })
       .catch((error: AxiosError<ErrorResponse>) => {
         console.error(error)
         toast.error(error.response?.data.message)

--- a/packages/dm-core-plugins/src/explorer/components/dialogs/NewFolderDialog.tsx
+++ b/packages/dm-core-plugins/src/explorer/components/dialogs/NewFolderDialog.tsx
@@ -18,11 +18,12 @@ import {
 type TProps = {
   setDialogId: (id: EDialog | undefined) => void
   node: TreeNode
+  setNodeOpen: (x: boolean) => void
   isRoot: boolean
 }
 
 const NewFolderDialog = (props: TProps) => {
-  const { setDialogId, node, isRoot } = props
+  const { setDialogId, node, setNodeOpen, isRoot } = props
   const [folderName, setFolderName] = useState<string>('')
   const [loading, setLoading] = useState<boolean>(false)
   const dmssAPI = useDMSS()
@@ -43,7 +44,7 @@ const NewFolderDialog = (props: TProps) => {
         updateUncontained: true,
       })
       .then(() => {
-        node.expand()
+        setNodeOpen(true)
         toast.success('Folder is created')
       })
       .catch((error: AxiosError<ErrorResponse>) => {

--- a/packages/dm-core/src/components/TreeView.tsx
+++ b/packages/dm-core/src/components/TreeView.tsx
@@ -35,7 +35,7 @@ const StyledLi = styled.li`
 
 export type TNodeWrapperProps = {
   node: TreeNode
-  removeNode?: () => void
+  setNodeOpen: (x: boolean) => void
   children: any
 }
 
@@ -129,15 +129,16 @@ const TreeListItem = (props: {
   const [loading, setLoading] = useState<boolean>(false)
   const [expanded, setExpanded] = useState<boolean>(false)
 
+  const open = async () => {
+    setLoading(true)
+    await node.expand()
+    setLoading(false)
+    setExpanded(true)
+  }
+  const close = () => setExpanded(false)
+  const setOpen = async (x: boolean) => (x ? await open() : close())
   const clickHandler = async () => {
-    if (expanded) {
-      setExpanded(false)
-    } else {
-      setLoading(true)
-      await node.expand()
-      setLoading(false)
-      setExpanded(true)
-    }
+    setOpen(!expanded)
     if (![EBlueprint.PACKAGE, 'dataSource'].includes(node.type)) {
       onSelect(node)
     }
@@ -146,7 +147,7 @@ const TreeListItem = (props: {
   return (
     <StyledLi>
       {NodeWrapper ? (
-        <NodeWrapper node={node} key={node.nodeId}>
+        <NodeWrapper node={node} key={node.nodeId} setNodeOpen={setOpen}>
           <TreeButton
             node={node}
             expanded={expanded}


### PR DESCRIPTION
## What does this pull request change?

Add the possibility for node wrappers to close or open a node in the tree.

## Why is this pull request needed?

It can be handy for wrappers to be able to extend and close nodes in the tree. For example if you're adding a blueprint to a folder that is closed, it makes sense to open it so that the user can see that the blueprint has been added. The explorer had tried to implement this before (thus the node.expand() calls) but it wasn't working. Now it does.

## Issues related to this change

ref #534

