### PR TITLE
fix: stop job poll on failed or completed status

### DIFF
--- a/packages/dm-core-plugins/src/job/JobPlugin.tsx
+++ b/packages/dm-core-plugins/src/job/JobPlugin.tsx
@@ -117,7 +117,7 @@ export const JobPlugin = (
   } = useDocument<TJob>(jobTargetAddress, 0, false)
 
   const { start, error, fetchResult, fetchStatusAndLogs, logs, status } =
-    useJob(jobTargetAddress)
+    useJob(jobTargetAddress, jobDocument?.uid)
 
   const jobEntity: TJob = {
     label: config?.label,

--- a/packages/dm-core/src/hooks/useJob.tsx
+++ b/packages/dm-core/src/hooks/useJob.tsx
@@ -104,7 +104,7 @@ export function useJob(entityId?: string, jobId?: string): IUseJob {
     }
   }, [entityId])
 
-  // When jobId changes, we register an interval to check status.
+  // When hookJobId changes, we register an interval to check status.
   // The interval is deregistered if the status of the job is not "Running"
   useEffect(() => {
     if (!hookJobId) return
@@ -163,7 +163,11 @@ export function useJob(entityId?: string, jobId?: string): IUseJob {
       .then((response: AxiosResponse<StatusJobResponse>) => {
         setLogs(response.data.log ?? '')
         if (response.data.status !== status) setStatus(response.data.status)
-        if (response.data.status !== JobStatus.Running) {
+        if (
+          ([JobStatus.Failed, JobStatus.Completed] as JobStatus[]).includes(
+            response.data.status
+          )
+        ) {
           clearInterval(statusIntervalId)
         }
         setError(undefined)


### PR DESCRIPTION
## What does this pull request change?
Stop polling when status on the polled job is failed or completed.

## Why is this pull request needed?
Polling now stop as long as the job is shown as not running. This is problematic when the polling starts before the job-api is able to change the status to running.

## Issues related to this change

Closes #736 