### PR TITLE
feat: when click away from header menu it goes away

### DIFF
--- a/packages/dm-core-plugins/src/header/HeaderPlugin.tsx
+++ b/packages/dm-core-plugins/src/header/HeaderPlugin.tsx
@@ -8,7 +8,7 @@ import {
   useUiPlugins,
 } from '@development-framework/dm-core'
 import { Icon, Menu, TopBar } from '@equinor/eds-core-react'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
 
 import { account_circle, menu, info_circle } from '@equinor/eds-icons'
@@ -85,7 +85,7 @@ export default (props: IUIPlugin): React.ReactElement => {
       config: recipe?.config ?? {},
     }
   }
-
+  const menuRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
     if (!isBlueprintLoading) {
       const defaultRecipe: TUiRecipe = config.uiRecipesList.length
@@ -94,6 +94,14 @@ export default (props: IUIPlugin): React.ReactElement => {
           )
         : uiRecipes[0]
       setSelectedRecipe(getRecipeConfigAndPlugin(defaultRecipe.name))
+    }
+    const handleMouseDown = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node))
+        setAppSelectorOpen(false)
+    }
+    document.addEventListener('mousedown', handleMouseDown)
+    return () => {
+      document.removeEventListener('mousedown', handleMouseDown)
     }
   }, [isBlueprintLoading])
 
@@ -128,7 +136,7 @@ export default (props: IUIPlugin): React.ReactElement => {
           >
             <Icon data={menu} size={32} title="Menu" />
           </ClickableIcon>
-          <Menu open={appSelectorOpen} anchorEl={anchorEl}>
+          <Menu open={appSelectorOpen} anchorEl={anchorEl} ref={menuRef}>
             {recipeNames.map((recipe: string, index: number) => (
               <Menu.Item
                 key={index}


### PR DESCRIPTION
## What does this pull request change?

When clicking the header menu, and click away, the header menu now disappears. 

Before you had to click on the menu again to make it go away. 

## Why is this pull request needed?

## Issues related to this change

