### PR TITLE
feat: open in tab icon instead of plus in list

### DIFF
--- a/packages/dm-core-plugins/src/list/ListPlugin.tsx
+++ b/packages/dm-core-plugins/src/list/ListPlugin.tsx
@@ -15,7 +15,7 @@ import {
 import { toast } from 'react-toastify'
 import { Button, Icon, Tooltip, Typography } from '@equinor/eds-core-react'
 import { AppendButton, ListItemButton, SaveButton } from './Components'
-import { add, chevron_down, link } from '@equinor/eds-icons'
+import { external_link, chevron_down, link } from '@equinor/eds-icons'
 
 type TListConfig = {
   expanded?: boolean
@@ -153,7 +153,10 @@ export const ListPlugin = (props: IUIPlugin & { config?: TListConfig }) => {
                     }
                   >
                     <Icon
-                      data={internalConfig.openAsTab ? add : chevron_down}
+                      data={
+                        internalConfig.openAsTab ? external_link : chevron_down
+                      }
+                      size={internalConfig.openAsTab ? 18 : 24}
                       title={expanded[item.key] ? 'Close item' : 'Open item'}
                       className="transition-all"
                       style={{


### PR DESCRIPTION
## What does this pull request change?


Changed list icon to be: 

![image](https://github.com/equinor/dm-core-packages/assets/37016135/68077d6b-f8f6-4fb6-acad-543a355aa75d)

instead of + which was not intuitive of being "open". Plus means add, not open. 

![image](https://github.com/equinor/dm-core-packages/assets/37016135/1cdaf76e-0600-4801-b2cf-f62d56f7766e)


## Why is this pull request needed?

## Issues related to this change

