### PR TITLE
test(grid): testing plugins in grid view

### DIFF
--- a/e2e/tests/plugin-grid-car_grid.spec.ts
+++ b/e2e/tests/plugin-grid-car_grid.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('http://localhost:3000/')
+  await page.getByRole('button', { name: 'DemoDataSource' }).click()
+  await page.getByRole('button', { name: 'plugins' }).click()
+  await page.getByRole('button', { name: 'grid' }).click()
+  await page.getByRole('button', { name: 'car_grid' }).click()
+  await page.getByRole('button', { name: 'RaceCenter' }).click()
+})
+
+test('Table non-referenced', async ({ page }) => {
+  const cars = page.getByTestId('carsOnGrid')
+  await expect(cars.getByText('Lando')).toBeVisible()
+  await cars.getByRole('tab', { name: 'Q2' }).click()
+  await expect(cars.getByText('Albon')).toBeVisible()
+})
+
+test('List reference resolved', async ({ page }) => {
+  const tyreList = page.getByTestId('tyreList')
+  await expect(tyreList.getByText('Hard')).toBeVisible()
+  await tyreList
+    .getByRole('row')
+    .filter({ hasText: 'Soft' })
+    .getByRole('button', { name: 'Open item' })
+    .click()
+  await expect(
+    tyreList
+      .getByLabel('Tyre description')
+      .getByText('Faster, but wears quicker.')
+  ).toBeVisible()
+})
+
+test('List reference unresolved', async ({ page }) => {
+  const tyreList = page.getByTestId('tyreList')
+  await expect(
+    tyreList.getByTestId('referenceType').getByTestId('form-textfield')
+  ).toHaveValue('link')
+})
+
+test('Nested form', async ({ page }) => {
+  const nestedForm = page.getByTestId('nestedForm')
+  await expect(nestedForm.getByLabel('Bar')).toHaveText('hello')
+})

--- a/example/app/data/DemoDataSource/plugins/grid/car_grid/blueprints/RaceCenter.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/grid/car_grid/blueprints/RaceCenter.blueprint.json
@@ -23,7 +23,7 @@
       "attributeType": "./TyreList"
     },
     {
-      "name": "aNestedObjectWithCustomUI",
+      "name": "nestedForm",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "./Nested",
       "label": "A nested object with custom ui"

--- a/example/app/data/DemoDataSource/plugins/grid/car_grid/raceCenter.entity.json
+++ b/example/app/data/DemoDataSource/plugins/grid/car_grid/raceCenter.entity.json
@@ -23,10 +23,10 @@
     ],
     "Q2": [
       {
-        "name": "Kevin Magnussen",
+        "name": "Alexander Albon",
         "type": "./blueprints/Car",
         "position": 1,
-        "team": "Haas",
+        "team": "Williams",
         "lap time": "1:30.231"
       }
     ]
@@ -36,7 +36,7 @@
     "address": "dmss://DemoDataSource/$gridTyreList",
     "referenceType": "link"
   },
-  "aNestedObjectWithCustomUI": {
+  "nestedForm": {
     "type": "./blueprints/Nested",
     "foo": 1337,
     "bar": "hello",

--- a/example/app/data/DemoDataSource/recipes/plugins/grid/car_grid/raceCenter.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/grid/car_grid/raceCenter.recipe.json
@@ -63,7 +63,7 @@
           "type": "PLUGINS:dm-core-plugins/grid/GridItem",
           "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
-            "scope": "aNestedObjectWithCustomUI",
+            "scope": "nestedForm",
             "recipe": {
               "name": "form",
               "type": "CORE:UiRecipe",


### PR DESCRIPTION
## What does this pull request change?
Added integration tests for the plugins in the grid example. 
The tests are mainly focusing on verifying that the plugins are showing correctly in the grid, not testing the plugins themselves.

The grid example should probably be expanded with more plugin examples and tests later.

## Why is this pull request needed?

## Issues related to this change

closes #567 