### PR TITLE
refactor: simply recipe by skipping view creator

### DIFF
--- a/example/app/data/DemoDataSource/recipes/plugins/form/read_only_primitives/readOnlyPrimitives.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/read_only_primitives/readOnlyPrimitives.recipe.json
@@ -2,42 +2,22 @@
   "type": "CORE:RecipeLink",
   "_blueprintPath_": "/plugins/form/read_only_primitives/blueprints/ReadOnlyPrimitives",
   "initialUiRecipe": {
-    "name": "ViewSelector",
+    "name": "ReadOnly",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
+    "plugin": "@development-framework/dm-core-plugins/form",
+    "category": "edit",
     "config": {
-      "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
-      "childTabsOnRender": true,
-      "items": [
-        {
-          "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
-          "viewConfig": {
-            "type": "CORE:ReferenceViewConfig",
-            "recipe": "ReadOnly"
-          }
-        }
-      ]
+      "type": "PLUGINS:dm-core-plugins/form/FormInput",
+      "fields": [
+        "stringRequired",
+        "stringOptional",
+        "numberRequired",
+        "numberOptional",
+        "integer",
+        "checkboxOptional",
+        "checkboxRequired"
+      ],
+      "readOnly": true
     }
-  },
-  "uiRecipes": [
-    {
-      "name": "ReadOnly",
-      "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/form",
-      "category": "edit",
-      "config": {
-        "type": "PLUGINS:dm-core-plugins/form/FormInput",
-        "fields": [
-          "stringRequired",
-          "stringOptional",
-          "numberRequired",
-          "numberOptional",
-          "integer",
-          "checkboxOptional",
-          "checkboxRequired"
-        ],
-        "readOnly": true
-      }
-    }
-  ]
+  }
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/form/simple/simple.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/simple/simple.recipe.json
@@ -2,27 +2,9 @@
   "type": "CORE:RecipeLink",
   "_blueprintPath_": "/plugins/form/simple/blueprints/Simple",
   "initialUiRecipe": {
-    "name": "ViewSelector",
+    "name": "Edit",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
-    "config": {
-      "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
-      "childTabsOnRender": true,
-      "items": [
-        {
-          "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
-          "viewConfig": {
-            "type": "CORE:InlineRecipeViewConfig",
-            "recipe": {
-              "name": "Edit",
-              "type": "CORE:UiRecipe",
-              "description": "Default edit",
-              "plugin": "@development-framework/dm-core-plugins/form"
-            },
-            "scope": "self"
-          }
-        }
-      ]
-    }
+    "description": "Default edit",
+    "plugin": "@development-framework/dm-core-plugins/form"
   }
 }


### PR DESCRIPTION
## What does this pull request change?

* The view creator was not used in the `read only primitives` and `simple` form examples, soI just removed the use of the view creator plugin in these examples.

## Why is this pull request needed?

## Issues related to this change

