### PR TITLE
ci: deploy to Radix

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -40,3 +40,13 @@ jobs:
       releases_created: ${{ steps.release.outputs.releases_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
 
+  deploy-dev:
+    permissions:
+      packages: write
+      contents: read
+      id-token: write
+    needs: release-please
+    uses: ./.github/workflows/on-release.yaml
+    with:
+      release-tag: ${{ needs.release-please.outputs.tag_name }}
+    if: ${{ needs.release-please.outputs.release_created }}

--- a/.github/workflows/deploy-to-radix.yaml
+++ b/.github/workflows/deploy-to-radix.yaml
@@ -1,4 +1,4 @@
-name: "Deploy image to radix"
+name: "Deploy to radix"
 on:
   workflow_dispatch:
     inputs:
@@ -54,12 +54,10 @@ jobs:
         with:
           args: >
             create job
-            build-deploy
-            --application $RADIX_APP
-            --environment ${{ inputs.radix-environment }}
-            --user $RADIX_USER
+            build-deploy                        
             --context production
-            --token-environment
+            --from-config
+            --branch main
             --follow
 
       - name: Get Azure principal token for Azure application

--- a/.github/workflows/on-main-push.yaml
+++ b/.github/workflows/on-main-push.yaml
@@ -29,9 +29,6 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.releases_created }}
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        package: [dm-core, dm-core-plugins]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -1,14 +1,30 @@
-name: Deploy to Radix on new releases
+name: New release
 
 on:
-  release:
-    types: [published]
+  # Workflow dispatch is used for manual triggers
+  workflow_dispatch:
+    inputs:
+      release-tag:
+        description: 'GitHub release tag'
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      release-tag:
+        description: 'GitHub release tag'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
 
 jobs:
   publish-latest:
     uses: ./.github/workflows/publish-image.yaml
     with:
-      image-tags: latest
+      image-tags: latest,${{ inputs.release-tag }}
 
   deploy-test:
     needs: publish-latest


### PR DESCRIPTION
## What does this pull request change?

* Fixed so that the packages are not tried to be published twice and therefore fail the second time (since it is already uploaded)
* Added the possibility to manually trigger the `on-release` workflow
* Added so that release please is responsible for triggering the  `on-release` after a release is created

## Why is this pull request needed?

## Issues related to this change

