### PR TITLE
feat(view_select): add sub menu

### DIFF
--- a/example/app/data/DemoDataSource/recipes/plugins/view_selector/roles_school_example/schoolDistrict.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/view_selector/roles_school_example/schoolDistrict.recipe.json
@@ -43,7 +43,33 @@
               "scope": "school",
               "eds_icon": "home",
               "recipe": "AdminView"
-            }
+            },
+            "subItems": [
+              {
+                "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
+                "label": "Students",
+                "viewConfig": {
+                  "type": "CORE:ViewConfig",
+                  "scope": "school.students"
+                }
+              },
+              {
+                "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
+                "label": "Headmaster",
+                "viewConfig": {
+                  "type": "CORE:ViewConfig",
+                  "scope": "school.headmaster"
+                }
+              },
+              {
+                "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
+                "label": "Teachers",
+                "viewConfig": {
+                  "type": "CORE:ViewConfig",
+                  "scope": "school.teachers"
+                }
+              }
+            ]
           },
           {
             "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",

--- a/packages/dm-core-plugins/blueprints/view_selector/ViewSelectorItem.json
+++ b/packages/dm-core-plugins/blueprints/view_selector/ViewSelectorItem.json
@@ -17,6 +17,13 @@
       "type": "CORE:BlueprintAttribute",
       "attributeType": "string",
       "optional": true
+    },
+    {
+      "name": "subItems",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
+      "optional": true,
+      "dimensions": "*"
     }
   ]
 }

--- a/packages/dm-core-plugins/src/view_selector/Sidebar.tsx
+++ b/packages/dm-core-plugins/src/view_selector/Sidebar.tsx
@@ -2,31 +2,89 @@ import * as React from 'react'
 import { SideBar } from '@equinor/eds-core-react'
 import * as EdsIcons from '@equinor/eds-icons'
 import { TItemData } from './types'
+import { TOnOpen } from '@development-framework/dm-core'
 
 export const Sidebar = (props: {
   selectedViewId: string
   setSelectedViewId: (k: string) => void
   viewSelectorItems: TItemData[]
+  addView: TOnOpen
 }): React.ReactElement => {
-  const { selectedViewId, setSelectedViewId, viewSelectorItems } = props
+  const { selectedViewId, setSelectedViewId, viewSelectorItems, addView } =
+    props
 
   return (
     <SideBar open style={{ height: 'auto' }}>
       <SideBar.Content>
-        {viewSelectorItems.map((config: TItemData) => (
-          <SideBar.Link
-            key={config.viewId}
-            icon={
-              config.viewConfig.eds_icon
-                ? EdsIcons[config.viewConfig.eds_icon as keyof typeof EdsIcons]
-                : EdsIcons.subdirectory_arrow_right
-            }
-            label={config.label}
-            role="tab"
-            onClick={() => setSelectedViewId(config.viewId)}
-            active={selectedViewId === config.viewId}
-          />
-        ))}
+        {viewSelectorItems.map((config: TItemData) => {
+          // subItem's will be rendered inside other items. Don't add them here
+          if (config.isSubItem) return null
+
+          return (
+            <div key={config.viewId}>
+              {config.subItems ? (
+                <SideBar.Accordion
+                  key={config.viewId}
+                  icon={
+                    config.viewConfig.eds_icon
+                      ? EdsIcons[
+                          config.viewConfig.eds_icon as keyof typeof EdsIcons
+                        ]
+                      : EdsIcons.subdirectory_arrow_right
+                  }
+                  label={config.label}
+                  role="tab"
+                  onClick={() => setSelectedViewId(config.viewId)}
+                  active={selectedViewId === config.viewId}
+                >
+                  {config.subItems.map((subConfig: TItemData, index) => {
+                    const subViewId = config.viewId + subConfig.viewConfig.scope
+                    return (
+                      <SideBar.AccordionItem
+                        key={index}
+                        icon={
+                          subConfig.viewConfig.eds_icon
+                            ? EdsIcons[
+                                subConfig.viewConfig
+                                  .eds_icon as keyof typeof EdsIcons
+                              ]
+                            : EdsIcons.subdirectory_arrow_right
+                        }
+                        label={subConfig.label}
+                        role="tab"
+                        onClick={() => {
+                          addView(
+                            subViewId,
+                            subConfig.viewConfig,
+                            undefined,
+                            true
+                          )
+                          setSelectedViewId(subViewId)
+                        }}
+                        active={selectedViewId === subViewId}
+                      />
+                    )
+                  })}
+                </SideBar.Accordion>
+              ) : (
+                <SideBar.Link
+                  key={config.viewId}
+                  icon={
+                    config.viewConfig.eds_icon
+                      ? EdsIcons[
+                          config.viewConfig.eds_icon as keyof typeof EdsIcons
+                        ]
+                      : EdsIcons.subdirectory_arrow_right
+                  }
+                  label={config.label}
+                  role="tab"
+                  onClick={() => setSelectedViewId(config.viewId)}
+                  active={selectedViewId === config.viewId}
+                />
+              )}
+            </div>
+          )
+        })}
       </SideBar.Content>
       <SideBar.Footer>
         <SideBar.Toggle />

--- a/packages/dm-core-plugins/src/view_selector/SidebarPlugin.tsx
+++ b/packages/dm-core-plugins/src/view_selector/SidebarPlugin.tsx
@@ -40,6 +40,7 @@ export const SidebarPlugin = (
         viewSelectorItems={viewSelectorItems}
         selectedViewId={selectedViewId}
         setSelectedViewId={setSelectedViewId}
+        addView={addView}
       />
       <div
         style={{

--- a/packages/dm-core-plugins/src/view_selector/types.tsx
+++ b/packages/dm-core-plugins/src/view_selector/types.tsx
@@ -16,6 +16,8 @@ export type TItemData = TViewSelectorItem & {
   rootEntityId: string
   // onSubmit is not yet supported
   onSubmit?: (data: TItemData) => void
+  subItems?: TItemData[]
+  isSubItem?: boolean
 }
 
 export type TViewSelectorConfig = {

--- a/packages/dm-core-plugins/src/view_selector/useViewSelector.tsx
+++ b/packages/dm-core-plugins/src/view_selector/useViewSelector.tsx
@@ -45,7 +45,8 @@ export function useViewSelector(
   const addView: TOnOpen = (
     viewId: string,
     viewConfig: TViewConfig | TReferenceViewConfig | TInlineRecipeViewConfig,
-    rootId?: string
+    rootId?: string,
+    isSubItem?: boolean
   ) => {
     if (!viewSelectorItems.find((view: TItemData) => view.viewId === viewId)) {
       // View does not exist, add it
@@ -56,6 +57,7 @@ export function useViewSelector(
         rootEntityId: rootId || idReference,
         onSubmit: () => undefined,
         closeable: true,
+        isSubItem: isSubItem,
       }
       setViewSelectorItems([...viewSelectorItems, newView])
     }

--- a/packages/dm-core/src/types.ts
+++ b/packages/dm-core/src/types.ts
@@ -147,7 +147,8 @@ export interface IUIPlugin {
 export type TOnOpen = (
   viewId: string,
   view: TViewConfig | TReferenceViewConfig | TInlineRecipeViewConfig,
-  rootId?: string
+  rootId?: string,
+  isSubItem?: boolean
 ) => void
 
 export type TUiPluginMap = { [pluginName: string]: TPlugin }


### PR DESCRIPTION

## What does this pull request change?
- Adds an optional list of "subItem" to the "ViewSelectorConfig". Allowing to configure sub items in the sidebar menu

 
![Screenshot_20231120_151342](https://github.com/equinor/dm-core-packages/assets/11062560/a1c1c6c5-11f4-41b1-a97d-44ff5036e9c7)

## Why is this pull request needed?
More compact and effective UI navigation

## Issues related to this change
closes #729 
