### PR TITLE
refactor: adjust default depth level to 0

### DIFF
--- a/packages/dm-core-plugins/src/form/FormPlugin.tsx
+++ b/packages/dm-core-plugins/src/form/FormPlugin.tsx
@@ -13,7 +13,7 @@ export const FormPlugin = (props: IUIPlugin) => {
   const config: TConfig = { ...defaultConfig, ...props.config }
   const { document, isLoading, updateDocument, error } = useDocument<any>(
     props.idReference,
-    1
+    0
   )
   if (isLoading) return <Loading />
 

--- a/packages/dm-core/src/hooks/useDocument.test.tsx
+++ b/packages/dm-core/src/hooks/useDocument.test.tsx
@@ -30,7 +30,7 @@ describe('useDocumentHook', () => {
         expect(mock).toHaveBeenCalledTimes(1)
         expect(mock).toHaveBeenCalledWith({
           address: 'testDS/1',
-          depth: 1,
+          depth: 0,
         })
       })
     })

--- a/packages/dm-core/src/hooks/useDocument.tsx
+++ b/packages/dm-core/src/hooks/useDocument.tsx
@@ -54,7 +54,7 @@ export function useDocument<T>(
 
   useEffect(() => {
     setLoading(true)
-    const documentDepth: number = depth || 1
+    const documentDepth: number = depth || 0
     if (documentDepth < 0 || documentDepth > 999)
       throw new Error('Depth must be a positive number < 999')
     dmssAPI


### PR DESCRIPTION
## What does this pull request change?

* Set default level to 0 for form package and `useDocument` hook

## Why is this pull request needed?

## Issues related to this change

