### PR TITLE
refactor: change icon on list open/close, and add animations

### DIFF
--- a/packages/dm-core-plugins/src/list/ListPlugin.tsx
+++ b/packages/dm-core-plugins/src/list/ListPlugin.tsx
@@ -15,7 +15,7 @@ import {
 import { toast } from 'react-toastify'
 import { Button, Icon, Tooltip, Typography } from '@equinor/eds-core-react'
 import { AppendButton, ListItemButton, SaveButton } from './Components'
-import { add, link, minimize } from '@equinor/eds-icons'
+import { chevron_down, link } from '@equinor/eds-icons'
 
 type TListConfig = {
   expanded?: boolean
@@ -153,8 +153,14 @@ export const ListPlugin = (props: IUIPlugin & { config?: TListConfig }) => {
                     }
                   >
                     <Icon
-                      data={expanded[item.key] ? minimize : add}
+                      data={chevron_down}
                       title={expanded[item.key] ? 'Close item' : 'Open item'}
+                      className="transition-all"
+                      style={{
+                        transform: expanded[item.key]
+                          ? 'rotate(180deg)'
+                          : 'rotate(0deg)',
+                      }}
                     />
                   </Button>
                 </Tooltip>

--- a/packages/dm-core/src/components/TreeView.tsx
+++ b/packages/dm-core/src/components/TreeView.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import { TreeNode } from '../domain/Tree'
 
 import { Button, Icon, Progress, Tooltip } from '@equinor/eds-core-react'
-import { chevron_down, chevron_right } from '@equinor/eds-icons'
+import { chevron_right } from '@equinor/eds-icons'
 import {
   FaDatabase,
   FaExclamationTriangle,
@@ -133,7 +133,11 @@ const TreeButton = (props: {
         }}
       >
         {isExpandable ? (
-          <Icon data={expanded ? chevron_down : chevron_right} />
+          <Icon
+            data={chevron_right}
+            className="transition-all"
+            style={{ transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)' }}
+          />
         ) : (
           <span style={{ width: '25px' }}></span>
         )}

--- a/packages/dm-core/src/styles/main.css
+++ b/packages/dm-core/src/styles/main.css
@@ -13,3 +13,9 @@ body {
 * {
   box-sizing: inherit;
 }
+
+.transition-all {
+  transition-property: all;
+  transition-duration: 150ms;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}

--- a/packages/dm-core/src/styles/main.css
+++ b/packages/dm-core/src/styles/main.css
@@ -14,6 +14,7 @@ body {
   box-sizing: inherit;
 }
 
+Button,
 .transition-all {
   transition-property: all;
   transition-duration: 150ms;


### PR DESCRIPTION
## What does this pull request change?
Changes the icon for opening and closing the list to be a chevron, as that is more appropriate. Also adds some animations, since they're oh so pretty

## Why is this pull request needed?
It pleases me

## Issues related to this change
none

## Screens


https://github.com/equinor/dm-core-packages/assets/3105885/8bc3e09a-39ff-4686-bf32-961b065c9858

