### PR TITLE
fix(form): add or remove optional lists

### DIFF
--- a/example/docker-compose.yaml
+++ b/example/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   dmss:
-    image: datamodelingtool.azurecr.io/dmss:v1.7.1
+    image: datamodelingtool.azurecr.io/dmss:v1.8.0
     platform: linux/amd64
     restart: unless-stopped
     environment:

--- a/example/vite.config.ts
+++ b/example/vite.config.ts
@@ -22,6 +22,10 @@ export default defineConfig({
     port: 3000,
     host: true,
   },
+  preview: {
+    port: 3000,
+    host: true,
+  },
   resolve: {
     preserveSymlinks: true, // Yarn uses symbolic links to link to local workspaces.
     ...localConfig(),

--- a/packages/dm-core-plugins/package.json
+++ b/packages/dm-core-plugins/package.json
@@ -12,7 +12,7 @@
     "highlight.js": "^11.8.0",
     "luxon": "^3.4.3",
     "mermaid": "^10.0.0",
-    "react-hook-form": "^7.31.2",
+    "react-hook-form": "^7.48.2",
     "react-toastify": "^9.1.3",
     "yaml": "^2.3.2"
   },

--- a/packages/dm-core-plugins/src/form/components/AddObjectButton.tsx
+++ b/packages/dm-core-plugins/src/form/components/AddObjectButton.tsx
@@ -1,0 +1,62 @@
+import { useFormContext } from 'react-hook-form'
+import { ErrorResponse, useDMSS } from '@development-framework/dm-core'
+import { useRegistryContext } from '../context/RegistryContext'
+import { AxiosError, AxiosResponse } from 'axios'
+import TooltipButton from '../../common/TooltipButton'
+import { add } from '@equinor/eds-icons'
+import React from 'react'
+
+const AddObject = (props: {
+  type: string
+  namePath: string
+  defaultValue?: any
+  onAdd?: () => void
+}) => {
+  const { type, namePath, defaultValue, onAdd } = props
+  const { setValue } = useFormContext()
+  const dmssAPI = useDMSS()
+  const { idReference } = useRegistryContext()
+  const handleAdd = () => {
+    if (!defaultValue) {
+      dmssAPI
+        .instantiateEntity({
+          entity: { type: type as string },
+        })
+        .then((newEntity: AxiosResponse<any>) => {
+          addDocument(newEntity.data)
+          onAdd && onAdd()
+        })
+    } else {
+      addDocument(defaultValue)
+      onAdd && onAdd()
+    }
+  }
+  const addDocument = (document: any) => {
+    const options = {
+      shouldValidate: true,
+      shouldDirty: true,
+      shouldTouch: true,
+    }
+    dmssAPI
+      .documentAdd({
+        address: `${idReference}.${namePath}`,
+        document: JSON.stringify(document),
+      })
+      .then(() => {
+        setValue(namePath, document, options)
+      })
+      .catch((error: AxiosError<ErrorResponse>) => {
+        console.error(error)
+      })
+  }
+  return (
+    <TooltipButton
+      title="Add and save"
+      button-variant="ghost_icon"
+      button-onClick={handleAdd}
+      icon={add}
+    />
+  )
+}
+
+export default AddObject

--- a/packages/dm-core-plugins/src/form/components/RemoveObjectButton.tsx
+++ b/packages/dm-core-plugins/src/form/components/RemoveObjectButton.tsx
@@ -1,0 +1,47 @@
+import { useFormContext } from 'react-hook-form'
+import { useRegistryContext } from '../context/RegistryContext'
+import { ErrorResponse, useDMSS } from '@development-framework/dm-core'
+import { AxiosError } from 'axios'
+import TooltipButton from '../../common/TooltipButton'
+import { delete_forever } from '@equinor/eds-icons'
+import React from 'react'
+
+const RemoveObject = (props: {
+  namePath: string
+  address?: string
+  onRemove?: () => void
+}) => {
+  const { namePath, address, onRemove } = props
+  const { setValue } = useFormContext()
+  const { idReference } = useRegistryContext()
+  const dmssAPI = useDMSS()
+
+  const onClick = () => {
+    const options = {
+      shouldValidate: true,
+      shouldDirty: true,
+      shouldTouch: true,
+    }
+    dmssAPI
+      .documentRemove({
+        address: address ? address : `${idReference}.${namePath}`,
+      })
+      .then(() => {
+        setValue(namePath, {}, options)
+        if (onRemove) onRemove()
+      })
+      .catch((error: AxiosError<ErrorResponse>) => {
+        console.error(error)
+      })
+  }
+  return (
+    <TooltipButton
+      title="Remove and save"
+      button-variant="ghost_icon"
+      button-onClick={onClick}
+      icon={delete_forever}
+    />
+  )
+}
+
+export default RemoveObject

--- a/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
@@ -2,13 +2,13 @@ import {
   EBlueprint,
   EntityView,
   ErrorResponse,
-  Stack,
   getKey,
+  Stack,
   useDMSS,
 } from '@development-framework/dm-core'
 import { Typography } from '@equinor/eds-core-react'
 import { AxiosError } from 'axios'
-import React from 'react'
+import React, { useState } from 'react'
 import { useFieldArray, useFormContext } from 'react-hook-form'
 
 import { add, delete_forever } from '@equinor/eds-icons'
@@ -19,16 +19,37 @@ import { Fieldset, Legend } from '../styles'
 import { TArrayFieldProps } from '../types'
 import { isPrimitive } from '../utils'
 import { AttributeField } from './AttributeField'
+import RemoveObject from '../components/RemoveObjectButton'
+import AddObject from '../components/AddObjectButton'
 
 const isPrimitiveType = (value: string): boolean => {
   return ['string', 'number', 'integer', 'boolean'].includes(value)
 }
 
-export default function ArrayField(props: TArrayFieldProps) {
-  const { namePath, displayLabel, type, uiAttribute, dimensions, readOnly } =
-    props
-
+const InlineList = (props: TArrayFieldProps) => {
+  const { namePath, displayLabel, type, uiAttribute, dimensions } = props
   const { idReference, onOpen } = useRegistryContext()
+  const uiRecipeName = getKey<string>(uiAttribute, 'uiRecipe', 'string')
+  return (
+    <Fieldset>
+      <Legend>
+        <Typography bold={true}>{displayLabel}</Typography>
+      </Legend>
+      <EntityView
+        recipeName={uiRecipeName}
+        idReference={`${idReference}.${namePath}`}
+        type={type}
+        onOpen={onOpen}
+        dimensions={dimensions}
+      />
+    </Fieldset>
+  )
+}
+
+const PrimitiveList = (props: TArrayFieldProps) => {
+  const { namePath, displayLabel, type, readOnly } = props
+
+  const { idReference } = useRegistryContext()
   const dmssAPI = useDMSS()
   const { control } = useFormContext()
 
@@ -36,7 +57,6 @@ export default function ArrayField(props: TArrayFieldProps) {
     control,
     name: namePath,
   })
-  const uiRecipeName = getKey<string>(uiAttribute, 'uiRecipe', 'string')
 
   const handleAddObject = () => {
     dmssAPI
@@ -57,41 +77,6 @@ export default function ArrayField(props: TArrayFieldProps) {
             console.error(error)
           })
       })
-  }
-
-  if (onOpen && !uiAttribute?.showInline && !isPrimitiveType(type)) {
-    return (
-      <Fieldset>
-        <Legend>
-          <Typography bold={true}>{displayLabel}</Typography>
-          <OpenObjectButton
-            viewId={namePath}
-            viewConfig={{
-              type: 'ReferenceViewConfig',
-              scope: namePath,
-              recipe: uiRecipeName,
-            }}
-          />
-        </Legend>
-      </Fieldset>
-    )
-  }
-
-  if (!isPrimitiveType(type)) {
-    return (
-      <Fieldset>
-        <Legend>
-          <Typography bold={true}>{displayLabel}</Typography>
-        </Legend>
-        <EntityView
-          recipeName={uiRecipeName}
-          idReference={`${idReference}.${namePath}`}
-          type={type}
-          onOpen={onOpen}
-          dimensions={dimensions}
-        />
-      </Fieldset>
-    )
   }
 
   return (
@@ -148,4 +133,61 @@ export default function ArrayField(props: TArrayFieldProps) {
       })}
     </Fieldset>
   )
+}
+
+const OpenList = (props: TArrayFieldProps) => {
+  const { namePath, displayLabel, type, uiAttribute, readOnly } = props
+
+  const { getValues, setValue } = useFormContext()
+  const [initialValue, setInitialValue] = useState(getValues(namePath))
+  const uiRecipeName = getKey<string>(uiAttribute, 'uiRecipe', 'string')
+  const isDefined = initialValue !== undefined
+
+  return (
+    <Fieldset>
+      <Legend>
+        <Typography bold={true}>{displayLabel}</Typography>
+        {!readOnly &&
+          (isDefined ? (
+            <RemoveObject
+              namePath={namePath}
+              onRemove={() => {
+                setInitialValue(undefined)
+                setValue(namePath, undefined)
+              }}
+            />
+          ) : (
+            <AddObject
+              namePath={namePath}
+              type={type}
+              defaultValue={[]}
+              onAdd={() => setInitialValue([])}
+            />
+          ))}
+        {!readOnly && isDefined && (
+          <OpenObjectButton
+            viewId={namePath}
+            viewConfig={{
+              type: 'ReferenceViewConfig',
+              scope: namePath,
+              recipe: uiRecipeName,
+            }}
+          />
+        )}
+      </Legend>
+    </Fieldset>
+  )
+}
+
+export default function ArrayField(props: TArrayFieldProps) {
+  const { type, uiAttribute } = props
+
+  const { onOpen } = useRegistryContext()
+
+  if (isPrimitiveType(type)) return <PrimitiveList {...props} />
+
+  if (onOpen && !uiAttribute?.showInline) {
+    return <OpenList {...props} />
+  }
+  return <InlineList {...props} />
 }

--- a/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
@@ -14,8 +14,8 @@ import {
   useDocument,
 } from '@development-framework/dm-core'
 import { Typography } from '@equinor/eds-core-react'
-import { add, delete_forever, edit } from '@equinor/eds-icons'
-import { AxiosError, AxiosResponse } from 'axios'
+import { add, edit } from '@equinor/eds-icons'
+import { AxiosError } from 'axios'
 import React, { useEffect, useState } from 'react'
 import { useFormContext } from 'react-hook-form'
 import TooltipButton from '../../common/TooltipButton'
@@ -31,6 +31,8 @@ import {
   TObjectFieldProps,
   TUiRecipeForm,
 } from '../types'
+import RemoveObject from '../components/RemoveObjectButton'
+import AddObject from '../components/AddObjectButton'
 
 const SelectReference = (props: { type: string; namePath: string }) => {
   const [showModal, setShowModal] = useState<boolean>(false)
@@ -85,87 +87,6 @@ const SelectReference = (props: { type: string; namePath: string }) => {
         setShowModal={setShowModal}
       />
     </>
-  )
-}
-
-const AddObject = (props: {
-  type: string
-  namePath: string
-  defaultValue: any
-}) => {
-  const { type, namePath, defaultValue } = props
-  const { setValue } = useFormContext()
-  const dmssAPI = useDMSS()
-  const { idReference } = useRegistryContext()
-  const handleAdd = () => {
-    if (!defaultValue) {
-      dmssAPI
-        .instantiateEntity({
-          entity: { type: type as string },
-        })
-        .then((newEntity: AxiosResponse<any>) => addDocument(newEntity.data))
-    } else {
-      addDocument(defaultValue)
-    }
-  }
-  const addDocument = (document: any) => {
-    const options = {
-      shouldValidate: true,
-      shouldDirty: true,
-      shouldTouch: true,
-    }
-    dmssAPI
-      .documentAdd({
-        address: `${idReference}.${namePath}`,
-        document: JSON.stringify(document),
-      })
-      .then(() => {
-        setValue(namePath, document, options)
-      })
-      .catch((error: AxiosError<ErrorResponse>) => {
-        console.error(error)
-      })
-  }
-  return (
-    <TooltipButton
-      title="Add and save"
-      button-variant="ghost_icon"
-      button-onClick={handleAdd}
-      icon={add}
-    />
-  )
-}
-
-const RemoveObject = (props: { namePath: string; address?: string }) => {
-  const { namePath, address } = props
-  const { setValue } = useFormContext()
-  const { idReference } = useRegistryContext()
-  const dmssAPI = useDMSS()
-
-  const onClick = () => {
-    const options = {
-      shouldValidate: true,
-      shouldDirty: true,
-      shouldTouch: true,
-    }
-    dmssAPI
-      .documentRemove({
-        address: address ? address : `${idReference}.${namePath}`,
-      })
-      .then(() => {
-        setValue(namePath, {}, options)
-      })
-      .catch((error: AxiosError<ErrorResponse>) => {
-        console.error(error)
-      })
-  }
-  return (
-    <TooltipButton
-      title="Remove and save"
-      button-variant="ghost_icon"
-      button-onClick={onClick}
-      icon={delete_forever}
-    />
   )
 }
 
@@ -343,7 +264,6 @@ export const UncontainedAttribute = (
     value && value.address && value.referenceType === 'link'
       ? resolveRelativeAddress(value.address, documentPath, dataSource)
       : undefined
-
   return (
     <Fieldset>
       <Legend>


### PR DESCRIPTION
## What does this pull request change?

* fix: add or remove optional lists
* fix: tab crashes if try to open a list that does not exists (need to add it first)
* refactor: moved `AddObjectButton` and `RemoveObjectButton` into their own files and out from `ObjectField` that was getting to big, and also re-using the buttons in the `ArrayField`.
* refactor: split up `ArrayField` which was too complex, into using several components `PrimitiveList`, `InlineList`, or `OpenList`, instead of everything being one huge component. 
* chore: update DMSS version that includes fix for add optional empty lists 

How it looks like:

<img width="631" alt="image" src="https://github.com/equinor/dm-core-packages/assets/1190419/126e6e20-dcd1-4445-9a50-94bba338d125">

UiRecipes exist, so can be removed or opened.

StorageRecipes does not exist, so can add it.

## Why is this pull request needed?

## Issues related to this change

