### PR TITLE
refactor(tree): remove unneeded root package init

### DIFF
--- a/packages/dm-core/src/domain/Tree.tsx
+++ b/packages/dm-core/src/domain/Tree.tsx
@@ -323,29 +323,7 @@ export class Tree {
         true
       )
     })
-    await Promise.all(
-      dataSources.map((dataSource: string) =>
-        this.dmssApi
-          .search({
-            // Find all rootPackages in every dataSource
-            body: { type: EBlueprint.PACKAGE, isRoot: 'true' },
-            dataSources: [dataSource],
-          })
-          .then((response) => {
-            updateRootPackagesInTree(
-              response.data as TPackage[],
-              this,
-              dataSource
-            )
-          })
-          .catch((error: Error) => {
-            // If the search fail, set the DataSource as an error node.
-            console.error(error)
-            this.index[dataSource].type = 'error'
-            this.index[dataSource].message = error.message
-          })
-      )
-    ).then(() => this.updateCallback(this))
+    this.updateCallback(this)
   }
 
   /**


### PR DESCRIPTION
## What does this pull request change?

## Why is this pull request needed?

Removing it didn't seem to make anything crash. I think the operation is covered by the more generic TreeNode.expand()

## Issues related to this change

ref #534

