### PR TITLE
refactor: lazy import plugins

### DIFF
--- a/packages/dm-core-plugins/src/index.tsx
+++ b/packages/dm-core-plugins/src/index.tsx
@@ -1,71 +1,108 @@
 import { TUiPluginMap } from '@development-framework/dm-core'
 
-import { YamlPlugin } from './yaml/YamlPlugin'
-import { BlueprintHierarchyPlugin } from './blueprint-hierarchy/BlueprintHierarchyPlugin'
-import { JobPlugin } from './job/JobPlugin'
-import { FormPlugin } from './form/FormPlugin'
-import HeaderPlugin from './header/HeaderPlugin'
-import JsonPlugin from './json/JsonPlugin'
-import { PdfPlugin } from './pdf/PdfPlugin'
-import { BlueprintPlugin } from './blueprint/BlueprintPlugin'
-import ExplorerPlugin from './explorer/ExplorerPlugin'
-import { GridPlugin } from './grid/GridPlugin'
-import { ListPlugin } from './list/ListPlugin'
-import { TablePlugin } from './table/TablePlugin'
-import { FilePlugin } from './file/FilePlugin'
-import { RoleFilterPlugin } from './role_filter/RoleFilterPlugin'
-import { SidebarPlugin } from './view_selector/SidebarPlugin'
-import { TabsPlugin } from './view_selector/TabsPlugin'
+import { lazy } from 'react'
 
 export { WidgetProvider } from './form/context/WidgetContext'
 
 export default {
   '@development-framework/dm-core-plugins/explorer': {
-    component: ExplorerPlugin,
+    component: lazy(() => import('./explorer/ExplorerPlugin')),
   },
   '@development-framework/dm-core-plugins/list': {
-    component: ListPlugin,
+    component: lazy(() =>
+      import('./list/ListPlugin').then((module) => ({
+        default: module.ListPlugin,
+      }))
+    ),
   },
   '@development-framework/dm-core-plugins/table': {
-    component: TablePlugin,
+    component: lazy(() =>
+      import('./table/TablePlugin').then((module) => ({
+        default: module.TablePlugin,
+      }))
+    ),
   },
   '@development-framework/dm-core-plugins/yaml': {
-    component: YamlPlugin,
+    component: lazy(() =>
+      import('./yaml/YamlPlugin').then((module) => ({
+        default: module.YamlPlugin,
+      }))
+    ),
   },
   '@development-framework/dm-core-plugins/file': {
-    component: FilePlugin,
+    component: lazy(() =>
+      import('./file/FilePlugin').then((module) => ({
+        default: module.FilePlugin,
+      }))
+    ),
   },
   '@development-framework/dm-core-plugins/grid': {
-    component: GridPlugin,
+    component: lazy(() =>
+      import('./grid/GridPlugin').then((module) => ({
+        default: module.GridPlugin,
+      }))
+    ),
   },
   '@development-framework/dm-core-plugins/view_selector/sidebar': {
-    component: SidebarPlugin,
+    component: lazy(() =>
+      import('./view_selector/SidebarPlugin').then((module) => ({
+        default: module.SidebarPlugin,
+      }))
+    ),
   },
   '@development-framework/dm-core-plugins/view_selector/tabs': {
-    component: TabsPlugin,
+    component: lazy(() =>
+      import('./view_selector/TabsPlugin').then((module) => ({
+        default: module.TabsPlugin,
+      }))
+    ),
   },
   '@development-framework/dm-core-plugins/blueprint-hierarchy': {
-    component: BlueprintHierarchyPlugin,
+    component: lazy(() =>
+      import('./blueprint-hierarchy/BlueprintHierarchyPlugin').then(
+        (module) => ({ default: module.BlueprintHierarchyPlugin })
+      )
+    ),
   },
   '@development-framework/dm-core-plugins/job/single_job': {
-    component: JobPlugin,
+    component: lazy(() =>
+      import('./job/JobPlugin').then((module) => ({
+        default: module.JobPlugin,
+      }))
+    ),
   },
   '@development-framework/dm-core-plugins/form': {
-    component: FormPlugin,
+    component: lazy(() =>
+      import('./form/FormPlugin').then((module) => ({
+        default: module.FormPlugin,
+      }))
+    ),
   },
   '@development-framework/dm-core-plugins/header': {
-    component: HeaderPlugin,
+    component: lazy(() => import('./header/HeaderPlugin')),
   },
   '@development-framework/dm-core-plugins/json': {
-    component: JsonPlugin,
+    component: lazy(() => import('./json/JsonPlugin')),
   },
   '@development-framework/dm-core-plugins/pdf': {
-    component: PdfPlugin,
+    component: lazy(() =>
+      import('./pdf/PdfPlugin').then((module) => ({
+        default: module.PdfPlugin,
+      }))
+    ),
   },
   '@development-framework/dm-core-plugins/blueprint': {
-    component: BlueprintPlugin,
+    component: lazy(() =>
+      import('./blueprint/BlueprintPlugin').then((module) => ({
+        default: module.BlueprintPlugin,
+      }))
+    ),
   },
   '@development-framework/dm-core-plugins/role_filter': {
-    component: RoleFilterPlugin,
+    component: lazy(() =>
+      import('./role_filter/RoleFilterPlugin').then((module) => ({
+        default: module.RoleFilterPlugin,
+      }))
+    ),
   },
 } as TUiPluginMap

--- a/packages/dm-core-plugins/src/role_filter/RoleFilterPlugin.tsx
+++ b/packages/dm-core-plugins/src/role_filter/RoleFilterPlugin.tsx
@@ -5,6 +5,9 @@ import {
 } from '@development-framework/dm-core'
 import React, { useContext, useEffect, useState } from 'react'
 import { Banner, Icon } from '@equinor/eds-core-react'
+import { edit_text, save, thumbs_down } from '@equinor/eds-icons'
+
+Icon.add({ thumbs_down, save, edit_text })
 
 type FilteredView = {
   type: string

--- a/packages/dm-core/src/components/EntityView.tsx
+++ b/packages/dm-core/src/components/EntityView.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Suspense } from 'react'
 
 import styled from 'styled-components'
 import { ErrorBoundary, ErrorGroup } from '../utils/ErrorBoundary'
@@ -52,16 +52,18 @@ export const EntityView = (props: IEntityView): React.ReactElement => {
 
   return (
     <Wrapper>
-      {/*@ts-ignore*/}
-      <ErrorBoundary message={`Plugin "${recipe.plugin}" crashed...`}>
-        <UiPlugin
-          idReference={idReference}
-          type={type}
-          onSubmit={onSubmit}
-          onOpen={onOpen}
-          config={recipe.config || {}}
-        />
-      </ErrorBoundary>
+      <Suspense fallback={<Loading />}>
+        {/*@ts-ignore*/}
+        <ErrorBoundary message={`Plugin "${recipe.plugin}" crashed...`}>
+          <UiPlugin
+            idReference={idReference}
+            type={type}
+            onSubmit={onSubmit}
+            onOpen={onOpen}
+            config={recipe.config || {}}
+          />
+        </ErrorBoundary>
+      </Suspense>
     </Wrapper>
   )
 }


### PR DESCRIPTION
## What does this pull request change?

* Lazy load plugins, see https://legacy.reactjs.org/docs/code-splitting.html

## Why is this pull request needed?

## Issues related to this change

