### PR TITLE
refactor: deprecated type

### DIFF
--- a/packages/dm-core-plugins/src/explorer/components/context-menu/getMenuItems.tsx
+++ b/packages/dm-core-plugins/src/explorer/components/context-menu/getMenuItems.tsx
@@ -8,7 +8,7 @@ import { EDialog } from '../../types'
 export function getMenuItems(
   node: TreeNode,
   setDialogId: (id: EDialog | undefined) => void
-): JSX.Element[] {
+): React.ReactElement[] {
   const menuItems = []
   const getMenuItem = (id: EDialog, text: string) => {
     return (

--- a/packages/dm-core-plugins/src/form/components/DynamicTable.tsx
+++ b/packages/dm-core-plugins/src/form/components/DynamicTable.tsx
@@ -16,7 +16,7 @@ const DynamicTable = (props: {
   columns: Array<string>
   rows: Array<any>
   onRowClicked?: MouseEventHandler
-}): JSX.Element => {
+}): React.ReactElement => {
   const { columns, rows, onRowClicked } = props
   const cols = prepareColumns(columns)
 

--- a/packages/dm-core-plugins/src/form/context/RegistryContext.tsx
+++ b/packages/dm-core-plugins/src/form/context/RegistryContext.tsx
@@ -16,7 +16,9 @@ export const useRegistryContext = () => {
   return context
 }
 
-export const RegistryProvider = (props: Props & { children: JSX.Element }) => {
+export const RegistryProvider = (
+  props: Props & { children: React.ReactElement }
+) => {
   const { children, ...value } = props
 
   return (

--- a/packages/dm-core-plugins/src/form/context/WidgetContext.tsx
+++ b/packages/dm-core-plugins/src/form/context/WidgetContext.tsx
@@ -27,7 +27,7 @@ export const getWidget = (widgetName: string) => {
  */
 export const WidgetProvider = (props: {
   widgets?: TWidgets
-  children: JSX.Element | JSX.Element[]
+  children: React.ReactElement | React.ReactElement[]
 }) => {
   const { widgets, children } = props
   return (

--- a/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
@@ -165,7 +165,9 @@ const RemoveObject = (props: { namePath: string }) => {
   )
 }
 
-export const ContainedAttribute = (props: TContentProps): JSX.Element => {
+export const ContainedAttribute = (
+  props: TContentProps
+): React.ReactElement => {
   const {
     type,
     namePath,
@@ -225,7 +227,7 @@ const Inline = (props: {
   namePath: string
   blueprint: TBlueprint | undefined
   uiRecipe: TUiRecipeForm | undefined
-}): JSX.Element => {
+}): React.ReactElement => {
   const { idReference, onOpen } = useRegistryContext()
   const { type, namePath, uiRecipe, blueprint } = props
   if (
@@ -250,7 +252,9 @@ const Inline = (props: {
   )
 }
 
-export const UncontainedAttribute = (props: TContentProps): JSX.Element => {
+export const UncontainedAttribute = (
+  props: TContentProps
+): React.ReactElement => {
   const {
     type,
     namePath,
@@ -301,7 +305,7 @@ export const UncontainedAttribute = (props: TContentProps): JSX.Element => {
   )
 }
 
-export const ObjectField = (props: TObjectFieldProps): JSX.Element => {
+export const ObjectField = (props: TObjectFieldProps): React.ReactElement => {
   const { type, namePath, uiAttribute, displayLabel, defaultValue } = props
   const { getValues } = useFormContext()
 
@@ -324,7 +328,9 @@ export const ObjectField = (props: TObjectFieldProps): JSX.Element => {
   )
 }
 
-export const ObjectTypeSelector = (props: TObjectFieldProps): JSX.Element => {
+export const ObjectTypeSelector = (
+  props: TObjectFieldProps
+): React.ReactElement => {
   const {
     type,
     namePath,

--- a/packages/dm-core-plugins/src/form/types.tsx
+++ b/packages/dm-core-plugins/src/form/types.tsx
@@ -118,5 +118,5 @@ export type TWidget = {
 }
 
 export type TWidgets = {
-  [key: string]: (props: TWidget) => JSX.Element
+  [key: string]: (props: TWidget) => React.ReactElement
 }

--- a/packages/dm-core-plugins/src/grid/GridElement.tsx
+++ b/packages/dm-core-plugins/src/grid/GridElement.tsx
@@ -14,7 +14,7 @@ type TGridItemProps = {
   type: string
 }
 
-export const GridElement = (props: TGridItemProps): JSX.Element => {
+export const GridElement = (props: TGridItemProps): React.ReactElement => {
   const { idReference, item } = props
 
   return (

--- a/packages/dm-core-plugins/src/grid/GridPlugin.tsx
+++ b/packages/dm-core-plugins/src/grid/GridPlugin.tsx
@@ -11,7 +11,7 @@ const Grid = styled.div<TGridSize>`
   row-gap: ${({ rowGap }) => rowGap || 16}px;
 `
 
-export const GridPlugin = (props: TGridPluginConfig): JSX.Element => {
+export const GridPlugin = (props: TGridPluginConfig): React.ReactElement => {
   const { config, idReference, type } = props
 
   return (

--- a/packages/dm-core-plugins/src/header/HeaderPlugin.tsx
+++ b/packages/dm-core-plugins/src/header/HeaderPlugin.tsx
@@ -52,10 +52,10 @@ const defaultHeaderPluginConfig = {
 
 type TRecipeConfigAndPlugin = {
   config?: TGenericObject
-  component: (props: IUIPlugin) => JSX.Element
+  component: (props: IUIPlugin) => React.ReactElement
 }
 
-export default (props: IUIPlugin): JSX.Element => {
+export default (props: IUIPlugin): React.ReactElement => {
   const { idReference, config: passedConfig, type } = props
   const config: THeaderPluginConfig = {
     ...defaultHeaderPluginConfig,
@@ -97,7 +97,8 @@ export default (props: IUIPlugin): JSX.Element => {
     }
   }, [isBlueprintLoading])
 
-  const UIPlugin: (props: IUIPlugin) => JSX.Element = selectedRecipe.component
+  const UIPlugin: (props: IUIPlugin) => React.ReactElement =
+    selectedRecipe.component
   if (isApplicationLoading || !entity || isBlueprintLoading) {
     return <Loading />
   }

--- a/packages/dm-core-plugins/src/role_filter/RoleFilterPlugin.tsx
+++ b/packages/dm-core-plugins/src/role_filter/RoleFilterPlugin.tsx
@@ -14,7 +14,7 @@ type FilteredView = {
   roles: string[]
   viewId?: string
 }
-export const RoleFilterPlugin = (props: IUIPlugin): JSX.Element => {
+export const RoleFilterPlugin = (props: IUIPlugin): React.ReactElement => {
   const { idReference, config } = props
   const [allowedViewConfigs, setAllowedViewConfigs] = useState<FilteredView[]>(
     []

--- a/packages/dm-core-plugins/src/view_selector/Content.tsx
+++ b/packages/dm-core-plugins/src/view_selector/Content.tsx
@@ -21,7 +21,7 @@ export const Content = (props: {
   onOpen: TOnOpen
   formData: TGenericObject
   style?: Record<string, string | number>
-}): JSX.Element => {
+}): React.ReactElement => {
   const { selectedViewId, viewSelectorItems, setFormData, formData, onOpen } =
     props
   return (

--- a/packages/dm-core-plugins/src/view_selector/Sidebar.tsx
+++ b/packages/dm-core-plugins/src/view_selector/Sidebar.tsx
@@ -7,7 +7,7 @@ export const Sidebar = (props: {
   selectedViewId: string
   setSelectedViewId: (k: string) => void
   viewSelectorItems: TItemData[]
-}): JSX.Element => {
+}): React.ReactElement => {
   const { selectedViewId, setSelectedViewId, viewSelectorItems } = props
 
   return (

--- a/packages/dm-core-plugins/src/view_selector/Tabs.tsx
+++ b/packages/dm-core-plugins/src/view_selector/Tabs.tsx
@@ -9,7 +9,7 @@ export const Tabs = (props: {
   setSelectedViewId: (viewId: string) => void
   viewSelectorItems: TItemData[]
   removeView: (viewId: string) => void
-}): JSX.Element => {
+}): React.ReactElement => {
   const { selectedViewId, setSelectedViewId, viewSelectorItems } = props
   return (
     <EdsTabs

--- a/packages/dm-core-plugins/src/view_selector/ViewSelectorPlugin.tsx
+++ b/packages/dm-core-plugins/src/view_selector/ViewSelectorPlugin.tsx
@@ -17,7 +17,7 @@ import { TItemData, TViewSelectorConfig, TViewSelectorItem } from './types'
 
 export const ViewSelectorPlugin = (
   props: IUIPlugin & { config?: TViewSelectorConfig }
-): JSX.Element => {
+): React.ReactElement => {
   const { idReference, config, type } = props
   const internalConfig: TViewSelectorConfig = {
     childTabsOnRender: true,

--- a/packages/dm-core/src/components/AccessControl/ACLOwnerPanel.tsx
+++ b/packages/dm-core/src/components/AccessControl/ACLOwnerPanel.tsx
@@ -12,7 +12,7 @@ interface IACLOwnerPanelProps {
 export const ACLOwnerPanel = ({
   acl,
   handleChange,
-}: IACLOwnerPanelProps): JSX.Element => {
+}: IACLOwnerPanelProps): React.ReactElement => {
   return (
     <>
       <CenteredRow width={'230px'}>

--- a/packages/dm-core/src/components/AccessControl/ACLSelect.tsx
+++ b/packages/dm-core/src/components/AccessControl/ACLSelect.tsx
@@ -20,7 +20,7 @@ export const ACLSelect = ({
 }: {
   value: AccessLevel
   handleChange: (newValue: AccessLevel) => void
-}): JSX.Element => {
+}): React.ReactElement => {
   const accessLevelKeys: string[] = []
   for (const enumMember in AccessLevel) {
     accessLevelKeys.push(enumMember)

--- a/packages/dm-core/src/components/AccessControl/ACLUserRolesPanel.tsx
+++ b/packages/dm-core/src/components/AccessControl/ACLUserRolesPanel.tsx
@@ -44,7 +44,7 @@ export const ACLUserRolesPanel = ({
   entities,
   handleChange,
   aclKey,
-}: IURPanelProps): JSX.Element => {
+}: IURPanelProps): React.ReactElement => {
   const [newRole, setNewRole] = useState<string>('')
   const getPlaceholderText = () => {
     if (aclKey === 'users') {

--- a/packages/dm-core/src/components/AccessControl/AccessControlListComponent.tsx
+++ b/packages/dm-core/src/components/AccessControl/AccessControlListComponent.tsx
@@ -47,7 +47,7 @@ export const CenteredRow = styled.div<CenteredRowType>`
 export const AccessControlListComponent = (props: {
   documentId: string
   dataSourceId: string
-}): JSX.Element => {
+}): React.ReactElement => {
   const { documentId, dataSourceId } = props
 
   const [activeTab, setActiveTab] = useState<number>(0)

--- a/packages/dm-core/src/components/DynamicTable.tsx
+++ b/packages/dm-core/src/components/DynamicTable.tsx
@@ -16,7 +16,7 @@ export const DynamicTable = (props: {
   columns: Array<string>
   rows: Array<any>
   onRowClicked?: MouseEventHandler
-}): JSX.Element => {
+}): React.ReactElement => {
   const { columns, rows } = props
   const onRowClicked = props.onRowClicked
     ? props.onRowClicked

--- a/packages/dm-core/src/components/EntityView.tsx
+++ b/packages/dm-core/src/components/EntityView.tsx
@@ -18,7 +18,7 @@ type IEntityView = IUIPlugin & {
   dimensions?: string
 }
 
-export const EntityView = (props: IEntityView): JSX.Element => {
+export const EntityView = (props: IEntityView): React.ReactElement => {
   const { idReference, type, onSubmit, onOpen, recipeName, dimensions } = props
   if (!type)
     throw new Error(`<EntityView> must be called with a type. Got "${type}"`)

--- a/packages/dm-core/src/components/ViewCreator/ViewCreator.tsx
+++ b/packages/dm-core/src/components/ViewCreator/ViewCreator.tsx
@@ -37,7 +37,7 @@ type TViewCreator = Omit<IUIPlugin, 'type'> & {
  * @returns React component
  * @param props
  */
-export const ViewCreator = (props: TViewCreator): JSX.Element => {
+export const ViewCreator = (props: TViewCreator): React.ReactElement => {
   const { idReference, viewConfig, onOpen } = props
   const dmssAPI = useDMSS()
   const [isLoading, setIsLoading] = useState<boolean>(true)

--- a/packages/dm-core/src/context/UiPluginContext.tsx
+++ b/packages/dm-core/src/context/UiPluginContext.tsx
@@ -4,7 +4,7 @@ import { ErrorGroup } from '../utils/ErrorBoundary'
 
 type TUiPluginContext = {
   plugins: TUiPluginMap
-  getUiPlugin: (pluginName: string) => (props: IUIPlugin) => JSX.Element
+  getUiPlugin: (pluginName: string) => (props: IUIPlugin) => React.ReactElement
 }
 
 const UiPluginContext = createContext<TUiPluginContext | undefined>(undefined)
@@ -24,7 +24,9 @@ export const UiPluginProvider = ({
   pluginsToLoad: TUiPluginMap
   children: any
 }) => {
-  function getUiPlugin(pluginName: string): (props: IUIPlugin) => JSX.Element {
+  function getUiPlugin(
+    pluginName: string
+  ): (props: IUIPlugin) => React.ReactElement {
     if (Object.keys(plugins).includes(pluginName))
       return plugins[pluginName].component
     return () => <ErrorGroup>Did not find the plugin: {pluginName}</ErrorGroup>

--- a/packages/dm-core/src/hooks/useRecipe.tsx
+++ b/packages/dm-core/src/hooks/useRecipe.tsx
@@ -58,7 +58,7 @@ interface IUseRecipe {
   recipe: TUiRecipe | undefined
   isLoading: boolean
   error: ErrorResponse | null
-  getUiPlugin: (pluginName: string) => (props: IUIPlugin) => JSX.Element
+  getUiPlugin: (pluginName: string) => (props: IUIPlugin) => React.ReactElement
 }
 
 /**

--- a/packages/dm-core/src/types.ts
+++ b/packages/dm-core/src/types.ts
@@ -155,7 +155,7 @@ export type TUiRecipe = {
 }
 
 export type TPlugin = {
-  component: (props: IUIPlugin) => JSX.Element
+  component: (props: IUIPlugin) => React.ReactElement
 }
 
 export type TUserIdMapping = { userId: string; username: string }


### PR DESCRIPTION
## What does this pull request change?
Replaces deprecated type `JSX.Element` with `React.ReactElement`

## Why is this pull request needed?


## Issues related to this change

