### PR TITLE
refactor(tree): remove attribute from treenode

### DIFF
--- a/packages/dm-core-plugins/src/explorer/components/context-menu/getMenuItems.tsx
+++ b/packages/dm-core-plugins/src/explorer/components/context-menu/getMenuItems.tsx
@@ -24,7 +24,7 @@ export function getMenuItems(
   }
 
   // Append to lists
-  if (node.attribute.dimensions !== '') {
+  if (Array.isArray(node.entity)) {
     menuItems.push(getMenuItem(EDialog.AppendEntity, `Append ${node.name}`))
   }
 

--- a/packages/dm-core-plugins/src/explorer/components/dialogs/AppendEntityDialog.tsx
+++ b/packages/dm-core-plugins/src/explorer/components/dialogs/AppendEntityDialog.tsx
@@ -19,7 +19,7 @@ const AppendEntityDialog = (props: TProps) => {
   const handleAppend = () => {
     setLoading(true)
     node
-      .addEntityToPackage(node.attribute.attributeType, `${node.entity.length}`)
+      .addEntityToPackage(node.type, `${node.entity.length}`)
       .then(() => {
         setNodeOpen(true)
         toast.success('The new entity has been appended to the list')


### PR DESCRIPTION
## What does this pull request change?

Removes `attribute` from TreeNode class.

## Why is this pull request needed?

Not really needed, and it increases the complexity of the code

## Issues related to this change

#ref #534

