### PR TITLE
feat(form): configure if fields should be expanded by default

### DIFF
--- a/example/app/data/DemoDataSource/recipes/plugins/form/nested/carRentalCompany.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/nested/carRentalCompany.recipe.json
@@ -44,7 +44,8 @@
             "name": "accountant",
             "type": "PLUGINS:dm-core-plugins/form/fields/ObjectField",
             "showInline": true,
-            "uiRecipe": "defaultYaml"
+            "uiRecipe": "defaultYaml",
+            "showExpanded": true
           },
           {
             "name": "cars",
@@ -57,6 +58,7 @@
             "showInline": true
           }
         ],
+        "showExpanded": true,
         "fields": [
           "owner",
           "ceo",

--- a/packages/dm-core-plugins/blueprints/form/FormInput.json
+++ b/packages/dm-core-plugins/blueprints/form/FormInput.json
@@ -32,6 +32,14 @@
       "optional": true,
       "contained": true,
       "default": false
+    },
+    {
+      "name": "showExpanded",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "If true, fields will be expanded by default if shown inline.",
+      "attributeType": "boolean",
+      "optional": true,
+      "default": true
     }
   ]
 }

--- a/packages/dm-core-plugins/blueprints/form/fields/ArrayField.json
+++ b/packages/dm-core-plugins/blueprints/form/fields/ArrayField.json
@@ -16,6 +16,14 @@
       "type": "dmss://system/SIMOS/BlueprintAttribute",
       "optional": true,
       "attributeType": "string"
+    },
+    {
+      "name": "showExpanded",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "If true, the attribute will be expanded if shown inline.",
+      "optional": true,
+      "default": false,
+      "attributeType": "boolean"
     }
   ]
 }

--- a/packages/dm-core-plugins/blueprints/form/fields/ObjectField.json
+++ b/packages/dm-core-plugins/blueprints/form/fields/ObjectField.json
@@ -16,6 +16,14 @@
       "type": "dmss://system/SIMOS/BlueprintAttribute",
       "optional": true,
       "attributeType": "string"
+    },
+    {
+      "name": "showExpanded",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "If true, the attribute will be expanded if shown inline.",
+      "optional": true,
+      "default": false,
+      "attributeType": "boolean"
     }
   ]
 }

--- a/packages/dm-core-plugins/src/form/components/AttributeList.tsx
+++ b/packages/dm-core-plugins/src/form/components/AttributeList.tsx
@@ -44,6 +44,7 @@ export const AttributeList = (props: {
               attribute={attribute}
               uiAttribute={uiAttribute}
               readOnly={config?.readOnly}
+              showExpanded={config?.showExpanded || true}
             />
           </div>
         )

--- a/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
@@ -7,8 +7,12 @@ import {
 import { Icon, Pagination, Typography } from '@equinor/eds-core-react'
 import React, { useState } from 'react'
 import { useFieldArray, useFormContext } from 'react-hook-form'
-
-import { add, remove_outlined } from '@equinor/eds-icons'
+import {
+  add,
+  remove_outlined,
+  chevron_down,
+  chevron_up,
+} from '@equinor/eds-icons'
 import TooltipButton from '../../common/TooltipButton'
 import { OpenObjectButton } from '../components/OpenObjectButton'
 import { useRegistryContext } from '../context/RegistryContext'
@@ -24,29 +28,55 @@ const isPrimitiveType = (value: string): boolean => {
 }
 
 const InlineList = (props: TArrayFieldProps) => {
-  const { namePath, displayLabel, type, uiAttribute, dimensions } = props
+  const {
+    namePath,
+    displayLabel,
+    type,
+    uiAttribute,
+    dimensions,
+    showExpanded,
+  } = props
   const { idReference, onOpen } = useRegistryContext()
+  const [isExpanded, setIsExpanded] = useState(
+    uiAttribute?.showExpanded !== undefined
+      ? uiAttribute?.showExpanded
+      : showExpanded
+  )
   const uiRecipeName = getKey<string>(uiAttribute, 'uiRecipe', 'string')
   return (
     <Fieldset>
       <Legend>
         <Typography bold={true}>{displayLabel}</Typography>
+        <TooltipButton
+          title="Expand"
+          button-variant="ghost_icon"
+          button-onClick={() => setIsExpanded(!isExpanded)}
+          icon={isExpanded ? chevron_up : chevron_down}
+        />
       </Legend>
-      <EntityView
-        recipeName={uiRecipeName}
-        idReference={`${idReference}.${namePath}`}
-        type={type}
-        onOpen={onOpen}
-        dimensions={dimensions}
-      />
+      {isExpanded && (
+        <EntityView
+          recipeName={uiRecipeName}
+          idReference={`${idReference}.${namePath}`}
+          type={type}
+          onOpen={onOpen}
+          dimensions={dimensions}
+        />
+      )}
     </Fieldset>
   )
 }
 
 const PrimitiveList = (props: TArrayFieldProps) => {
-  const { namePath, displayLabel, type, readOnly } = props
+  const { namePath, displayLabel, type, readOnly, uiAttribute, showExpanded } =
+    props
 
   const { control } = useFormContext()
+  const [isExpanded, setIsExpanded] = useState(
+    uiAttribute?.showExpanded !== undefined
+      ? uiAttribute?.showExpanded
+      : showExpanded
+  )
 
   const { fields, append, remove } = useFieldArray({
     control,
@@ -59,7 +89,13 @@ const PrimitiveList = (props: TArrayFieldProps) => {
     <Fieldset>
       <Legend>
         <Typography bold={true}>{displayLabel}</Typography>
-        {!readOnly && (
+        <TooltipButton
+          title="Expand"
+          button-variant="ghost_icon"
+          button-onClick={() => setIsExpanded(!isExpanded)}
+          icon={isExpanded ? chevron_up : chevron_down}
+        />
+        {!readOnly && isExpanded && (
           <TooltipButton
             title="Add"
             button-variant="ghost_icon"
@@ -74,57 +110,59 @@ const PrimitiveList = (props: TArrayFieldProps) => {
           />
         )}
       </Legend>
-      <div
-        style={{
-          display: 'flex',
-          flexFlow: 'column wrap',
-          maxHeight: '23em',
-          alignContent: 'flex-start',
-        }}
-      >
-        {fields
-          .slice(
-            currentPageIndex * itemsPerPage,
-            currentPageIndex * itemsPerPage + itemsPerPage
-          )
-          .map((item: any, index: number) => {
-            const pagedIndex = itemsPerPage * currentPageIndex + index
-            return (
-              <Stack
-                key={item.id}
-                direction="row"
-                spacing={0.5}
-                alignSelf="stretch"
-                alignItems="flex-end"
-              >
-                <Stack grow={1}>
-                  <AttributeField
-                    namePath={`${namePath}.${pagedIndex}`}
-                    attribute={{
-                      attributeType: type,
-                      dimensions: '',
-                      name: '',
-                      type: EBlueprint.ATTRIBUTE,
-                    }}
-                    readOnly={readOnly}
-                    leftAdornments={String(pagedIndex)}
-                    rightAdornments={
-                      <Icon
-                        data={remove_outlined}
-                        size={18}
-                        // @ts-ignore
-                        onClick={() => remove(pagedIndex)}
-                        style={{ cursor: 'pointer' }}
-                        data-testid={`form-text-widget-remove-${pagedIndex}`}
-                      />
-                    }
-                  />
-                </Stack>
-              </Stack>
+      {isExpanded && (
+        <div
+          style={{
+            display: 'flex',
+            flexFlow: 'column wrap',
+            maxHeight: '23em',
+            alignContent: 'flex-start',
+          }}
+        >
+          {fields
+            .slice(
+              currentPageIndex * itemsPerPage,
+              currentPageIndex * itemsPerPage + itemsPerPage
             )
-          })}
-      </div>
-      {fields.length > itemsPerPage && (
+            .map((item: any, index: number) => {
+              const pagedIndex = itemsPerPage * currentPageIndex + index
+              return (
+                <Stack
+                  key={item.id}
+                  direction="row"
+                  spacing={0.5}
+                  alignSelf="stretch"
+                  alignItems="flex-end"
+                >
+                  <Stack grow={1}>
+                    <AttributeField
+                      namePath={`${namePath}.${pagedIndex}`}
+                      attribute={{
+                        attributeType: type,
+                        dimensions: '',
+                        name: '',
+                        type: EBlueprint.ATTRIBUTE,
+                      }}
+                      readOnly={readOnly}
+                      leftAdornments={String(pagedIndex)}
+                      rightAdornments={
+                        <Icon
+                          data={remove_outlined}
+                          size={18}
+                          // @ts-ignore
+                          onClick={() => remove(pagedIndex)}
+                          style={{ cursor: 'pointer' }}
+                          data-testid={`form-text-widget-remove-${pagedIndex}`}
+                        />
+                      }
+                    />
+                  </Stack>
+                </Stack>
+              )
+            })}
+        </div>
+      )}
+      {isExpanded && fields.length > itemsPerPage && (
         <div>
           <Pagination
             totalItems={fields.length}

--- a/packages/dm-core-plugins/src/form/fields/AttributeField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/AttributeField.tsx
@@ -43,6 +43,7 @@ export const AttributeField = (props: TAttributeFieldProps) => {
     readOnly,
     leftAdornments,
     rightAdornments,
+    showExpanded,
   } = props
 
   const fieldType = getFieldType(attribute)
@@ -73,6 +74,7 @@ export const AttributeField = (props: TAttributeFieldProps) => {
           uiAttribute={uiAttribute}
           defaultValue={attribute.default}
           readOnly={readOnly}
+          showExpanded={showExpanded}
         />
       )
 
@@ -85,6 +87,7 @@ export const AttributeField = (props: TAttributeFieldProps) => {
           uiAttribute={uiAttribute}
           dimensions={attribute.dimensions}
           readOnly={readOnly}
+          showExpanded={showExpanded}
         />
       )
     case 'string':

--- a/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
@@ -14,7 +14,7 @@ import {
   useDocument,
 } from '@development-framework/dm-core'
 import { Typography } from '@equinor/eds-core-react'
-import { add, edit } from '@equinor/eds-icons'
+import { add, chevron_down, chevron_up, edit } from '@equinor/eds-icons'
 import { AxiosError } from 'axios'
 import React, { useEffect, useState } from 'react'
 import { useFormContext } from 'react-hook-form'
@@ -168,9 +168,15 @@ export const ContainedAttribute = (
     uiRecipe,
     defaultValue,
     readOnly,
+    showExpanded,
   } = props
   const { watch } = useFormContext()
   const { idReference, onOpen } = useRegistryContext()
+  const [isExpanded, setIsExpanded] = useState(
+    uiAttribute?.showExpanded !== undefined
+      ? uiAttribute?.showExpanded
+      : showExpanded
+  )
   const value = watch(namePath)
   const isDefined = value && Object.keys(value).length > 0
   return (
@@ -188,6 +194,14 @@ export const ContainedAttribute = (
               defaultValue={defaultValue}
             />
           ))}
+        {isDefined && !(onOpen && !uiAttribute?.showInline) && (
+          <TooltipButton
+            title="Expand"
+            button-variant="ghost_icon"
+            button-onClick={() => setIsExpanded(!isExpanded)}
+            icon={isExpanded ? chevron_up : chevron_down}
+          />
+        )}
         {isDefined && onOpen && !uiAttribute?.showInline && (
           <OpenObjectButton
             viewId={namePath}
@@ -200,7 +214,7 @@ export const ContainedAttribute = (
           />
         )}
       </Legend>
-      {isDefined && !(onOpen && !uiAttribute?.showInline) && (
+      {isDefined && !(onOpen && !uiAttribute?.showInline) && isExpanded && (
         <EntityView
           recipeName={uiRecipe.name}
           idReference={`${idReference}.${namePath}`}
@@ -223,9 +237,15 @@ export const UncontainedAttribute = (
     uiRecipe,
     optional,
     readOnly,
+    showExpanded,
   } = props
   const { watch } = useFormContext()
   const { idReference, onOpen } = useRegistryContext()
+  const [isExpanded, setIsExpanded] = useState(
+    uiAttribute?.showExpanded !== undefined
+      ? uiAttribute?.showExpanded
+      : showExpanded
+  )
   const value = watch(namePath)
   const { dataSource, documentPath } = splitAddress(idReference)
   const address =
@@ -240,6 +260,14 @@ export const UncontainedAttribute = (
         {optional && address && !readOnly && (
           <RemoveObject namePath={namePath} />
         )}
+        {address && !(onOpen && !uiAttribute?.showInline) && (
+          <TooltipButton
+            title="Expand"
+            button-variant="ghost_icon"
+            button-onClick={() => setIsExpanded(!isExpanded)}
+            icon={isExpanded ? chevron_up : chevron_down}
+          />
+        )}
         {address && onOpen && !uiAttribute?.showInline && (
           <OpenObjectButton
             viewId={namePath}
@@ -252,7 +280,7 @@ export const UncontainedAttribute = (
           />
         )}
       </Legend>
-      {address && !(onOpen && !uiAttribute?.showInline) && (
+      {address && !(onOpen && !uiAttribute?.showInline) && isExpanded && (
         <EntityView
           idReference={address}
           type={type}
@@ -303,6 +331,7 @@ export const ObjectTypeSelector = (
     uiAttribute,
     defaultValue,
     readOnly,
+    showExpanded,
   } = props
   const { blueprint, uiRecipes, isLoading, error } = useBlueprint(type)
   const { watch } = useFormContext()
@@ -352,6 +381,7 @@ export const ObjectTypeSelector = (
       uiAttribute={uiAttribute}
       defaultValue={defaultValue}
       readOnly={readOnly}
+      showExpanded={showExpanded}
     />
   )
 }

--- a/packages/dm-core-plugins/src/form/types.tsx
+++ b/packages/dm-core-plugins/src/form/types.tsx
@@ -21,9 +21,10 @@ export type TObjectFieldProps = {
   type: string
   displayLabel: string
   optional: boolean
-  uiAttribute: TAttributeConfig | undefined
+  uiAttribute: TAttributeObject | undefined
   readOnly?: boolean
   defaultValue?: any
+  showExpanded?: boolean
 }
 
 export type TContentProps = {
@@ -33,18 +34,20 @@ export type TContentProps = {
   optional: boolean
   blueprint: TBlueprint | undefined
   uiRecipe: TUiRecipeForm
-  uiAttribute: TAttributeConfig | undefined
+  uiAttribute: TAttributeObject | undefined
   readOnly?: boolean
   defaultValue?: any
+  showExpanded?: boolean
 }
 
 export type TArrayFieldProps = {
   namePath: string
   displayLabel: string
   type: string
-  uiAttribute: TAttributeConfig | undefined
+  uiAttribute: TAttributeArray | undefined
   dimensions: string | undefined
   readOnly?: boolean
+  showExpanded?: boolean
 }
 
 export type TAttributeFieldProps = {
@@ -52,6 +55,7 @@ export type TAttributeFieldProps = {
   attribute: TAttribute
   uiAttribute?: TAttributeConfig
   readOnly?: boolean
+  showExpanded?: boolean
   leftAdornments?: React.ReactElement | string
   rightAdornments?: React.ReactElement | string
 }
@@ -101,10 +105,12 @@ type TAttributeString = TAttributeBasis & {
 type TAttributeArray = TAttributeBasis & {
   widget?: string
   uiRecipe?: string
+  showExpanded?: boolean
 }
 type TAttributeObject = TAttributeBasis & {
   widget?: string
   uiRecipe?: string
+  showExpanded?: boolean
 }
 export type TAttributeConfig =
   | TAttributeArray
@@ -114,6 +120,7 @@ export type TConfig = {
   attributes: TAttributeConfig[]
   fields: string[]
   readOnly?: boolean
+  showExpanded?: boolean
 }
 
 export type TUiRecipeForm = Omit<TUiRecipe, 'config'> & {


### PR DESCRIPTION
## What does this pull request change?

Add config to say if inline objects or arrays should be collapsable/expanded by default or not!

<img width="1728" alt="image" src="https://github.com/equinor/dm-core-packages/assets/1190419/208b3707-101c-4e65-9022-51c9fb5085db">

<img width="1728" alt="image" src="https://github.com/equinor/dm-core-packages/assets/1190419/4dcae1b3-854c-4538-b07b-7b514f95de1e">

## Why is this pull request needed?

## Issues related to this change

