### PR TITLE
fix(blueprint): fix several minor bugs in blueprint plugin

### DIFF
--- a/example/app/data/DemoDataSource/recipes/blueprint.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/blueprint.recipe.json
@@ -18,7 +18,7 @@
               "name": "Edit",
               "type": "CORE:UiRecipe",
               "description": "Default edit",
-              "plugin": "@development-framework/dm-core-plugins/form"
+              "plugin": "@development-framework/dm-core-plugins/blueprint"
             },
             "scope": "self"
           }

--- a/packages/dm-core/src/Enums.ts
+++ b/packages/dm-core/src/Enums.ts
@@ -20,3 +20,9 @@ export enum EBlueprint {
   REFERENCE = 'dmss://system/SIMOS/Reference',
   FILE = 'dmss://system/SIMOS/File',
 }
+
+export enum EPrimitiveTypes {
+  string,
+  number,
+  boolean,
+}


### PR DESCRIPTION
## What does this pull request change?
- Set "blueprint" as the default plugin for "Blueprint"-entities
- Reset value of "default" when changing type of the attribute
- Use a switch to set default value of a boolean
- Only render "contained"-switch on none-primitive types (excluding "any")

## Why is this pull request needed?

- Fixes several bugs with the plugin

## Issues related to this change
none

