### PR TITLE
fix: allow multiple ways of defining scope

### DIFF
--- a/packages/dm-core/src/components/ViewCreator/utils.ts
+++ b/packages/dm-core/src/components/ViewCreator/utils.ts
@@ -2,6 +2,14 @@ import { TViewConfig } from '../../types'
 
 export const getTarget = (idReference: string, viewConfig: TViewConfig) => {
   if (viewConfig?.scope && viewConfig.scope !== 'self')
-    return `${idReference}.${viewConfig.scope}`
+    if (viewConfig.scope.slice(0, 5) == 'self.') {
+      return `${idReference}.${viewConfig.scope.slice(5, -1)}`
+    } else if (viewConfig.scope.slice(0, 1) == '^') {
+      return `${idReference}.${viewConfig.scope.slice(1, -1)}`
+    } else if (viewConfig.scope.slice(0, 1) == '.') {
+      return `${idReference}${viewConfig.scope}`
+    } else {
+      return `${idReference}.${viewConfig.scope}`
+    }
   return idReference
 }


### PR DESCRIPTION
## What does this pull request change?
allow scope to be defined in UiRecipes using `self`, `self.attribute`, `.attribute` and `^.attribute`

## Why is this pull request needed?

## Issues related to this change

