### PR TITLE
chore: bump eds version

### DIFF
--- a/packages/dm-core-plugins/package.json
+++ b/packages/dm-core-plugins/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "dependencies": {
     "@development-framework/dm-core": "^1.3.4",
-    "@equinor/eds-core-react": "^0.32.4",
+    "@equinor/eds-core-react": "^0.33.0",
     "@equinor/eds-icons": "^0.19.3",
     "@equinor/eds-tokens": "^0.9.0",
     "axios": "^1.4.0",

--- a/packages/dm-core/package.json
+++ b/packages/dm-core/package.json
@@ -10,7 +10,7 @@
     "styled-components": "^5.2.3"
   },
   "dependencies": {
-    "@equinor/eds-core-react": "^0.32.4",
+    "@equinor/eds-core-react": "^0.33.0",
     "@equinor/eds-icons": "^0.19.3",
     "@equinor/eds-tokens": "^0.9.0",
     "axios": "^1.4.0",


### PR DESCRIPTION
## What does this pull request change?

Bump eds-core-react to version 0.33.0.

## Why is this pull request needed?

## Issues related to this change

