### PR TITLE
feat: list clickable and chevron change

### DIFF
--- a/packages/dm-core-plugins/src/list/ListPlugin.tsx
+++ b/packages/dm-core-plugins/src/list/ListPlugin.tsx
@@ -17,7 +17,7 @@ import {
 import { toast } from 'react-toastify'
 import { Button, Icon, Tooltip, Typography } from '@equinor/eds-core-react'
 import { AppendButton, ListItemButton, SaveButton } from './Components'
-import { external_link, chevron_down, link } from '@equinor/eds-icons'
+import { external_link, chevron_right, link } from '@equinor/eds-icons'
 
 type TListConfig = {
   expanded?: boolean
@@ -82,19 +82,18 @@ export const ListPlugin = (props: IUIPlugin & { config?: TListConfig }) => {
       ),
     [paginationPage, paginationRowsPerPage, items]
   )
-
-  function openItemAsTab(item: TGenericObject) {
-    const view = { label: item?.data?.name, type: 'ViewConfig' }
-    if (!onOpen) {
-      toast.error(
-        'Invalid UiRecipes. The list plugin was not passed an "onOpen()"-function.'
-      )
+  function expandOrOpen(item: TGenericObject) {
+    if (internalConfig.openAsTab) {
+      const view = { label: item?.data?.name, type: 'ViewConfig' }
+      if (!onOpen) {
+        toast.error(
+          'Invalid UiRecipes. The list plugin was not passed an "onOpen()"-function.'
+        )
+        return
+      }
+      onOpen(crypto.randomUUID(), view, `${idReference}[${item.index}]`)
       return
     }
-    onOpen(crypto.randomUUID(), view, `${idReference}[${item.index}]`)
-  }
-
-  function expandItem(item: TItem<any>) {
     const isExpanded = expanded[item.key] || false
     setExpanded({ ...expanded, [item.key]: !isExpanded })
   }
@@ -150,22 +149,18 @@ export const ListPlugin = (props: IUIPlugin & { config?: TListConfig }) => {
                     color="secondary"
                     disabled={!item.isSaved}
                     data-testid={`expandListItem-${index}`}
-                    onClick={
-                      !internalConfig.openAsTab
-                        ? () => expandItem(item)
-                        : () => openItemAsTab(item)
-                    }
+                    onClick={() => expandOrOpen(item)}
                   >
                     <Icon
                       data={
-                        internalConfig.openAsTab ? external_link : chevron_down
+                        internalConfig.openAsTab ? external_link : chevron_right
                       }
                       size={internalConfig.openAsTab ? 18 : 24}
                       title={expanded[item.key] ? 'Close item' : 'Open item'}
                       className="transition-all"
                       style={{
                         transform: expanded[item.key]
-                          ? 'rotate(180deg)'
+                          ? 'rotate(90deg)'
                           : 'rotate(0deg)',
                       }}
                     />
@@ -184,6 +179,8 @@ export const ListPlugin = (props: IUIPlugin & { config?: TListConfig }) => {
                           key={attribute}
                           variant="body_short"
                           bold={index === 0}
+                          onClick={() => expandOrOpen(item)}
+                          style={{ cursor: 'pointer' }}
                         >
                           {item?.data[attribute]}
                         </Typography>


### PR DESCRIPTION
## What does this pull request change?

1. Chevron is now right and down, instead of down and up. This is to be consistent with the other usages of chevron in the application. Like how it is used in the tree view. 
<img width="354" alt="image" src="https://github.com/equinor/dm-core-packages/assets/37016135/1cadc3f8-5c7b-4d26-a4d3-691ef312d6b3">
2. List title is now clickable as well, not only the chevron. Makes it easier to use. 

## Why is this pull request needed?

## Issues related to this change

