### PR TITLE
refactor: tweak the user info dialog

### DIFF
--- a/packages/dm-core-plugins/src/header/components/UserInfoDialog.tsx
+++ b/packages/dm-core-plugins/src/header/components/UserInfoDialog.tsx
@@ -1,7 +1,7 @@
 import { Dialog, RoleContext, useDMSS } from '@development-framework/dm-core'
 import { Button, Radio, Typography } from '@equinor/eds-core-react'
 import { AxiosResponse } from 'axios'
-import React, { useContext, useRef, useState } from 'react'
+import React, { useContext, useState } from 'react'
 import { AuthContext } from 'react-oauth2-code-pkce'
 import { toast } from 'react-toastify'
 import styled from 'styled-components'
@@ -42,7 +42,8 @@ export const UserInfoDialog = (props: UserInfoDialogProps) => {
   const { tokenData, token, logOut } = useContext(AuthContext)
   const dmssAPI = useDMSS()
   const { selectedRole, setSelectedRole, roles } = useContext(RoleContext)
-  const originalRole = useRef(selectedRole)
+  const [tempSelectedRole, setTempSelectedRole] = useState<string>(selectedRole)
+
   return (
     <Dialog
       isDismissable
@@ -69,7 +70,7 @@ export const UserInfoDialog = (props: UserInfoDialogProps) => {
 
         {roles?.length && (
           <>
-            <Typography>Chose role (UI only)</Typography>
+            <Typography>Chose role (UI only) {tempSelectedRole}</Typography>
             <UnstyledList>
               {roles.map((role: string) => (
                 <li key={role}>
@@ -78,9 +79,10 @@ export const UserInfoDialog = (props: UserInfoDialogProps) => {
                     name="impersonate-role"
                     value={role}
                     checked={
-                      selectedRole != 'anonymous' && role == selectedRole
+                      tempSelectedRole != 'anonymous' &&
+                      role == tempSelectedRole
                     }
-                    onChange={(e: any) => setSelectedRole(e.target.value)}
+                    onChange={(e: any) => setTempSelectedRole(e.target.value)}
                   />
                 </li>
               ))}
@@ -121,8 +123,13 @@ export const UserInfoDialog = (props: UserInfoDialogProps) => {
             <Button variant="ghost" color="danger" onClick={() => logOut()}>
               Log out
             </Button>
-            <Button onClick={() => setIsOpen(false)}>
-              {selectedRole !== originalRole.current ? 'Save' : 'Cancel'}
+            <Button
+              onClick={() => {
+                setSelectedRole(tempSelectedRole)
+                setIsOpen(false)
+              }}
+            >
+              {selectedRole !== tempSelectedRole ? 'Save' : 'Cancel'}
             </Button>
           </FlexRow>
         </FlexRow>

--- a/packages/dm-core-plugins/src/header/components/UserInfoDialog.tsx
+++ b/packages/dm-core-plugins/src/header/components/UserInfoDialog.tsx
@@ -1,7 +1,7 @@
 import { Dialog, RoleContext, useDMSS } from '@development-framework/dm-core'
 import { Button, Radio, Typography } from '@equinor/eds-core-react'
 import { AxiosResponse } from 'axios'
-import React, { useContext, useState } from 'react'
+import React, { useContext, useRef, useState } from 'react'
 import { AuthContext } from 'react-oauth2-code-pkce'
 import { toast } from 'react-toastify'
 import styled from 'styled-components'
@@ -23,6 +23,13 @@ const UserInfoLabel = styled.b`
   margin-left: 5px;
 `
 
+const FlexRow = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+`
+
 type UserInfoDialogProps = {
   isOpen: boolean
   setIsOpen: (newValue: boolean) => void
@@ -35,7 +42,7 @@ export const UserInfoDialog = (props: UserInfoDialogProps) => {
   const { tokenData, token, logOut } = useContext(AuthContext)
   const dmssAPI = useDMSS()
   const { selectedRole, setSelectedRole, roles } = useContext(RoleContext)
-
+  const originalRole = useRef(selectedRole)
   return (
     <Dialog
       isDismissable
@@ -82,33 +89,43 @@ export const UserInfoDialog = (props: UserInfoDialogProps) => {
         )}
       </Dialog.CustomContent>
       <Dialog.Actions>
-        <Button
-          onClick={() => {
-            navigator.clipboard.writeText(token)
-            toast.success('Copied token to clipboard')
-          }}
-        >
-          Copy token to clipboard
-        </Button>
-        <Button
-          onClick={() =>
-            dmssAPI
-              .tokenCreate()
-              .then((response: AxiosResponse<string>) =>
-                setAPIKey(response.data)
-              )
-              .catch((error: any) => {
-                console.error(error)
-                toast.error('Failed to create personal access token')
-              })
-          }
-        >
-          Create API-Key
-        </Button>
-        <Button onClick={() => logOut()}>Log out</Button>
-        <Button variant="outlined" onClick={() => setIsOpen(false)}>
-          Cancel
-        </Button>
+        <FlexRow style={{ justifyContent: 'space-between', width: '100%' }}>
+          <FlexRow>
+            <Button
+              variant="ghost"
+              onClick={() => {
+                navigator.clipboard.writeText(token)
+                toast.success('Copied token to clipboard')
+              }}
+            >
+              Copy token to clipboard
+            </Button>
+            <Button
+              variant="ghost"
+              onClick={() =>
+                dmssAPI
+                  .tokenCreate()
+                  .then((response: AxiosResponse<string>) =>
+                    setAPIKey(response.data)
+                  )
+                  .catch((error: any) => {
+                    console.error(error)
+                    toast.error('Failed to create personal access token')
+                  })
+              }
+            >
+              Create API-Key
+            </Button>
+          </FlexRow>
+          <FlexRow>
+            <Button variant="ghost" color="danger" onClick={() => logOut()}>
+              Log out
+            </Button>
+            <Button onClick={() => setIsOpen(false)}>
+              {selectedRole !== originalRole.current ? 'Save' : 'Cancel'}
+            </Button>
+          </FlexRow>
+        </FlexRow>
       </Dialog.Actions>
     </Dialog>
   )


### PR DESCRIPTION
## What does this pull request change?
Slightly tweaks the user info dialog


<img width="1003" alt="Screenshot 2023-11-10 at 15 31 27" src="https://github.com/equinor/dm-core-packages/assets/3105885/dc19b5ed-3c8c-4265-912a-bf3544af1910">
<img width="917" alt="Screenshot 2023-11-10 at 15 31 30" src="https://github.com/equinor/dm-core-packages/assets/3105885/f0dc229d-161b-488a-b197-ed35d1f0681c">
