### PR TITLE
fix(listPLugin): sane default config

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,9 +20,6 @@ jobs:
         run: pre-commit run --all-files
 
   tests:
-    strategy:
-      matrix:
-        package: [ dm-core, dm-core-plugins ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main

--- a/e2e/tests/plugin-form-Nested.spec.ts
+++ b/e2e/tests/plugin-form-Nested.spec.ts
@@ -137,20 +137,16 @@ test('New car', async () => {
   await expect.soft(carsDiv.getByText('1 - 3 of 3')).toBeVisible()
   await carsDiv.getByRole('button', { name: 'Save' }).click()
   await carsDiv.getByRole('button', { name: 'Open item' }).last().click()
-  const lastTabPanel = page.getByRole('tabpanel').last()
-  await expect(lastTabPanel).toBeVisible()
-  await lastTabPanel.getByLabel('Name').fill('McLaren')
-  await lastTabPanel.getByLabel('Plate Number').fill('3000')
-  await lastTabPanel.getByRole('button', { name: 'Submit' }).click()
-  await expect(page.getByRole('alert')).toHaveText(['Document updated'])
-  await page.getByRole('button', { name: 'close', exact: true }).click()
+  await page.getByLabel('Name').nth(1).fill('McLaren')
+  await page.getByLabel('Plate Number').fill('3000')
+  await page.getByRole('button', { name: 'Submit' }).first().click()
+  await page.getByText('Document updated').click()
   await page.reload()
   await navigate()
   await expect(carsDiv.getByText('McLaren')).toBeVisible()
   await carsDiv.getByRole('button', { name: 'Open item' }).last().click()
-  await expect(page.getByRole('tab', { name: 'McLaren' })).toBeVisible()
-  await expect(lastTabPanel.getByLabel('Name')).toHaveValue('McLaren')
-  await expect(lastTabPanel.getByLabel('Plate Number')).toHaveValue('3000')
+  await expect(page.getByLabel('Name').nth(1)).toHaveValue('McLaren')
+  await expect(page.getByLabel('Plate Number')).toHaveValue('3000')
 })
 
 test('New customer', async () => {
@@ -173,9 +169,15 @@ test('New customer', async () => {
   await customersDiv.getByRole('button', { name: 'Open' }).click()
   await expect(page.getByText('Lewis')).toBeVisible()
   await page.getByRole('button', { name: 'Open item' }).last().click()
-  await expect(page.getByRole('tab', { name: 'Lewis' })).toBeVisible()
-  await expect(lastTabPanel.getByLabel('Name')).toHaveValue('Lewis')
-  await expect(lastTabPanel.getByLabel('Phone number (optional)')).toHaveValue(
-    '12345678'
-  )
+  await expect(
+    page.getByTestId('name').getByTestId('form-textfield')
+  ).toBeVisible()
+  // await expect(page.getByTestId('name').getByTestId('form-textfield')).toBeVisible()
+  await expect(
+    page.getByTestId('name').getByTestId('form-textfield')
+  ).toHaveValue('Lewis')
+  // await expect(lastTabPanel.getByLabel('Name')).toHaveValue('Lewis')
+  await expect(
+    lastTabPanel.getByTestId('phoneNumber').getByTestId('form-textfield')
+  ).toHaveValue('12345678')
 })

--- a/e2e/tests/plugin-view_selector-car_garage.spec.ts
+++ b/e2e/tests/plugin-view_selector-car_garage.spec.ts
@@ -42,9 +42,7 @@ test('View selector - car garage', async ({ page }) => {
     page.getByRole('tab', { name: 'Owner details' })
   ).toHaveAttribute('aria-selected', 'true')
   await expect(page.getByRole('tab', { name: 'Owner history' })).toBeVisible()
-  await expect(
-    page.locator('form').filter({ hasText: 'Name of Owner' }).locator('#name')
-  ).toHaveValue('Aiden')
+  await expect(page.locator('#name').nth(2)).toHaveValue('Aiden')
   await page.getByText('Owner history').click()
   await expect(
     page.getByRole('tab', { name: 'group Owner history' })

--- a/example/app/data/DemoDataSource/recipes/plugins/grid/example/order.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/grid/example/order.recipe.json
@@ -33,7 +33,6 @@
           "name",
           "description"
         ],
-        "openInline": false,
         "functionality": {
           "type": "PLUGINS:dm-core-plugins/list/FunctionalityConfig",
           "delete": true

--- a/example/app/data/DemoDataSource/recipes/plugins/grid/example/orderItem.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/grid/example/orderItem.recipe.json
@@ -49,7 +49,7 @@
           "quantity",
           "type"
         ],
-        "openInline": false,
+        "openAsTab": true,
         "functionality": {
           "type": "PLUGINS:dm-core-plugins/list/FunctionalityConfig",
           "delete": true

--- a/example/app/data/DemoDataSource/recipes/plugins/list/order_example/order.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/list/order_example/order.recipe.json
@@ -33,7 +33,7 @@
           "name",
           "description"
         ],
-        "openInline": false,
+        "openAsTab": true,
         "functionality": {
           "type": "PLUGINS:dm-core-plugins/list/FunctionalityConfig",
           "delete": true

--- a/example/app/data/DemoDataSource/recipes/plugins/list/order_example/orderItem.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/list/order_example/orderItem.recipe.json
@@ -48,7 +48,7 @@
           "quantity",
           "type"
         ],
-        "openInline": false,
+        "openAsTab": false,
         "functionality": {
           "type": "PLUGINS:dm-core-plugins/list/FunctionalityConfig",
           "delete": true,

--- a/example/app/data/DemoDataSource/recipes/plugins/list/task_list/task.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/list/task_list/task.recipe.json
@@ -54,7 +54,7 @@
       "config": {
         "type": "PLUGINS:dm-core-plugins/list/ListPluginConfig",
         "viewConfigs": [],
-        "openInline": true,
+        "openAsTab": false,
         "headers": [
           "name",
           "assigned"
@@ -63,8 +63,6 @@
           "type": "PLUGINS:dm-core-plugins/list/FunctionalityConfig",
           "delete": true,
           "add": true,
-          "openAsTab": true,
-          "openAsExpandable": true,
           "sort": true
         }
       }

--- a/example/app/data/DemoDataSource/recipes/plugins/list/task_list/taskList.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/list/task_list/taskList.recipe.json
@@ -32,12 +32,7 @@
         "headers": [
           "name",
           "assigned"
-        ],
-        "openInline": false,
-        "functionality": {
-          "type": "PLUGINS:dm-core-plugins/list/FunctionalityConfig",
-          "delete": true
-        }
+        ]
       }
     }
   ]

--- a/packages/dm-core-plugins/blueprints/list/FunctionalityConfig.json
+++ b/packages/dm-core-plugins/blueprints/list/FunctionalityConfig.json
@@ -8,46 +8,32 @@
       "attributeType": "string"
     },
     {
-      "name": "openAsTab",
+      "name": "delete",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "boolean",
       "optional": true,
       "default": true
     },
     {
-      "name": "openAsExpandable",
-      "type": "CORE:BlueprintAttribute",
-      "attributeType": "boolean",
-      "optional": true,
-      "default": false
-    },
-    {
-      "name": "delete",
-      "type": "CORE:BlueprintAttribute",
-      "attributeType": "boolean",
-      "optional": true,
-      "default": false
-    },
-    {
       "name": "add",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "boolean",
       "optional": true,
-      "default": false
+      "default": true
     },
     {
       "name": "edit",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "boolean",
       "optional": true,
-      "default": false
+      "default": true
     },
     {
       "name": "sort",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "boolean",
       "optional": true,
-      "default": false
+      "default": true
     }
   ]
 }

--- a/packages/dm-core-plugins/blueprints/list/ListPluginConfig.json
+++ b/packages/dm-core-plugins/blueprints/list/ListPluginConfig.json
@@ -16,12 +16,20 @@
       "default": false
     },
     {
+      "name": "openAsTab",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "boolean",
+      "optional": true,
+      "default": false
+    },
+    {
       "name": "headers",
       "type": "CORE:BlueprintAttribute",
       "description": "Name of primitive child attributes to display in item",
       "attributeType": "string",
       "default": [
-        "name"
+        "name",
+        "type"
       ],
       "dimensions": "*"
     },
@@ -35,15 +43,9 @@
     {
       "name": "defaultView",
       "type": "CORE:BlueprintAttribute",
+      "description": "Which ViewConfig to render when expanding the list item. Defaults to the types default UiRecipe",
       "attributeType": "CORE:ViewConfig",
       "optional": true
-    },
-    {
-      "name": "openInline",
-      "type": "CORE:BlueprintAttribute",
-      "attributeType": "boolean",
-      "optional": false,
-      "default": false
     },
     {
       "name": "viewConfigs",

--- a/packages/dm-core-plugins/src/form/components/Form.tsx
+++ b/packages/dm-core-plugins/src/form/components/Form.tsx
@@ -8,7 +8,7 @@ import { RegistryProvider } from '../context/RegistryContext'
 import { TFormProps } from '../types'
 import { AttributeList } from './AttributeList'
 
-const StyledForm = styled.form`
+const Wrapper = styled.div`
   max-width: 650px;
   width: 100%;
   padding: 1rem 0;
@@ -46,7 +46,7 @@ export const Form = (props: TFormProps) => {
   return (
     <FormProvider {...methods}>
       <RegistryProvider onOpen={onOpen} idReference={idReference}>
-        <StyledForm onSubmit={handleSubmit}>
+        <Wrapper>
           <AttributeList
             namePath={namePath}
             config={config}
@@ -57,11 +57,12 @@ export const Form = (props: TFormProps) => {
               type="submit"
               data-testid="form-submit"
               style={{ alignSelf: 'flex-start' }}
+              onClick={handleSubmit}
             >
               Submit
             </Button>
           )}
-        </StyledForm>
+        </Wrapper>
       </RegistryProvider>
     </FormProvider>
   )

--- a/packages/dm-core-plugins/src/form/fields/BooleanField.test.tsx
+++ b/packages/dm-core-plugins/src/form/fields/BooleanField.test.tsx
@@ -144,7 +144,7 @@ describe('BooleanField', () => {
         expect(inputNode).toBeDefined()
         const value = inputNode !== null ? inputNode.getAttribute('value') : ''
         expect(value).toBe('true')
-        fireEvent.submit(screen.getByTestId('form-submit'))
+        fireEvent.click(screen.getByTestId('form-submit'))
         expect(onSubmit).toHaveBeenCalled()
         expect(onSubmit).toHaveBeenCalledWith({
           foo: true,
@@ -178,7 +178,7 @@ describe('BooleanField', () => {
         const value = inputNode !== null ? inputNode.getAttribute('value') : ''
         expect(value).toBe('true')
         userEvent.click(screen.getByTestId('form-checkbox'))
-        fireEvent.submit(screen.getByTestId('form-submit'))
+        fireEvent.click(screen.getByTestId('form-submit'))
       })
     })
 

--- a/packages/dm-core-plugins/src/form/fields/NumberField.test.tsx
+++ b/packages/dm-core-plugins/src/form/fields/NumberField.test.tsx
@@ -45,7 +45,7 @@ const setup = async (props: {
     const setValue = (value: string) =>
       fireEvent.change(inputElement, { target: { value: value } })
     const submit = () =>
-      fireEvent.submit(screen.getByRole<HTMLButtonElement>('button'))
+      fireEvent.click(screen.getByRole<HTMLButtonElement>('button'))
     return { ...utils, inputElement, setValue, submit, onSubmit }
   })
 }

--- a/packages/dm-core-plugins/src/form/fields/ObjectField.test.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ObjectField.test.tsx
@@ -101,7 +101,7 @@ test('should handle submit', async () => {
     onSubmit: onSubmit,
   })
   await waitFor(() => {
-    fireEvent.submit(utils.submit)
+    fireEvent.click(screen.getByRole<HTMLButtonElement>('button'))
     expect(onSubmit).toHaveBeenCalled()
     expect(onSubmit).toHaveBeenCalledWith({ foo: 'beep', bar: false })
   })

--- a/packages/dm-core-plugins/src/form/fields/StringField.test.tsx
+++ b/packages/dm-core-plugins/src/form/fields/StringField.test.tsx
@@ -76,7 +76,7 @@ test('should assign a default value', async () => {
   })
   await waitFor(() => {
     expect(utils.textbox.value).toBe('boo')
-    fireEvent.submit(utils.submit)
+    fireEvent.click(utils.submit)
     expect(onSubmit).toHaveBeenCalled()
     expect(onSubmit).toHaveBeenCalledWith({
       foo: 'boo',
@@ -131,7 +131,7 @@ test('should default submit value to empty object', async () => {
     onSubmit: onSubmit,
   })
 
-  fireEvent.submit(utils.submit)
+  fireEvent.click(utils.submit)
   waitFor(() => {
     expect(onSubmit).toHaveBeenCalled()
     expect(onSubmit).toHaveBeenCalledWith({})
@@ -164,7 +164,7 @@ test('should handle optional', async () => {
     />,
     { wrapper }
   )
-  fireEvent.submit(screen.getByRole('button', { name: 'Submit' }))
+  fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
   // The useForm "methods.handleSubmit" seems to be async, and needs to be awaited
   await waitFor(() => expect(onSubmit).toHaveBeenCalled())
   expect(onSubmit).toHaveBeenCalledWith({})
@@ -190,7 +190,7 @@ test.skip('should not call onSubmit if non-optional field are missing value', as
   render(<Form idReference="ds/$1" type="SingleField" onSubmit={onSubmit} />, {
     wrapper,
   })
-  fireEvent.submit(screen.getByRole('button'))
+  fireEvent.click(screen.getByRole('button'))
   await waitFor(() => {
     expect(onSubmit).not.toHaveBeenCalled()
     expect(onSubmit).toHaveBeenCalledTimes(0)

--- a/packages/dm-core-plugins/src/list/README.md
+++ b/packages/dm-core-plugins/src/list/README.md
@@ -19,13 +19,12 @@ Explanation of the attributes in the `ListPluginConfig`
 NB! as of August 2023 the functionality of the list plugin is rapidly changing and the docs here are outdated.
 TODO update this documentation.
 
-* expanded: is used to specify if items in the list should be expanded initially.
-* headers: a list of which attributes to display has headers in the list view.
+* expanded(boolean): items in the list is expanded by default
+* headers(list(string)): a list of which attributes to display as headers in the list view
+* openAsTab(boolean): will open the item in a new tab when clicking the expand button
 * functionality: is used for specifying which functionality that should be available in the UI plugin. The possible
   options are
-    * OpenAsTab (will open the item in a new tab when clicking the expand button)
-    * openAsExandable (will open the item in a accordian when clicking the expand button)
     * delete
     * add
-    * edit
+    * edit (not implemented)
     * sort


### PR DESCRIPTION
## What does this pull request change?
- remove redundant config values
- set most functionality to be enabled by default
- make use of "sort" and "delete" config values
- error toast when attempting to open in tab when no "onOpen()" was passed to the plugin

## Why is this pull request needed?

Plugins should work and have sane defaults without having to create UiRecipes

## Issues related to this change
closes #616 

