### PR TITLE
refactor: update attribute name from "view" to "viewConfig"

### DIFF
--- a/example/app/data/DemoDataSource/apps/MySignalApp/instances/CaseUISelector.recipe.json
+++ b/example/app/data/DemoDataSource/apps/MySignalApp/instances/CaseUISelector.recipe.json
@@ -11,7 +11,7 @@
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
           "label": "Tabs",
-          "view": {
+          "viewConfig": {
             "type": "CORE:ReferenceViewConfig",
             "recipe": "Tabs",
             "scope": "self"
@@ -20,7 +20,7 @@
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
           "label": "Run",
-          "view": {
+          "viewConfig": {
             "type": "CORE:ReferenceViewConfig",
             "recipe": "Run",
             "scope": "self"

--- a/example/app/data/DemoDataSource/recipes/apps/EmployeeApp/employeeApp.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/apps/EmployeeApp/employeeApp.recipe.json
@@ -11,7 +11,7 @@
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
           "label": "Employees",
-          "view": {
+          "viewConfig": {
             "type": "CORE:ReferenceViewConfig",
             "recipe": "Edit",
             "scope": "employees"

--- a/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/containers/equallySpacedSignal.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/containers/equallySpacedSignal.recipe.json
@@ -11,7 +11,7 @@
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
           "label": "Plot",
-          "view": {
+          "viewConfig": {
             "type": "CORE:ReferenceViewConfig",
             "recipe": "Plot",
             "scope": "self"
@@ -20,7 +20,7 @@
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
           "label": "Table",
-          "view": {
+          "viewConfig": {
             "type": "CORE:ReferenceViewConfig",
             "recipe": "Table",
             "scope": "self"

--- a/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/signalApp.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/signalApp.recipe.json
@@ -39,7 +39,7 @@
           {
             "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
             "label": "Study",
-            "view": {
+            "viewConfig": {
               "type": "CORE:ReferenceViewConfig",
               "recipe": "Tabs",
               "scope": "study",

--- a/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/signals_simple/case.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/signals_simple/case.recipe.json
@@ -73,7 +73,7 @@
           {
             "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
             "label": "Home",
-            "view": {
+            "viewConfig": {
               "type": "CORE:ReferenceViewConfig",
               "recipe": "Edit"
             }

--- a/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/signals_simple/study.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/signals_simple/study.recipe.json
@@ -13,7 +13,7 @@
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
           "label": "Home",
-          "view": {
+          "viewConfig": {
             "type": "CORE:ReferenceViewConfig",
             "recipe": "Edit"
           }

--- a/example/app/data/DemoDataSource/recipes/blueprint.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/blueprint.recipe.json
@@ -13,7 +13,7 @@
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
           "label": "Edit",
-          "view": {
+          "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
             "recipe": {
               "name": "Edit",
@@ -27,7 +27,7 @@
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
           "label": "Yaml",
-          "view": {
+          "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
             "recipe": {
               "name": "Yaml",

--- a/example/app/data/DemoDataSource/recipes/file.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/file.recipe.json
@@ -11,7 +11,7 @@
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
           "label": "About",
-          "view": {
+          "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
             "recipe": {
               "name": "Edit",
@@ -26,7 +26,7 @@
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
           "label": "File",
-          "view": {
+          "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
             "recipe": {
               "name": "Download",
@@ -40,7 +40,7 @@
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
           "label": "Yaml",
-          "view": {
+          "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
             "recipe": {
               "name": "Yaml",

--- a/example/app/data/DemoDataSource/recipes/plugins/form/nested/carRentalCompany.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/nested/carRentalCompany.recipe.json
@@ -12,7 +12,7 @@
       "items": [
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
-          "view": {
+          "viewConfig": {
             "type": "CORE:ReferenceViewConfig",
             "recipe": "Edit"
           }

--- a/example/app/data/DemoDataSource/recipes/plugins/form/nested/person.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/nested/person.recipe.json
@@ -12,7 +12,7 @@
       "items": [
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
-          "view": {
+          "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
             "recipe": {
               "name": "Edit",

--- a/example/app/data/DemoDataSource/recipes/plugins/form/read_only/carRentalCompany.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/read_only/carRentalCompany.recipe.json
@@ -12,7 +12,7 @@
       "items": [
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
-          "view": {
+          "viewConfig": {
             "type": "CORE:ReferenceViewConfig",
             "recipe": "ReadOnly"
           }

--- a/example/app/data/DemoDataSource/recipes/plugins/form/read_only/person.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/read_only/person.recipe.json
@@ -12,7 +12,7 @@
       "items": [
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
-          "view": {
+          "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
             "recipe": {
               "name": "Edit",

--- a/example/app/data/DemoDataSource/recipes/plugins/form/read_only_primitives/readOnlyPrimitives.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/read_only_primitives/readOnlyPrimitives.recipe.json
@@ -12,7 +12,7 @@
       "items": [
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
-          "view": {
+          "viewConfig": {
             "type": "CORE:ReferenceViewConfig",
             "recipe": "ReadOnly"
           }

--- a/example/app/data/DemoDataSource/recipes/plugins/form/simple/simple.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/simple/simple.recipe.json
@@ -12,7 +12,7 @@
       "items": [
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
-          "view": {
+          "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
             "recipe": {
               "name": "Edit",

--- a/example/app/data/DemoDataSource/recipes/plugins/form/uncontained/company.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/uncontained/company.recipe.json
@@ -12,7 +12,7 @@
       "items": [
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
-          "view": {
+          "viewConfig": {
             "type": "CORE:ReferenceViewConfig",
             "recipe": "Edit"
           }

--- a/example/app/data/DemoDataSource/recipes/plugins/form/uncontained/person.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/uncontained/person.recipe.json
@@ -12,7 +12,7 @@
       "items": [
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
-          "view": {
+          "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
             "recipe": {
               "name": "Edit",

--- a/example/app/data/DemoDataSource/recipes/plugins/grid/order.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/grid/order.recipe.json
@@ -28,7 +28,7 @@
       "dimensions": "*",
       "config": {
         "type": "PLUGINS:dm-core-plugins/list/ListPluginConfig",
-        "views": [],
+        "viewConfigs": [],
         "headers": [
           "name",
           "description"

--- a/example/app/data/DemoDataSource/recipes/plugins/grid/orderItem.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/grid/orderItem.recipe.json
@@ -11,7 +11,7 @@
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
           "label": "Edit",
-          "view": {
+          "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
             "recipe": {
               "name": "Edit",
@@ -43,7 +43,7 @@
       "dimensions": "*",
       "config": {
         "type": "PLUGINS:dm-core-plugins/list/ListPluginConfig",
-        "views": [],
+        "viewConfigs": [],
         "headers": [
           "name",
           "quantity",

--- a/example/app/data/DemoDataSource/recipes/plugins/list/order_example/order.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/list/order_example/order.recipe.json
@@ -28,7 +28,7 @@
       "dimensions": "*",
       "config": {
         "type": "PLUGINS:dm-core-plugins/list/ListPluginConfig",
-        "views": [],
+        "viewConfigs": [],
         "headers": [
           "name",
           "description"

--- a/example/app/data/DemoDataSource/recipes/plugins/list/order_example/orderItem.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/list/order_example/orderItem.recipe.json
@@ -11,7 +11,7 @@
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
           "label": "Edit",
-          "view": {
+          "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
             "recipe": {
               "name": "Edit",
@@ -43,7 +43,7 @@
       "dimensions": "*",
       "config": {
         "type": "PLUGINS:dm-core-plugins/list/ListPluginConfig",
-        "views": [],
+        "viewConfigs": [],
         "headers": [
           "quantity",
           "type"

--- a/example/app/data/DemoDataSource/recipes/plugins/list/task_list/task.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/list/task_list/task.recipe.json
@@ -11,7 +11,7 @@
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
           "label": "Edit",
-          "view": {
+          "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
             "recipe": {
               "name": "Edit",
@@ -53,7 +53,7 @@
       "dimensions": "*",
       "config": {
         "type": "PLUGINS:dm-core-plugins/list/ListPluginConfig",
-        "views": [],
+        "viewConfigs": [],
         "openInline": true,
         "headers": [
           "name",

--- a/example/app/data/DemoDataSource/recipes/plugins/list/task_list/taskList.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/list/task_list/taskList.recipe.json
@@ -28,7 +28,7 @@
       "dimensions": "*",
       "config": {
         "type": "PLUGINS:dm-core-plugins/list/ListPluginConfig",
-        "views": [],
+        "viewConfigs": [],
         "headers": [
           "name",
           "assigned"

--- a/example/app/data/DemoDataSource/recipes/plugins/table/car_list/carList.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/table/car_list/carList.recipe.json
@@ -10,7 +10,7 @@
       "items": [
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
-          "view": {
+          "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
             "recipe": {
               "name": "cars",

--- a/example/app/data/DemoDataSource/recipes/plugins/view_selector/car_infosys/car.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/view_selector/car_infosys/car.recipe.json
@@ -13,7 +13,7 @@
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
           "label": "Home",
-          "view": {
+          "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
             "recipe": {
               "name": "Edit",

--- a/example/app/data/DemoDataSource/recipes/plugins/view_selector/car_infosys/carGarage.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/view_selector/car_infosys/carGarage.recipe.json
@@ -12,7 +12,7 @@
       "items": [
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
-          "view": {
+          "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
             "recipe": {
               "name": "Edit",
@@ -33,7 +33,7 @@
         },
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
-          "view": {
+          "viewConfig": {
             "type": "CORE:ViewConfig",
             "scope": "Audi",
             "eds_icon": "car"
@@ -41,7 +41,7 @@
         },
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
-          "view": {
+          "viewConfig": {
             "type": "CORE:ViewConfig",
             "scope": "Volvo",
             "eds_icon": "car"

--- a/example/app/data/DemoDataSource/recipes/plugins/view_selector/car_infosys/owner.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/view_selector/car_infosys/owner.recipe.json
@@ -13,7 +13,7 @@
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
           "label": "Owner details",
-          "view": {
+          "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
             "recipe": {
               "name": "Edit",
@@ -34,7 +34,7 @@
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
           "label": "Owner history",
-          "view": {
+          "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
             "recipe": {
               "name": "Edit",

--- a/example/app/data/DemoDataSource/recipes/plugins/view_selector/car_infosys/technical.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/view_selector/car_infosys/technical.recipe.json
@@ -13,7 +13,7 @@
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
           "label": "EU control",
-          "view": {
+          "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
             "recipe": {
               "name": "Edit",
@@ -34,7 +34,7 @@
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
           "label": "Dimensions",
-          "view": {
+          "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
             "recipe": {
               "name": "Edit",

--- a/packages/dm-core-plugins/blueprints/list/ListPluginConfig.json
+++ b/packages/dm-core-plugins/blueprints/list/ListPluginConfig.json
@@ -46,7 +46,7 @@
       "default": false
     },
     {
-      "name": "views",
+      "name": "viewConfigs",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "CORE:ViewConfig",
       "dimensions": "*",

--- a/packages/dm-core-plugins/blueprints/view_selector/RecipeSelectorConfig.json
+++ b/packages/dm-core-plugins/blueprints/view_selector/RecipeSelectorConfig.json
@@ -8,7 +8,7 @@
       "attributeType": "string"
     },
     {
-      "name": "views",
+      "name": "viewConfig",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "CORE:ViewConfig",
       "dimensions": "*",

--- a/packages/dm-core-plugins/blueprints/view_selector/ViewSelectorItem.json
+++ b/packages/dm-core-plugins/blueprints/view_selector/ViewSelectorItem.json
@@ -8,7 +8,7 @@
       "attributeType": "string"
     },
     {
-      "name": "view",
+      "name": "viewConfig",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "CORE:ViewConfig"
     },

--- a/packages/dm-core-plugins/src/form/components/OpenObjectButton.tsx
+++ b/packages/dm-core-plugins/src/form/components/OpenObjectButton.tsx
@@ -10,11 +10,11 @@ import { useRegistryContext } from '../context/RegistryContext'
 
 export const OpenObjectButton = ({
   viewId,
-  view,
+  viewConfig,
   idReference,
 }: {
   viewId: string
-  view: TViewConfig | TReferenceViewConfig | TInlineRecipeViewConfig
+  viewConfig: TViewConfig | TReferenceViewConfig | TInlineRecipeViewConfig
   idReference?: string
 }) => {
   const { onOpen } = useRegistryContext()
@@ -23,7 +23,7 @@ export const OpenObjectButton = ({
     <TooltipButton
       title="Open in tab"
       button-variant="ghost_icon"
-      button-onClick={() => onOpen?.(viewId, view, idReference)}
+      button-onClick={() => onOpen?.(viewId, viewConfig, idReference)}
       icon={external_link}
     />
   )

--- a/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
@@ -67,7 +67,7 @@ export default function ArrayField(props: TArrayFieldProps) {
           <Typography bold={true}>{displayLabel}</Typography>
           <OpenObjectButton
             viewId={namePath}
-            view={{
+            viewConfig={{
               type: 'ReferenceViewConfig',
               scope: namePath,
               recipe: uiRecipeName,

--- a/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
@@ -200,7 +200,7 @@ export const ContainedAttribute = (props: TContentProps): JSX.Element => {
           <OpenObjectButton
             viewId={namePath}
             idReference={idReference}
-            view={{
+            viewConfig={{
               type: 'ReferenceViewConfig',
               scope: namePath,
               recipe: uiRecipe?.name,
@@ -280,7 +280,7 @@ export const UncontainedAttribute = (props: TContentProps): JSX.Element => {
         {address && onOpen && !uiAttribute?.showInline && (
           <OpenObjectButton
             viewId={namePath}
-            view={{
+            viewConfig={{
               type: 'ReferenceViewConfig',
               scope: '',
               recipe: uiRecipe?.name,

--- a/packages/dm-core-plugins/src/view_selector/Content.tsx
+++ b/packages/dm-core-plugins/src/view_selector/Content.tsx
@@ -15,25 +15,26 @@ const HidableWrapper = styled.div<any>`
 
 export const Content = (props: {
   type: string
-  selectedView: string
-  items: TItemData[]
+  selectedViewId: string
+  viewSelectorItems: TItemData[]
   setFormData: (v: TGenericObject) => void
   onOpen: TOnOpen
   formData: TGenericObject
   style?: Record<string, string | number>
 }): JSX.Element => {
-  const { selectedView, items, setFormData, formData, onOpen } = props
+  const { selectedViewId, viewSelectorItems, setFormData, formData, onOpen } =
+    props
   return (
     <div style={props.style}>
-      {items.map((config: TItemData) => (
+      {viewSelectorItems.map((config: TItemData) => (
         <HidableWrapper
           key={config.viewId}
-          hidden={config.viewId !== selectedView}
+          hidden={config.viewId !== selectedViewId}
           role="tabpanel"
         >
           <ViewCreator
             idReference={config.rootEntityId}
-            viewConfig={config.view}
+            viewConfig={config.viewConfig}
             onOpen={onOpen}
             onSubmit={(data: TGenericObject) => {
               setFormData({

--- a/packages/dm-core-plugins/src/view_selector/Sidebar.tsx
+++ b/packages/dm-core-plugins/src/view_selector/Sidebar.tsx
@@ -4,27 +4,27 @@ import * as EdsIcons from '@equinor/eds-icons'
 import { TItemData } from './types'
 
 export const Sidebar = (props: {
-  selectedView: string
-  setSelectedView: (k: string) => void
-  items: TItemData[]
+  selectedViewId: string
+  setSelectedViewId: (k: string) => void
+  viewSelectorItems: TItemData[]
 }): JSX.Element => {
-  const { selectedView, setSelectedView, items } = props
+  const { selectedViewId, setSelectedViewId, viewSelectorItems } = props
 
   return (
     <SideBar open style={{ height: 'auto' }}>
       <SideBar.Content>
-        {items.map((config: TItemData) => (
+        {viewSelectorItems.map((config: TItemData) => (
           <SideBar.Link
             key={config.viewId}
             icon={
-              config.view.eds_icon
-                ? EdsIcons[config.view.eds_icon as keyof typeof EdsIcons]
+              config.viewConfig.eds_icon
+                ? EdsIcons[config.viewConfig.eds_icon as keyof typeof EdsIcons]
                 : EdsIcons.subdirectory_arrow_right
             }
             label={config.label}
             role="tab"
-            onClick={() => setSelectedView(config.viewId)}
-            active={selectedView === config.viewId}
+            onClick={() => setSelectedViewId(config.viewId)}
+            active={selectedViewId === config.viewId}
           />
         ))}
       </SideBar.Content>

--- a/packages/dm-core-plugins/src/view_selector/Tabs.tsx
+++ b/packages/dm-core-plugins/src/view_selector/Tabs.tsx
@@ -5,16 +5,18 @@ import Icon from './Icon'
 import { TItemData } from './types'
 
 export const Tabs = (props: {
-  selectedView: string
-  setSelectedView: (viewId: string) => void
-  items: TItemData[]
+  selectedViewId: string
+  setSelectedViewId: (viewId: string) => void
+  viewSelectorItems: TItemData[]
   removeView: (viewId: string) => void
 }): JSX.Element => {
-  const { selectedView, setSelectedView, items } = props
+  const { selectedViewId, setSelectedViewId, viewSelectorItems } = props
   return (
-    <EdsTabs activeTab={items.findIndex((x) => x.viewId == selectedView)}>
+    <EdsTabs
+      activeTab={viewSelectorItems.findIndex((x) => x.viewId == selectedViewId)}
+    >
       <EdsTabs.List>
-        {items.map((config: TItemData) => {
+        {viewSelectorItems.map((config: TItemData) => {
           return (
             <EdsTabs.Tab
               key={config.viewId}
@@ -27,14 +29,14 @@ export const Tabs = (props: {
               }}
             >
               <Button
-                onClick={() => setSelectedView(config.viewId)}
+                onClick={() => setSelectedViewId(config.viewId)}
                 variant="ghost"
                 style={{ fontSize: '16px' }}
               >
-                {config.view?.eds_icon && (
+                {config.viewConfig?.eds_icon && (
                   <Icon
-                    name={config.view.eds_icon}
-                    title={config.view.eds_icon}
+                    name={config.viewConfig.eds_icon}
+                    title={config.viewConfig.eds_icon}
                   />
                 )}
                 {config.label}

--- a/packages/dm-core-plugins/src/view_selector/types.tsx
+++ b/packages/dm-core-plugins/src/view_selector/types.tsx
@@ -5,7 +5,7 @@ import {
 } from '@development-framework/dm-core'
 
 export type TViewSelectorItem = {
-  view: TReferenceViewConfig | TInlineRecipeViewConfig | TViewConfig
+  viewConfig: TReferenceViewConfig | TInlineRecipeViewConfig | TViewConfig
   label?: string
 }
 


### PR DESCRIPTION
## What does this pull request change?
Refactors the name of attributes with type "CORE:ViewConfig" from "view" to "viewConfig" 

## Why is this pull request needed?
Currently we are inconsistent with the naming of "ViewConfig" attributes. It is helpful for readability to have one single name across the entire framework for this attribute type, by saying exactly what the attributes and variables are.

## Issues related to this change
Closes #556 
