### PR TITLE
test(e2e): make test pass again

### DIFF
--- a/e2e/tests/plugin-form-UncontainedObject.spec.ts
+++ b/e2e/tests/plugin-form-UncontainedObject.spec.ts
@@ -19,7 +19,8 @@ test('uncontainedObject', async ({ page }) => {
     await dialog.getByRole('button', { name: 'employees' }).click()
     await dialog
       .getByRole('listitem')
-      .filter({ hasText: /^employees/ })
+      .filter({ hasText: 'employees' })
+      .last() // Get innermost list
       .getByRole('button', { name: 'John' })
       .click()
     await expect(dialog.getByText('Selected: John')).toBeVisible()

--- a/e2e/tests/signalApp.spec.ts
+++ b/e2e/tests/signalApp.spec.ts
@@ -2,10 +2,10 @@ import { expect, test } from '@playwright/test'
 
 test.beforeEach(async ({ page }) => {
   await page.goto('http://localhost:3000/')
-  await page.getByRole('button', { name: 'DemoDataSource' }).click()
-  await page.getByRole('button', { name: 'apps' }).click()
-  await page.getByRole('button', { name: 'MySignalApp' }).click()
-  await page.getByRole('button', { name: 'signalApp', exact: true }).click()
+  await page.getByRole('button', { name: 'data source DemoDataSource' }).click()
+  await page.getByRole('button', { name: 'root package apps' }).click()
+  await page.getByRole('button', { name: 'package MySignalApp' }).click()
+  await page.getByRole('button', { name: 'file signalApp' }).click()
 })
 
 test('Start SignalApp', async ({ page }) => {


### PR DESCRIPTION
## What does this pull request change?

## Why is this pull request needed?

I added title to the svg icons, causing some of the tree selections to fail (ie those with exact==true or regex)

## Issues related to this change

