### PR TITLE
fix: remove 'gh' from redirect uri

### DIFF
--- a/example/.env.test
+++ b/example/.env.test
@@ -1,5 +1,5 @@
 # This is for running Playwright tests
-VITE_ghREDIRECT_URI=http://localhost:3000/
+VITE_REDIRECT_URI=http://localhost:3000/
 VITE_DMSS_URL=http://localhost:5000
 VITE_DM_JOB_URL=http://localhost:5001
 VITE_AUTH_ENABLED=0


### PR DESCRIPTION
## What does this pull request change?

there was a 'gh' extra in redirect uri

## Why is this pull request needed?

## Issues related to this change

