### PR TITLE
fix: make it possible to append to lists in explorer plugin

### DIFF
--- a/example/app/data/DemoDataSource/apps/MySignalApp/Jobs/exampleGenericJobList.json
+++ b/example/app/data/DemoDataSource/apps/MySignalApp/Jobs/exampleGenericJobList.json
@@ -1,0 +1,5 @@
+{
+  "name": "fetch_omniaTS_signal_jobs",
+  "type": "dmss://DemoDataSource/apps/MySignalApp/models/JobList",
+  "jobs": []
+}

--- a/example/app/data/DemoDataSource/apps/MySignalApp/models/JobList.blueprint.json
+++ b/example/app/data/DemoDataSource/apps/MySignalApp/models/JobList.blueprint.json
@@ -1,0 +1,24 @@
+{
+  "name": "JobList",
+  "type": "CORE:Blueprint",
+  "attributes": [
+    {
+      "name": "name",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "type",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "jobs",
+      "type": "CORE:BlueprintAttribute",
+      "label": "Jobs",
+      "attributeType": "JOBCORE:Job",
+      "optional": false,
+      "dimensions": "*"
+    }
+  ]
+}

--- a/packages/dm-core-plugins/src/explorer/components/dialogs/AppendEntityDialog.tsx
+++ b/packages/dm-core-plugins/src/explorer/components/dialogs/AppendEntityDialog.tsx
@@ -19,7 +19,7 @@ const AppendEntityDialog = (props: TProps) => {
   const handleAppend = () => {
     setLoading(true)
     node
-      .addEntityToPackage(node.type, `${node.entity.length}`)
+      .appendEntity(node.type, `${node.entity.length}`)
       .then(() => {
         setNodeOpen(true)
         toast.success('The new entity has been appended to the list')

--- a/packages/dm-core-plugins/src/explorer/components/dialogs/NewBlueprintDialog.tsx
+++ b/packages/dm-core-plugins/src/explorer/components/dialogs/NewBlueprintDialog.tsx
@@ -29,7 +29,7 @@ const NewBlueprintDialog = (props: TProps) => {
   const handleCreate = () => {
     setLoading(true)
     node
-      .addEntityToPackage(EBlueprint.BLUEPRINT, blueprintName)
+      .appendEntity(EBlueprint.BLUEPRINT, blueprintName)
       .then(() => {
         setNodeOpen(true)
         toast.success('Blueprint is created')

--- a/packages/dm-core-plugins/src/explorer/components/dialogs/NewEntityDialog.tsx
+++ b/packages/dm-core-plugins/src/explorer/components/dialogs/NewEntityDialog.tsx
@@ -28,7 +28,7 @@ const NewEntityDialog = (props: TProps) => {
   const handleCreate = () => {
     setLoading(true)
     node
-      .addEntityToPackage(`dmss://${blueprint}`, 'Created_entity')
+      .appendEntity(`dmss://${blueprint}`, 'Created_entity')
       .then(() => {
         setNodeOpen(true)
         toast.success(`Entity is created`)

--- a/packages/dm-core/src/components/ViewCreator/ViewCreator.tsx
+++ b/packages/dm-core/src/components/ViewCreator/ViewCreator.tsx
@@ -69,6 +69,11 @@ export const ViewCreator = (props: TViewCreator): React.ReactElement => {
   if (attribute === undefined)
     throw new Error('Unable to find type and dimensions for view')
 
+  if (viewConfig === undefined)
+    throw new Error(
+      'Cannot create a View without a "viewConfig". Sure the attribute is properly named?'
+    )
+
   if (isInlineRecipeViewConfig(viewConfig)) {
     return (
       <InlineRecipeView

--- a/packages/dm-core/src/domain/Tree.tsx
+++ b/packages/dm-core/src/domain/Tree.tsx
@@ -236,21 +236,19 @@ export class TreeNode {
     this.tree.updateCallback(this.tree)
   }
 
-  // Creates a new entity on DMSS of the given type and saves it to this package,
+  // Creates a new entity in DMSS of the given type and saves it to this target,
   // returns the entity's UUID
-  async addEntityToPackage(type: string, name: string): Promise<string> {
-    if (this.type !== EBlueprint.PACKAGE) {
-      throw 'Entities can only be added to package'
-    }
-
+  async appendEntity(type: string, name: string): Promise<string> {
     const response = await this.tree.dmssApi.instantiateEntity({
       // @ts-ignore
       entity: { name: name, type: type },
     })
+    const targetAddress =
+      this.type === EBlueprint.PACKAGE ? `${this.nodeId}.content` : this.nodeId
     const newEntity = { ...response.data, name: name }
     const createResponse: AxiosResponse<any> =
       await this.tree.dmssApi.documentAdd({
-        address: `${this.nodeId}.content`,
+        address: targetAddress,
         document: JSON.stringify(newEntity),
         updateUncontained: true,
       })


### PR DESCRIPTION
## What does this pull request change?
A few things:
- Update a function on the Tree in dm-core for appending documents. Can now correctly append to lists as well as packages
- Sets up blueprints to test and make a PoC with creating and running generic jobs
-  ViewCreator now returns a more helpful error on missig "viewConfig"

## Why is this pull request needed?
- Should be possible to create and append new items to a list in the explorer. 

## Issues related to this change
none

