### PR TITLE
test(grid): list with referenced ui-recipe

### DIFF
--- a/example/app/data/DemoDataSource/plugins/grid/car_grid/blueprints/TyreList.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/grid/car_grid/blueprints/TyreList.blueprint.json
@@ -13,7 +13,7 @@
       "attributeType": "string"
     },
     {
-      "name": "tyre list",
+      "name": "tyre",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "./Tyre",
       "dimensions": "*"

--- a/example/app/data/DemoDataSource/plugins/grid/car_grid/raceCenter.entity.json
+++ b/example/app/data/DemoDataSource/plugins/grid/car_grid/raceCenter.entity.json
@@ -32,40 +32,9 @@
     ]
   },
   "tyreList": {
-    "name": "tyreList",
-    "type": "./blueprints/TyreList",
-    "tyre list": [
-      {
-        "name": "Hard",
-        "type": "./blueprints/Tyre",
-        "description": "Slower, but more durable.",
-        "compound": "C1"
-      },
-      {
-        "name": "Medium",
-        "type": "./blueprints/Tyre",
-        "description": "Balanced between pace and degradation",
-        "compound": "C2"
-      },
-      {
-        "name": "Soft",
-        "type": "./blueprints/Tyre",
-        "description": "Faster, but wears quicker.",
-        "compound": "C4"
-      },
-      {
-        "name": "Intermediate",
-        "type": "./blueprints/Tyre",
-        "description": "For damp conditions.",
-        "compound": "Int"
-      },
-      {
-        "name": "Extremes",
-        "type": "./blueprints/Tyre",
-        "description": "For heavy rain.",
-        "compound": "Wet"
-      }
-    ]
+    "type": "CORE:Reference",
+    "address": "dmss://DemoDataSource/$gridTyreList",
+    "referenceType": "link"
   },
   "aNestedObjectWithCustomUI": {
     "type": "./blueprints/Nested",

--- a/example/app/data/DemoDataSource/plugins/grid/car_grid/tyreList.entity.json
+++ b/example/app/data/DemoDataSource/plugins/grid/car_grid/tyreList.entity.json
@@ -2,5 +2,36 @@
   "_id": "gridTyreList",
   "name": "TyreList",
   "type": "./blueprints/TyreList",
-  "tyre list": []
+  "tyre": [
+    {
+      "name": "Hard",
+      "type": "./blueprints/Tyre",
+      "description": "Slower, but more durable.",
+      "compound": "C1"
+    },
+    {
+      "name": "Medium",
+      "type": "./blueprints/Tyre",
+      "description": "Balanced between pace and degradation",
+      "compound": "C2"
+    },
+    {
+      "name": "Soft",
+      "type": "./blueprints/Tyre",
+      "description": "Faster, but wears quicker.",
+      "compound": "C4"
+    },
+    {
+      "name": "Intermediate",
+      "type": "./blueprints/Tyre",
+      "description": "For damp conditions.",
+      "compound": "Int"
+    },
+    {
+      "name": "Extremes",
+      "type": "./blueprints/Tyre",
+      "description": "For heavy rain.",
+      "compound": "Wet"
+    }
+  ]
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/grid/car_grid/raceCenter.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/grid/car_grid/raceCenter.recipe.json
@@ -33,7 +33,7 @@
           "viewConfig": {
             "type": "CORE:ReferenceViewConfig",
             "scope": "tyreList",
-            "recipe": "TyreList"
+            "recipe": "Edit"
           },
           "gridArea": {
             "type": "PLUGINS:dm-core-plugins/grid/GridArea",


### PR DESCRIPTION
## What does this pull request change?
Moved the entity data from the grid´s entity to the list´s entity. This will organise the data inside the actual plugin´s entity, instead of gathering all the data in one large entity (the grid). 

## Why is this pull request needed?

## Issues related to this change
Right now the Grid plugin is unable to resolve UI-recipes that are referenced #639 

