### PR TITLE
test(grid): added resolve false example

### DIFF
--- a/example/app/data/DemoDataSource/recipes/plugins/grid/car_grid/raceCenter.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/grid/car_grid/raceCenter.recipe.json
@@ -25,7 +25,7 @@
             "rowStart": 1,
             "columnStart": 1,
             "rowEnd": 5,
-            "columnEnd": 3
+            "columnEnd": 2
           }
         },
         {
@@ -39,7 +39,23 @@
             "type": "PLUGINS:dm-core-plugins/grid/GridArea",
             "rowStart": 3,
             "columnStart": 1,
-            "rowEnd": 10,
+            "rowEnd": 6,
+            "columnEnd": 3
+          }
+        },
+        {
+          "type": "PLUGINS:dm-core-plugins/grid/GridItem",
+          "viewConfig": {
+            "type": "CORE:ReferenceViewConfig",
+            "scope": "tyreList",
+            "recipe": "Edit",
+            "resolve": false
+          },
+          "gridArea": {
+            "type": "PLUGINS:dm-core-plugins/grid/GridArea",
+            "rowStart": 7,
+            "columnStart": 1,
+            "rowEnd": 8,
             "columnEnd": 3
           }
         },


### PR DESCRIPTION
## What does this pull request change?
Added an example where the reference is not resolved. The same example plugin is now shown as resolved and unresolved, using the same blueprints and entities.

## Why is this pull request needed?
Testing that the resolve flag in ViewConfig works as intended.

## Issues related to this change

