### PR TITLE
test: make e2e stable and faster

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -18,9 +18,6 @@ jobs:
   integration-tests:
     timeout-minutes: 60
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: e2e/
     # Map a step output to a job output
     outputs:
       dm_cli_version: ${{ steps.capture_dm_cli_version.outputs.version }}
@@ -35,7 +32,6 @@ jobs:
 
       - name: Install daemon process manager
         run: npm install pm2 -g
-        working-directory: ./
 
       - name: Cache node modules
         id: cache-npm
@@ -44,21 +40,20 @@ jobs:
           cache-name: cache-node-modules
         with:
           path: |
+            ./example/node_modules
             ./node_modules
             ./yarn.lock
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('./packages/dm-core/package.json')}}-${{ hashFiles('./packages/dm-core-plugins/package.json') }}
 
       - name: Install dependencies
         run: yarn install
-        working-directory: ./
 
       - name: Build packages
         run: yarn build:packages
-        working-directory: ./
 
       - name: Start example application
-        run: pm2 start "yarn start:example --mode test" --name web --wait-ready --listen-timeout 10000 # wait for 10 seconds
-        working-directory: ./
+        run: pm2 start "yarn build --mode test && yarn serve" --name web --wait-ready #--listen-timeout 10000 # wait for 10 seconds
+        working-directory: example/
 
       - name: Pull docker images
         run: docker-compose pull
@@ -103,6 +98,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
+          cache: 'pip'
 
       - name: Install dm-cli package
         run: |
@@ -119,13 +115,15 @@ jobs:
         run: ./reset-app.sh
         working-directory: example/
 
-      - name: Cache e2e-deps
+      - name: Cache e2e dependencies
         uses: actions/cache@v3
+        id: cache-e2e
         env:
           cache-name: cache-e2e-deps-modules
         with:
           path: |
-            ./node_modules
+            ~/.cache/ms-playwright
+            ./e2e/node_modules
             ./yarn.lock
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('./package.json')}}
 
@@ -133,14 +131,17 @@ jobs:
         run: |
           npm install --package-lock-only
           npm ci
+        working-directory: e2e/
 
-      - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
+      - run: npx playwright install --with-deps
+        if: steps.cache-e2e.outputs.cache-hit != 'true'
+        working-directory: e2e/
 
-      - name: Run Playwright tests
+      - name: Run e2e tests
         run: |
           pm2 ps
           npx playwright test
+        working-directory: e2e/
 
       - uses: actions/upload-artifact@v3
         if: always()

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -33,9 +33,6 @@ export default defineConfig({
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
     video: 'retain-on-failure',
-    launchOptions: {
-      slowMo: 500,
-    },
   },
 
   /* Configure projects for major browsers */

--- a/e2e/tests/plugin-list-task_list.spec.ts
+++ b/e2e/tests/plugin-list-task_list.spec.ts
@@ -26,6 +26,8 @@ async function reloadPage(page: Page) {
 }
 
 test('Add a new task', async ({ page }) => {
+  const lastTabPanel = page.getByRole('tabpanel').last()
+  await expect(lastTabPanel).toBeVisible()
   await page.getByRole('button', { name: 'Add item' }).click()
   await expect(page.getByText('1 - 4 of 4')).toBeVisible()
   await page.getByRole('button', { name: 'Save' }).click()
@@ -43,6 +45,7 @@ test('Add a new task', async ({ page }) => {
   await expect(page.getByRole('alert')).toHaveText(['Document updated'])
   await page.getByRole('button', { name: 'close', exact: true }).click()
   await reloadPage(page) //TODO: Remove when #153 is solved.
+  await expect(lastTabPanel).toBeVisible()
   await expect(page.getByText('Tax return', { exact: true })).toBeVisible()
   await page
     .getByRole('button', { name: 'Open item', exact: true })
@@ -62,10 +65,13 @@ test('Add a new task', async ({ page }) => {
 })
 
 test('Mark task as complete', async ({ page }) => {
+  const lastTabPanel = page.getByRole('tabpanel').last()
+  await expect(lastTabPanel).toBeVisible()
   await page
     .getByRole('button', { name: 'Open item', exact: true })
     .first()
     .click()
+  await expect(page.getByRole('button', { name: 'Submit' })).toBeVisible()
   await expect(page.getByLabel('Task title:')).toHaveValue('Wash the car')
   await page.getByText('Mark task as complete').click()
   await page.getByRole('button', { name: 'Submit' }).click()
@@ -76,6 +82,7 @@ test('Mark task as complete', async ({ page }) => {
     .getByRole('button', { name: 'Open item', exact: true })
     .first()
     .click()
+  await expect(page.getByTestId('form-checkbox')).toBeVisible()
   await expect(page.getByTestId('form-checkbox')).toBeChecked()
   await page
     .getByRole('button', { name: 'Close item', exact: true })
@@ -84,6 +91,8 @@ test('Mark task as complete', async ({ page }) => {
 })
 
 test('Delete a task', async ({ page }) => {
+  const lastTabPanel = page.getByRole('tabpanel').last()
+  await expect(lastTabPanel).toBeVisible()
   await expect(
     page.getByRole('paragraph').getByText('Tax return')
   ).toBeVisible()
@@ -96,6 +105,7 @@ test('Delete a task', async ({ page }) => {
   await page.getByRole('button', { name: 'Save' }).click()
   await expect(page.getByRole('button', { name: 'Save' })).toBeDisabled()
   await reloadPage(page) //TODO: Remove when #153 is solved.
+  await expect(lastTabPanel).toBeVisible()
   await expect(
     page.getByRole('paragraph').getByText('Wash the car')
   ).toBeVisible()

--- a/e2e/tests/plugin-table-car_list.spec.ts
+++ b/e2e/tests/plugin-table-car_list.spec.ts
@@ -7,6 +7,8 @@ test('Table car list example', async ({ page }) => {
     await page.getByRole('button', { name: 'table' }).click()
     await page.getByRole('button', { name: 'car_list' }).click()
     await page.getByRole('button', { name: 'CarList' }).click()
+    const lastTabPanel = page.getByRole('tabpanel').last()
+    await expect(lastTabPanel).toBeVisible()
   }
 
   await page.goto('http://localhost:3000/')

--- a/packages/dm-core-plugins/src/view_selector/Content.tsx
+++ b/packages/dm-core-plugins/src/view_selector/Content.tsx
@@ -4,14 +4,35 @@ import {
   ViewCreator,
 } from '@development-framework/dm-core'
 import * as React from 'react'
-import styled from 'styled-components'
 import { TItemData } from './types'
+import { PropsWithChildren, useRef } from 'react'
+import styled from 'styled-components'
 
-const HidableWrapper = styled.div<any>`
+type LazyProps = {
+  visible: boolean
+}
+
+const HideContentWrapper = styled.div<any>`
   display: ${(props: { hidden: boolean }) => (props.hidden && 'none') || 'flex'}
   align-self: normal;
   width: 100%;
 `
+
+const Lazy = ({ visible, children }: PropsWithChildren<LazyProps>) => {
+  const rendered = useRef(visible)
+
+  if (visible && !rendered.current) {
+    rendered.current = true
+  }
+
+  if (!rendered.current) return null
+
+  return (
+    <HideContentWrapper hidden={!visible} role="tabpanel">
+      {children}
+    </HideContentWrapper>
+  )
+}
 
 export const Content = (props: {
   type: string
@@ -24,14 +45,11 @@ export const Content = (props: {
 }): React.ReactElement => {
   const { selectedViewId, viewSelectorItems, setFormData, formData, onOpen } =
     props
+
   return (
     <div style={props.style}>
       {viewSelectorItems.map((config: TItemData) => (
-        <HidableWrapper
-          key={config.viewId}
-          hidden={config.viewId !== selectedViewId}
-          role="tabpanel"
-        >
+        <Lazy key={config.viewId} visible={selectedViewId == config.viewId}>
           <ViewCreator
             idReference={config.rootEntityId}
             viewConfig={config.viewConfig}
@@ -43,7 +61,7 @@ export const Content = (props: {
               })
             }}
           />
-        </HidableWrapper>
+        </Lazy>
       ))}
     </div>
   )

--- a/packages/dm-core-plugins/src/view_selector/TabsPlugin.tsx
+++ b/packages/dm-core-plugins/src/view_selector/TabsPlugin.tsx
@@ -1,4 +1,4 @@
-import { IUIPlugin, Loading } from '@development-framework/dm-core'
+import { IUIPlugin } from '@development-framework/dm-core'
 import { TViewSelectorConfig } from './types'
 import * as React from 'react'
 import { Tabs } from './Tabs'
@@ -7,7 +7,7 @@ import { useViewSelector } from './useViewSelector'
 
 export const TabsPlugin = (
   props: IUIPlugin & { config?: TViewSelectorConfig }
-): React.ReactElement => {
+): React.ReactElement | null => {
   const { idReference, config, type } = props
 
   const {
@@ -26,7 +26,7 @@ export const TabsPlugin = (
     throw new Error(JSON.stringify(error, null, 2))
   }
   if (isLoading || !viewSelectorItems.length || !selectedViewId) {
-    return <Loading />
+    return null
   }
 
   return (

--- a/packages/dm-core/src/hooks/useList.tsx
+++ b/packages/dm-core/src/hooks/useList.tsx
@@ -69,7 +69,6 @@ export function useList<T extends object>(
       .catch((error: AxiosError<ErrorResponse>) => {
         setError(error.response?.data || { message: error.name, data: error })
       })
-      .finally(() => setLoading(false))
   }, [dmssAPI, idReference])
 
   useEffect(() => {


### PR DESCRIPTION
## What does this pull request change?

* Use production build (dist/) when running tests
* Cache playwright binary dependencies 
* Remove `slowMo` from playwright config
* Added extra expect that seems to make the code more stable (not 100% sure here)
* For `TabPlugin` and `SidebarPlugin`, don't render hidden tabs or sidebar content if not visible.
* Don't set loading false in `useList` plugin after getting the attribute, this makes it only disable loading after both attribute and the actual data is fetched

## Why is this pull request needed?

## Issues related to this change

