### PR TITLE
refactor: remove card around job plugin

### DIFF
--- a/packages/dm-core-plugins/src/job/JobPlugin.tsx
+++ b/packages/dm-core-plugins/src/job/JobPlugin.tsx
@@ -23,6 +23,7 @@ const JobButtonWrapper = styled.div`
   flex-direction: row;
   align-items: center;
   gap: 8px;
+  margin-bottom: 0.5rem;
 `
 
 interface ITargetAddress {
@@ -120,7 +121,7 @@ export const JobPlugin = (props: IUIPlugin & { config: JobPluginConfig }) => {
   }, [isLoading, jobEntityError, jobDocument])
 
   return (
-    <Card elevation={'raised'} style={{ padding: '1.25rem' }}>
+    <div>
       <JobButtonWrapper>
         <JobControlButton jobStatus={status} createJob={createAndStartJob} />
         {status === JobStatus.Running && (
@@ -166,6 +167,6 @@ export const JobPlugin = (props: IUIPlugin & { config: JobPluginConfig }) => {
           <pre>{result.result}</pre>
         </>
       )}
-    </Card>
+    </div>
   )
 }


### PR DESCRIPTION
## What does this pull request change?
Removes the card wrapping the job plugin.

## Why is this pull request needed?
I wasn't fully aware of the intended usage when I added it, and I don't think it fits. Also, removing it makes it easier to reuse in different places.

## Issues related to this change

