### PR TITLE
Fix: Select correct recipes when switching views

### DIFF
--- a/packages/dm-core/src/hooks/useBlueprint.tsx
+++ b/packages/dm-core/src/hooks/useBlueprint.tsx
@@ -41,15 +41,8 @@ export const useBlueprint = (typeRef: string): IUseBlueprint => {
   const [initialUiRecipe, setInitialUiRecipe] = useState<TUiRecipe>()
   const [isLoading, setLoading] = useState<boolean>(true)
   const [error, setError] = useState<ErrorResponse | null>(null)
-
   const { name } = useContext(ApplicationContext)
   const dmssAPI = useDMSS()
-
-  console.log('useBlueprint (blueprint): ', blueprint)
-  console.log('useBlueprint (initialUiRecipe): ', initialUiRecipe)
-  console.log('useBlueprint (uiRecipes): ', uiRecipes)
-  console.log('useBlueprint (isLoading): ', isLoading)
-  console.log('useBlueprint (error): ', error)
 
   useEffect(() => {
     dmssAPI
@@ -57,14 +50,22 @@ export const useBlueprint = (typeRef: string): IUseBlueprint => {
       .then((response: any) => {
         setBlueprint(response.data.blueprint)
         setInitialUiRecipe(response.data.initialUiRecipe)
-        setUiRecipes(response.data.uiRecipes ?? [])
+        setUiRecipes(response.data.uiRecipes)
         setError(null)
       })
-      .catch((error: AxiosError<ErrorResponse>) =>
+      .catch((error: AxiosError<ErrorResponse>) => {
         setError(error.response?.data || null)
-      )
-      .finally(() => setLoading(false))
+      })
+      .finally(() => {
+        setLoading(false)
+      })
   }, [typeRef])
 
-  return { blueprint, initialUiRecipe, uiRecipes, isLoading, error }
+  return {
+    blueprint,
+    initialUiRecipe,
+    uiRecipes,
+    isLoading,
+    error,
+  }
 }

--- a/packages/dm-core/src/hooks/useBlueprint.tsx
+++ b/packages/dm-core/src/hooks/useBlueprint.tsx
@@ -4,6 +4,7 @@ import { TBlueprint, TUiRecipe } from 'src/types'
 import { ApplicationContext } from '../context/ApplicationContext'
 import { useDMSS } from '../context/DMSSContext'
 import { ErrorResponse } from '../services'
+
 interface IUseBlueprint {
   blueprint: TBlueprint | undefined
   initialUiRecipe: TUiRecipe | undefined
@@ -11,6 +12,7 @@ interface IUseBlueprint {
   isLoading: boolean
   error: ErrorResponse | null
 }
+
 /**
  * Hook to fetch a Blueprint from the DMSS API
  *
@@ -39,8 +41,15 @@ export const useBlueprint = (typeRef: string): IUseBlueprint => {
   const [initialUiRecipe, setInitialUiRecipe] = useState<TUiRecipe>()
   const [isLoading, setLoading] = useState<boolean>(true)
   const [error, setError] = useState<ErrorResponse | null>(null)
+
   const { name } = useContext(ApplicationContext)
   const dmssAPI = useDMSS()
+
+  console.log('useBlueprint (blueprint): ', blueprint)
+  console.log('useBlueprint (initialUiRecipe): ', initialUiRecipe)
+  console.log('useBlueprint (uiRecipes): ', uiRecipes)
+  console.log('useBlueprint (isLoading): ', isLoading)
+  console.log('useBlueprint (error): ', error)
 
   useEffect(() => {
     dmssAPI

--- a/packages/dm-core/src/hooks/useRecipe.tsx
+++ b/packages/dm-core/src/hooks/useRecipe.tsx
@@ -7,7 +7,7 @@ import {
   useDMSS,
   useUiPlugins,
 } from '../index'
-import { AxiosError } from 'axios/index'
+import { AxiosError } from 'axios'
 
 const findRecipe = (
   recipes: TUiRecipe[],

--- a/packages/dm-core/src/hooks/useRecipe.tsx
+++ b/packages/dm-core/src/hooks/useRecipe.tsx
@@ -92,21 +92,11 @@ export const useRecipe = (
   recipeName?: string,
   dimensions: string = ''
 ): IUseRecipe => {
-  // const {
-  // 	initialUiRecipe,
-  // 	uiRecipes,
-  // 	isLoading: isBlueprintLoading,
-  // 	error,
-  // } = useBlueprint(typeRef)
   const { getUiPlugin } = useUiPlugins()
   const [foundRecipe, setFoundRecipe] = useState<TUiRecipe>()
   const [findRecipeError, setFindRecipeError] = useState<ErrorResponse | null>(
     null
   )
-
-  // const [blueprint, setBlueprint] = useState<TBlueprint>()
-  // const [uiRecipes, setUiRecipes] = useState<TUiRecipe[]>([])
-  // const [initialUiRecipe, setInitialUiRecipe] = useState<TUiRecipe>()
   const [isLoading, setLoading] = useState<boolean>(true)
   const [error, setError] = useState<ErrorResponse | null>(null)
 

--- a/packages/dm-core/src/hooks/useRecipe.tsx
+++ b/packages/dm-core/src/hooks/useRecipe.tsx
@@ -18,10 +18,6 @@ const findRecipe = (
   if (dimensions) {
     initialUiRecipe = undefined
   }
-  console.log('findRecipe (recipes)', recipes)
-  console.log('findRecipe (initialUiRecipe)', initialUiRecipe)
-  console.log('findRecipe (recipe name)', recipeName)
-  console.log('findRecipe (dimensions)', dimensions)
   // If recipe is defined, find and return the ui recipe from available recipes.
   if (recipeName) {
     const recipesToSearch = initialUiRecipe


### PR DESCRIPTION
## What does this pull request change?
There currently is a bug where the previous recipe is used when selecting a new plugin/app. I'm fairly certain that happens because of some state dependencies that don't work out correctly.

The `useRecipe()` hook is/was dependent on state variables from the `useBlueprint()` hook, but state variables are not updated before a re-render occurs. That means the `useRecipe` hooks is/was always getting the previous values, and not the current ones.


## Why is this pull request needed?

## Issues related to this change

