### PR TITLE
fix: UserInfoDialog crash when no roles in token

### DIFF
--- a/packages/dm-core-plugins/src/header/components/UserInfoDialog.tsx
+++ b/packages/dm-core-plugins/src/header/components/UserInfoDialog.tsx
@@ -64,7 +64,7 @@ export const UserInfoDialog = (props: UserInfoDialogProps) => {
         </Row>
         {apiKey && <pre>{apiKey}</pre>}
 
-        {tokenData?.roles.includes(applicationEntity.adminRole) && (
+        {tokenData?.roles?.includes(applicationEntity.adminRole) && (
           <>
             <Typography>Impersonate a role (UI only)</Typography>
             <UnstyledList>


### PR DESCRIPTION
## What does this pull request change?
A one character change so the UserInfoDialog does not crash if the user has no role.


## Why is this pull request needed?
Avoid crashing. Making the code more robust.

## Issues related to this change
none

