### PR TITLE
chore: update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ yarn-error.log
 
 .venv
 venv
+
+.DS_Store


### PR DESCRIPTION
## What does this pull request change?
update gitignore to exclude the `.DS_Store` file generated by macs
## Why is this pull request needed?

## Issues related to this change

