### PR TITLE
refactor(tree): remove unused TreeNode iterator

### DIFF
--- a/packages/dm-core/src/domain/Tree.tsx
+++ b/packages/dm-core/src/domain/Tree.tsx
@@ -192,19 +192,6 @@ export class TreeNode {
     this.children = children
   }
 
-  *[Symbol.iterator]() {
-    function* recursiveYieldChildren(node: TreeNode): any {
-      yield node
-      for (const child of Object.values<TreeNode>(node?.children || {})) {
-        yield* recursiveYieldChildren(child)
-      }
-    }
-
-    for (const node of Object.values<TreeNode>(Object.values(this.children))) {
-      yield* recursiveYieldChildren(node)
-    }
-  }
-
   // Fetches the unresolved document of the node
   async fetch() {
     return this.tree.dmssApi


### PR DESCRIPTION
## What does this pull request change?

## Why is this pull request needed?

Removing it didn't make anything crash

## Issues related to this change

ref #534

