### PR TITLE
fix: update table test pagination check

### DIFF
--- a/e2e/tests/plugin-table-car_list.spec.ts
+++ b/e2e/tests/plugin-table-car_list.spec.ts
@@ -90,7 +90,7 @@ test('Table car list example', async ({ page }) => {
   await page.getByRole('button', { name: 'Save' }).click()
   await page.getByRole('button', { name: 'Next page' }).click()
   await expect(page.getByText('6 - 6 of 6')).toBeVisible()
-  //await expect(page.getByRole('button', { name: 'Next page' })).toBeDisabled() //BUG #258
+  await expect(page.getByRole('button', { name: 'Next page' })).toBeDisabled()
   await page.getByRole('button', { name: 'Previous page' }).click()
   await expect(page.getByText('1 - 5 of 6')).toBeVisible()
   await expect(


### PR DESCRIPTION
## What does this pull request change?

#553 fixed the issue with pagination where it was possible to navigate beyond the number of items in the table.
Playwright test had a check for this but commented out until issue was fixed. Therefore uncommenting the check. 

## Why is this pull request needed?

## Issues related to this change

