### PR TITLE
build: enable type check in pre-commit

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,6 +25,9 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('./.pre-commit-config.yaml')}}
 
       - name: Run pre-commit
+        env:
+          # These need node_modules, and will be covered in the build step anyway
+          SKIP: type_check_core,type_check_plugins
         run: pre-commit run --all-files
 
   tests:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,20 @@ repos:
         args: [--branch, main]
         stages: [commit-msg]
 
+  - repo: local
+    hooks:
+      - id: type_check_core
+        name: Run typecheck on dm-core
+        language: system
+        pass_filenames: false
+        entry: bash -c "cd packages/dm-core && tsc"
+
+      - id: type_check_plugins
+        name: Run typecheck on dm-core-plugins
+        language: system
+        pass_filenames: false
+        entry: bash -c "cd packages/dm-core-plugins && tsc --noEmit"
+
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v2.3.0
     hooks:


### PR DESCRIPTION
## What does this pull request change?

 Adds hooks to run type checks in pre-commit

## Why is this pull request needed?

Save time on not pushing code that will fail CI on types

## Issues related to this change
closes #595 
