### PR TITLE
feat: add sample json schema for validating blueprints and recipes

### DIFF
--- a/_schema/blueprint.schema.json
+++ b/_schema/blueprint.schema.json
@@ -1,0 +1,74 @@
+{
+  "type": "object",
+  "description": "Schema for writing correct blueprints",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Blueprint schema",
+  "additionalItems": false,
+  "$defs": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "CORE:Blueprint",
+        "dmss://system/SIMOS/Blueprint"
+      ]
+    },
+    "attributeTypes": {
+      "type": "string",
+      "enum": [
+        "CORE:BlueprintAttribute",
+        "dmss://system/SIMOS/BlueprintAttribute"
+      ]
+    }
+  },
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "type": {
+      "$ref": "#/$defs/type"
+    },
+    "description": {
+      "type": "string"
+    },
+    "attributes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "$ref": "#/$defs/attributeTypes"
+          },
+          "description": {
+            "type": "string"
+          },
+          "attributeType": {
+            "type": "string"
+          },
+          "optional": {
+            "type": "boolean"
+          },
+          "label": {
+            "type": "string"
+          },
+          "dimensions": {
+            "type": "string"
+          },
+          "default": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "attributeType"
+        ]
+      }
+    }
+  },
+  "required": [
+    "name",
+    "type"
+  ]
+}

--- a/_schema/recipe.schema.json
+++ b/_schema/recipe.schema.json
@@ -1,0 +1,81 @@
+{
+  "type": "object",
+  "description": "Schema for writing correct blueprints",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Blueprint schema",
+  "additionalItems": false,
+  "$defs": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "CORE:RecipeLink",
+        "dmss://system/SIMOS/RecipeLink"
+      ]
+    },
+    "uiRecipes": {
+      "type": "string",
+      "enum": [
+        "CORE:UiRecipe",
+        "dmss://system/SIMOS/UiRecipe"
+      ]
+    }
+  },
+  "properties": {
+    "type": {
+      "$ref": "#/$defs/type"
+    },
+    "_blueprintPath_": {
+      "type": "string"
+    },
+    "initialUiRecipe": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "$ref": "#/$defs/uiRecipes"
+        },
+        "plugin": {
+          "type": "string"
+        },
+        "config": {
+          "$ref": "recipeConfig.schema.json"
+        }
+      },
+      "required": [
+        "type",
+        "plugin",
+        "config"
+      ]
+    },
+    "uiRecipes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "plugin": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "plugin"
+        ]
+      }
+    }
+  },
+  "required": [
+    "type",
+    "_blueprintPath_"
+  ]
+}

--- a/_schema/recipeConfig.schema.json
+++ b/_schema/recipeConfig.schema.json
@@ -1,0 +1,116 @@
+{
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "View Config recipe schema",
+  "additionalItems": false,
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "PLUGINS:dm-core-plugins/form/FormInput",
+        "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig"
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "enum": [
+              "PLUGINS:dm-core-plugins/form/FormInput"
+            ]
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "then": {
+        "properties": {
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "readOnly": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "fields"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "enum": [
+              "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig"
+            ]
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "then": {
+        "properties": {
+          "childTabsOnRender": {
+            "type": "boolean"
+          },
+          "asSidebar": {
+            "type": "boolean"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "label": {
+                  "type": "string"
+                },
+                "viewConfig": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string"
+                    },
+                    "recipe": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "plugin": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "scope": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "items"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Here's a "quick" demo of what I talked about last week regarding json-schema and validation. Its probably a bit of a set-up job, but I think this is something that could prove pretty useful for us, and for other people using the framework.

This is purely a DX feature, and has to be manually enabled in the editor (afaik).

To enable the json schema validation:

For pycharm/intellij/webstorm, open settings, and go to `Languages & Frameworks` -> `Schemas and DTDs` -> `JSON Schema Mappings` and add a schema for the recipe and one for the blueprint schema. Then, make it validate files matching the paths `*.recipe.json` and `*.blueprint.json`

in VSCode, open settings and search for JSON Schema. It will tell you to edit `settings.json`. There, you'll have to add the following snippet to link to the schemas:
```json
{
    "json.schemas": [
        {
            "fileMatch": [
                "*.blueprint.json"
            ],
            "url": "file:<PATH TO dm-core-packages>/_schema/blueprint.schema.json"
        },
        {
            "fileMatch": [
                "*.recipe.json"
            ],
            "url": "file:<PATH TO dm-core-packages>/_schema/recipe.schema.json"
        }
    ]
}
```

If set up correctly you'll now get suggestions when writing blueprints and recipes, and errors if you're missing something or have provided an invalid value.
<img width="546" alt="Screenshot 2023-10-03 at 13 45 05" src="https://github.com/equinor/dm-core-packages/assets/3105885/52acd937-5b90-49d7-92af-c5bbca2ca91f">
<img width="470" alt="Screenshot 2023-10-03 at 13 45 17" src="https://github.com/equinor/dm-core-packages/assets/3105885/9bdfde89-8e5f-4dd1-8350-62a17927a0ee">



