### PR TITLE
fix: skip from config flag

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -39,14 +39,3 @@ jobs:
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
-
-  deploy-dev:
-    permissions:
-      packages: write
-      contents: read
-      id-token: write
-    needs: release-please
-    uses: ./.github/workflows/on-release.yaml
-    with:
-      release-tag: ${{ needs.release-please.outputs.tag_name }}
-    if: ${{ needs.release-please.outputs.releases_created }}

--- a/.github/workflows/deploy-to-radix.yaml
+++ b/.github/workflows/deploy-to-radix.yaml
@@ -54,9 +54,9 @@ jobs:
         with:
           args: >
             create job
-            build-deploy                        
+            build-deploy
+            --application dm-demos
             --context production
-            --from-config
             --branch main
             --follow
 

--- a/.github/workflows/on-main-push.yaml
+++ b/.github/workflows/on-main-push.yaml
@@ -52,3 +52,13 @@ jobs:
         run: yarn workspace @development-framework/dm-core-plugins publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  new-release:
+    needs: publish-packages
+    permissions:
+      packages: write
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/on-release.yaml
+    with:
+      release-tag: ${{ needs.release-please.outputs.tag_name }}

--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -21,13 +21,13 @@ permissions:
   id-token: write
 
 jobs:
-  publish-latest:
+  publish-image:
     uses: ./.github/workflows/publish-image.yaml
     with:
       image-tags: latest,${{ inputs.release-tag }}
 
-  deploy-test:
-    needs: publish-latest
+  deploy:
+    needs: publish-image
     uses: ./.github/workflows/deploy-to-radix.yaml
     with:
       radix-environment: "dev"

--- a/example/src/init.sh
+++ b/example/src/init.sh
@@ -4,7 +4,7 @@ set -eu
 
 if [ "$1" = 'start' ]; then
   echo "Running in Radix environment: $RADIX_ENVIRONMENT"
-  yarn build --mode ${RADIX_ENVIRONMENT:-'local'}
+  ALIAS=off yarn build --mode ${RADIX_ENVIRONMENT:-'local'}
   npm run serve
 else
   exec "$@"


### PR DESCRIPTION
## What does this pull request change?

* Remove `--from-config`since the `radixconfig.yaml` is not inside this repository and therefore it does not make sense to have the flag
* Dont use alias when building in Radix (since should use dm-* NPM packages instead)

## Why is this pull request needed?

## Issues related to this change

