### PR TITLE
fix: make grid columns span correctly

### DIFF
--- a/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/signals_simple/case.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/signals_simple/case.recipe.json
@@ -24,8 +24,8 @@
             "type": "PLUGINS:dm-core-plugins/grid/GridArea",
             "rowStart": 1,
             "columnStart": 1,
-            "rowEnd": 3,
-            "columnEnd": 2
+            "rowEnd": 2,
+            "columnEnd": 1
           }
         },
         {
@@ -39,8 +39,8 @@
             "type": "PLUGINS:dm-core-plugins/grid/GridArea",
             "rowStart": 1,
             "columnStart": 2,
-            "rowEnd": 2,
-            "columnEnd": 3
+            "rowEnd": 1,
+            "columnEnd": 2
           }
         },
         {
@@ -53,8 +53,8 @@
             "type": "PLUGINS:dm-core-plugins/grid/GridArea",
             "rowStart": 2,
             "columnStart": 2,
-            "rowEnd": 3,
-            "columnEnd": 3
+            "rowEnd": 2,
+            "columnEnd": 2
           }
         }
       ]

--- a/example/app/data/DemoDataSource/recipes/plugins/grid/example/dashboard.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/grid/example/dashboard.recipe.json
@@ -24,7 +24,7 @@
             "type": "PLUGINS:dm-core-plugins/grid/GridArea",
             "rowStart": 1,
             "columnStart": 1,
-            "rowEnd": 3,
+            "rowEnd": 1,
             "columnEnd": 6
           }
         },
@@ -51,9 +51,9 @@
           },
           "gridArea": {
             "type": "PLUGINS:dm-core-plugins/grid/GridArea",
-            "rowStart": 1,
+            "rowStart": 2,
             "columnStart": 4,
-            "rowEnd": 3,
+            "rowEnd": 2,
             "columnEnd": 6
           }
         },
@@ -66,10 +66,10 @@
           },
           "gridArea": {
             "type": "PLUGINS:dm-core-plugins/grid/GridArea",
-            "rowStart": 5,
-            "columnStart": 3,
-            "rowEnd": 6,
-            "columnEnd": 7
+            "rowStart": 4,
+            "columnStart": 1,
+            "rowEnd": 5,
+            "columnEnd": 3
           }
         },
         {
@@ -81,10 +81,10 @@
           },
           "gridArea": {
             "type": "PLUGINS:dm-core-plugins/grid/GridArea",
-            "rowStart": 3,
-            "columnStart": 3,
-            "rowEnd": 6,
-            "columnEnd": 5
+            "rowStart": 4,
+            "columnStart": 4,
+            "rowEnd": 5,
+            "columnEnd": 6
           }
         },
         {
@@ -99,10 +99,10 @@
           },
           "gridArea": {
             "type": "PLUGINS:dm-core-plugins/grid/GridArea",
-            "rowStart": 3,
+            "rowStart": 5,
             "columnStart": 1,
             "rowEnd": 6,
-            "columnEnd": 3
+            "columnEnd": 6
           }
         }
       ]

--- a/packages/dm-core-plugins/src/grid/GridElement.tsx
+++ b/packages/dm-core-plugins/src/grid/GridElement.tsx
@@ -8,7 +8,6 @@ const Element = styled.div<TGridArea>`
     `${props.rowStart} / ${props.columnStart} / ${props.rowEnd + 1} / ${
       props.columnEnd + 1
     } `};
-  border: 1px solid black;
 `
 
 type TGridItemProps = {

--- a/packages/dm-core-plugins/src/grid/GridElement.tsx
+++ b/packages/dm-core-plugins/src/grid/GridElement.tsx
@@ -5,7 +5,10 @@ import { TGridArea, TGridItem } from './types'
 
 const Element = styled.div<TGridArea>`
   grid-area: ${(props: TGridArea) =>
-    `${props.rowStart} / ${props.columnStart} / ${props.rowEnd} / ${props.columnEnd} `};
+    `${props.rowStart} / ${props.columnStart} / ${props.rowEnd + 1} / ${
+      props.columnEnd + 1
+    } `};
+  border: 1px solid black;
 `
 
 type TGridItemProps = {

--- a/packages/dm-core-plugins/src/grid/GridPlugin.tsx
+++ b/packages/dm-core-plugins/src/grid/GridPlugin.tsx
@@ -21,9 +21,6 @@ export const GridPlugin = (props: TGridPluginConfig): React.ReactElement => {
       rowGap={config.size.rowGap}
       columnGap={config.size.columnGap}
     >
-      {config.items.forEach(() => (
-        <div style={{ backgroundColor: 'hotpink' }}></div>
-      ))}
       <GridItems idReference={idReference} items={config.items} type={type} />
     </Grid>
   )

--- a/packages/dm-core-plugins/src/grid/GridPlugin.tsx
+++ b/packages/dm-core-plugins/src/grid/GridPlugin.tsx
@@ -21,6 +21,9 @@ export const GridPlugin = (props: TGridPluginConfig): React.ReactElement => {
       rowGap={config.size.rowGap}
       columnGap={config.size.columnGap}
     >
+      {config.items.forEach(() => (
+        <div style={{ backgroundColor: 'hotpink' }}></div>
+      ))}
       <GridItems idReference={idReference} items={config.items} type={type} />
     </Grid>
   )


### PR DESCRIPTION
## What does this pull request change?
the grid positioning is referencing the grid lines, not the columns. Therefor I increment the end by one to reference the "ending line" of the column
## Why is this pull request needed?

## Issues related to this change
closes #638 
