### PR TITLE
refactor: different icon for opening list in tab or inline

### DIFF
--- a/packages/dm-core-plugins/src/list/ListPlugin.tsx
+++ b/packages/dm-core-plugins/src/list/ListPlugin.tsx
@@ -15,7 +15,7 @@ import {
 import { toast } from 'react-toastify'
 import { Button, Icon, Tooltip, Typography } from '@equinor/eds-core-react'
 import { AppendButton, ListItemButton, SaveButton } from './Components'
-import { chevron_down, link } from '@equinor/eds-icons'
+import { add, chevron_down, link } from '@equinor/eds-icons'
 
 type TListConfig = {
   expanded?: boolean
@@ -153,7 +153,7 @@ export const ListPlugin = (props: IUIPlugin & { config?: TListConfig }) => {
                     }
                   >
                     <Icon
-                      data={chevron_down}
+                      data={internalConfig.openAsTab ? add : chevron_down}
                       title={expanded[item.key] ? 'Close item' : 'Open item'}
                       className="transition-all"
                       style={{


### PR DESCRIPTION
## What does this pull request change?
Different icons for opening tabs inline or in tab

## Why is this pull request needed?

## Issues related to this change

