### PR TITLE
Fix/tree correct node id prefix

### DIFF
--- a/example/app/data/DemoDataSource/recipes/plugins/list/task_list/task.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/list/task_list/task.recipe.json
@@ -55,6 +55,7 @@
         "type": "PLUGINS:dm-core-plugins/list/ListPluginConfig",
         "viewConfigs": [],
         "openAsTab": false,
+        "selectFromScope": "dmss://DemoDataSource/plugins/list/task_list",
         "headers": [
           "name",
           "assigned"

--- a/packages/dm-core-plugins/blueprints/list/ListPluginConfig.json
+++ b/packages/dm-core-plugins/blueprints/list/ListPluginConfig.json
@@ -16,6 +16,13 @@
       "default": false
     },
     {
+      "name": "selectFromScope",
+      "type": "CORE:BlueprintAttribute",
+      "description": "An address for where the user should be able to select entities from, when adding to the list",
+      "attributeType": "string",
+      "optional": true
+    },
+    {
       "name": "openAsTab",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "boolean",

--- a/packages/dm-core-plugins/src/header/components/UserInfoDialog.tsx
+++ b/packages/dm-core-plugins/src/header/components/UserInfoDialog.tsx
@@ -60,7 +60,7 @@ export const UserInfoDialog = (props: UserInfoDialogProps) => {
         </Row>
         {apiKey && <pre>{apiKey}</pre>}
 
-        {roles.length && (
+        {roles?.length && (
           <>
             <Typography>Chose role (UI only)</Typography>
             <UnstyledList>

--- a/packages/dm-core-plugins/src/list/Components.tsx
+++ b/packages/dm-core-plugins/src/list/Components.tsx
@@ -20,7 +20,11 @@ export const SaveButton = (props: {
   disabled: boolean
   isLoading: boolean
 }) => (
-  <Button disabled={props.disabled} onClick={props.onClick}>
+  <Button
+    disabled={props.disabled}
+    onClick={props.onClick}
+    data-testid="SaveList"
+  >
     {props.isLoading ? <Progress.Dots color={'primary'} /> : 'Save'}
   </Button>
 )

--- a/packages/dm-core-plugins/src/list/ListPlugin.tsx
+++ b/packages/dm-core-plugins/src/list/ListPlugin.tsx
@@ -27,6 +27,7 @@ type TListConfig = {
   defaultView: TViewConfig
   views: TViewConfig[]
   openAsTab: boolean
+  selectFromScope?: string
   functionality: {
     add: boolean
     sort: boolean
@@ -39,6 +40,7 @@ const defaultConfig: TListConfig = {
   defaultView: { type: 'ViewConfig', scope: 'self' },
   views: [],
   openAsTab: false,
+  selectFromScope: undefined,
   functionality: {
     add: true,
     sort: true,
@@ -210,6 +212,7 @@ export const ListPlugin = (props: IUIPlugin & { config?: TListConfig }) => {
         showModal={showModal}
         setShowModal={setShowModal}
         typeFilter={type}
+        scope={config.selectFromScope}
         onChange={(address: string, entity: TValidEntity) => {
           setUnsavedChanges(true)
           setItems([

--- a/packages/dm-core/src/components/Pickers/EntityPickerDialog.tsx
+++ b/packages/dm-core/src/components/Pickers/EntityPickerDialog.tsx
@@ -62,7 +62,7 @@ export const EntityPickerDialog = (props: {
       .fetch()
       .then((doc: any) => {
         setShowModal(false)
-        onChange(`dmss://${selectedTreeNode.nodeId}`, doc)
+        onChange(selectedTreeNode.nodeId, doc)
       })
       .catch((error: any) => {
         console.error(error)

--- a/packages/dm-core/src/domain/Tree.tsx
+++ b/packages/dm-core/src/domain/Tree.tsx
@@ -55,7 +55,7 @@ const createFolderChildren = (
 ): TTreeMap => {
   const newChildren: TTreeMap = {}
   document.content?.forEach((resolvedChild: any) => {
-    const newChildId = `${parentNode.dataSource}/$${resolvedChild?._id}`
+    const newChildId = `dmss://${parentNode.dataSource}/$${resolvedChild?._id}`
     newChildren[newChildId] = new TreeNode({
       tree: parentNode.tree,
       nodeId: newChildId,
@@ -87,7 +87,7 @@ const updateRootPackagesInTree = (
       const rootPackageNode = new TreeNode({
         // Add the rootPackage nodes to the dataSource
         tree,
-        nodeId: `${dataSource}/$${rootPackage._id}`,
+        nodeId: `dmss://${dataSource}/$${rootPackage._id}`,
         entity: rootPackage,
         type: EBlueprint.PACKAGE,
         parent: tree.index[dataSource],
@@ -140,7 +140,7 @@ export class TreeNode {
   }) {
     this.tree = tree
     this.nodeId = nodeId
-    this.dataSource = nodeId.split('/', 1)[0]
+    this.dataSource = nodeId.replace(/^(dmss:\/\/)/, '').split('/', 1)[0]
     this.parent = parent
     this.isRoot = isRoot
     this.isDataSource = isDataSource


### PR DESCRIPTION
## What does this pull request change?
- Fixes a bug where nodeId in the Tree did not have the "dmss://" prefix
- Feature: expose the EntityPickerDialog "scope" parameter for ListPlugin

## Why is this pull request needed?
- Frontend generated invalid references because of wrong nodeID
- When selecting items to append to a list, should be possible to limit the tree view

## Issues related to this change

none