### PR TITLE
fix: make job api provider use dm job api url from vite

### DIFF
--- a/packages/dm-core/src/context/DMJobContext.tsx
+++ b/packages/dm-core/src/context/DMJobContext.tsx
@@ -9,6 +9,8 @@ export const DMJobProvider = (props: {
   dmJobPath?: string
 }) => {
   const { token } = useContext(AuthContext)
+  if (!props.dmJobPath)
+    throw new Error('DMJobProvider is missing a job api url')
   const dmJobApi = new DmJobAPI(token, props.dmJobPath)
   return (
     <DMJobContext.Provider value={dmJobApi}>

--- a/packages/dm-core/src/services/api/DmJobAPI.ts
+++ b/packages/dm-core/src/services/api/DmJobAPI.ts
@@ -1,12 +1,10 @@
 import { Configuration, DMJobsApi } from './configs/gen-job'
 
-const DM_JOB_URL = process.env.REACT_APP_DM_JOB_URL ?? '/api/dmt'
-
 export class DmJobAPI extends DMJobsApi {
-  constructor(token: string, baseUrl?: string) {
+  constructor(token: string, baseUrl: string) {
     const DMTConfiguration = new Configuration({
       accessToken: token,
-      basePath: baseUrl ?? DM_JOB_URL,
+      basePath: baseUrl,
     })
     super(DMTConfiguration)
   }


### PR DESCRIPTION
## What does this pull request change?
remove old base url, throw error if job api url has not been provided

## Why is this pull request needed?

## Issues related to this change

