### PR TITLE
fix: disallow hat operator in scope

### DIFF
--- a/packages/dm-core/src/components/ViewCreator/utils.ts
+++ b/packages/dm-core/src/components/ViewCreator/utils.ts
@@ -5,7 +5,9 @@ export const getTarget = (idReference: string, viewConfig: TViewConfig) => {
     if (viewConfig.scope.slice(0, 5) == 'self.') {
       return `${idReference}.${viewConfig.scope.slice(5, -1)}`
     } else if (viewConfig.scope.slice(0, 1) == '^') {
-      return `${idReference}.${viewConfig.scope.slice(1, -1)}`
+      throw new Error(
+        `'^' operator is not allowed in 'scope' (location: ${idReference})`
+      )
     } else if (viewConfig.scope.slice(0, 1) == '.') {
       return `${idReference}${viewConfig.scope}`
     } else {


### PR DESCRIPTION
## What does this pull request change?
Do not allow the use of ^ operator when using scope, throw exception if attempted
e.g. $123.a.b  w/ scope .c. ->  $123.1.b.c
dont allow scope ^.a.b.c

## Why is this pull request needed?

## Issues related to this change

