### PR TITLE
fix: wrap recipe errors message in EntityView

### DIFF
--- a/packages/dm-core/src/components/EntityView.tsx
+++ b/packages/dm-core/src/components/EntityView.tsx
@@ -41,7 +41,7 @@ export const EntityView = (props: IEntityView): React.ReactElement => {
         <Typography>{`Failed to find UiRecipe for type "${
           type || '(unknown type)'
         }"`}</Typography>
-        <pre>{JSON.stringify(error)}</pre>
+        <pre>{JSON.stringify(error, null, 2)}</pre>
       </ErrorGroup>
     )
 


### PR DESCRIPTION
Just break and wrap long lines for nicer, easier to read error messages.