### PR TITLE
chore: upgrade node docker image

### DIFF
--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:19-bullseye-slim as base
+FROM node:21-bullseye-slim as base
 WORKDIR /code
 COPY package.json ./
 RUN yarn install  --immutable --immutable-cache


### PR DESCRIPTION
## What does this pull request change?

* Upgrade node docker image to fix 

```
error vite@5.0.0: The engine "node" is incompatible with this module. Expected version "^18.0.0 || >=20.0.0". Got "19.9.0"
```

## Why is this pull request needed?

## Issues related to this change

