### PR TITLE
fix: Bug where header menu did not appear after switching

### DIFF
--- a/e2e/tests/plugin-header-roles_header_example.spec.ts
+++ b/e2e/tests/plugin-header-roles_header_example.spec.ts
@@ -11,10 +11,12 @@ test.beforeEach(async ({ page }) => {
 
 test('Admin role', async ({ page }) => {
   await page.getByRole('button', { name: 'Menu' }).nth(1).click()
-  await expect(page.getByRole('menuitem', { name: 'Yaml' })).toBeVisible()
-  await expect(page.getByRole('menuitem', { name: 'Edit' })).toBeVisible()
-  await expect(page.getByRole('menuitem', { name: 'Explorer' })).toBeVisible()
-  await page.getByRole('menuitem', { name: 'Edit' }).click()
+  await expect(
+    page.getByRole('button', { name: 'Yaml', exact: true })
+  ).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Edit' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Explorer' })).toBeVisible()
+  await page.getByRole('button', { name: 'Edit' }).click()
   await expect(page.getByTestId('form-text-widget-Name')).toHaveValue(
     'elonMusk'
   )
@@ -29,13 +31,15 @@ test('Change to operator role and back', async ({ page }) => {
 
   await test.step('Edit option not visible', async () => {
     await page.getByRole('button', { name: 'Menu' }).nth(1).click()
-    await expect(page.getByRole('menuitem', { name: 'Yaml' })).toBeVisible()
-    await expect(page.getByRole('menuitem', { name: 'Edit' })).not.toBeVisible()
-    await expect(page.getByRole('menuitem', { name: 'Explorer' })).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: 'Yaml', exact: true })
+    ).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Edit' })).not.toBeVisible()
+    await expect(page.getByRole('button', { name: 'Explorer' })).toBeVisible()
   })
 
   await test.step('Edit option not visible through Explorer', async () => {
-    await page.getByRole('menuitem', { name: 'Explorer' }).click()
+    await page.getByRole('button', { name: 'Explorer' }).click()
     await page
       .locator('li')
       .filter({ hasText: /^data sourceDemoDataSource$/ })
@@ -57,19 +61,26 @@ test('Change to operator role and back', async ({ page }) => {
       .getByRole('button')
       .click()
     await page.getByRole('button', { name: 'file elonMusk' }).nth(1).click()
+    await expect(page.getByRole('code')).toBeVisible()
     await page.getByRole('button', { name: 'Menu' }).nth(2).click()
-    await expect(page.getByRole('menuitem', { name: 'Yaml' })).toBeVisible()
-    await expect(page.getByRole('menuitem', { name: 'Edit' })).not.toBeVisible()
-    await expect(page.getByRole('menuitem', { name: 'Explorer' })).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: 'Yaml', exact: true })
+    ).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Edit' })).not.toBeVisible()
+    await expect(page.getByRole('button', { name: 'Explorer' })).toBeVisible()
+    await page.getByRole('button', { name: 'Yaml', exact: true }).click()
   })
 
   await test.step('Change back to admin', async () => {
     await page.getByRole('button', { name: 'Menu' }).nth(1).click()
-    await page.getByRole('menuitem', { name: 'Yaml' }).first().click()
+    await page
+      .getByRole('button', { name: 'Yaml', exact: true })
+      .first()
+      .click()
     await page.getByRole('button', { name: 'User' }).click()
     await page.getByLabel('admin').check()
     await page.getByRole('button', { name: 'Save' }).click()
     await page.getByRole('button', { name: 'Menu' }).nth(1).click()
-    await expect(page.getByRole('menuitem', { name: 'Edit' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Edit' })).toBeVisible()
   })
 })

--- a/e2e/tests/plugin-header-roles_header_example.spec.ts
+++ b/e2e/tests/plugin-header-roles_header_example.spec.ts
@@ -1,75 +1,75 @@
-// import { expect, test } from '@playwright/test'
-//
-// test.beforeEach(async ({ page }) => {
-//   await page.goto('http://localhost:3000/')
-//   await page.getByRole('button', { name: 'DemoDataSource' }).click()
-//   await page.getByRole('button', { name: 'plugins' }).click()
-//   await page.getByRole('button', { name: 'header' }).click()
-//   await page.getByRole('button', { name: 'roles_header_example' }).click()
-//   await page.getByRole('button', { name: 'elonMusk' }).click()
-// })
-//
-// test('Admin role', async ({ page }) => {
-//   await page.getByRole('button', { name: 'Menu' }).nth(1).click()
-//   await expect(page.getByRole('menuitem', { name: 'Yaml' })).toBeVisible()
-//   await expect(page.getByRole('menuitem', { name: 'Edit' })).toBeVisible()
-//   await expect(page.getByRole('menuitem', { name: 'Explorer' })).toBeVisible()
-//   await page.getByRole('menuitem', { name: 'Edit' }).click()
-//   await expect(page.getByTestId('form-text-widget-Name')).toHaveValue(
-//     'elonMusk'
-//   )
-// })
-//
-// test('Change to operator role and back', async ({ page }) => {
-//   await test.step('Change role to operator', async () => {
-//     await page.getByRole('button', { name: 'User' }).click()
-//     await page.getByLabel('operator').check()
-//     await page.getByRole('button', { name: 'Save' }).click()
-//   })
-//
-//   await test.step('Edit option not visible', async () => {
-//     await page.getByRole('button', { name: 'Menu' }).nth(1).click()
-//     await expect(page.getByRole('menuitem', { name: 'Yaml' })).toBeVisible()
-//     await expect(page.getByRole('menuitem', { name: 'Edit' })).not.toBeVisible()
-//     await expect(page.getByRole('menuitem', { name: 'Explorer' })).toBeVisible()
-//   })
-//
-//   await test.step('Edit option not visible through Explorer', async () => {
-//     await page.getByRole('menuitem', { name: 'Explorer' }).click()
-//     await page
-//       .locator('li')
-//       .filter({ hasText: /^data sourceDemoDataSource$/ })
-//       .getByRole('button')
-//       .click()
-//     await page
-//       .locator('li')
-//       .filter({ hasText: /^root packageplugins$/ })
-//       .getByRole('button')
-//       .click()
-//     await page
-//       .locator('li')
-//       .filter({ hasText: /^packageheader$/ })
-//       .getByRole('button')
-//       .click()
-//     await page
-//       .locator('li')
-//       .filter({ hasText: /^packageroles_header_example$/ })
-//       .getByRole('button')
-//       .click()
-//     await page.getByRole('button', { name: 'file elonMusk' }).nth(1).click()
-//     await page.getByRole('button', { name: 'Menu' }).nth(2).click()
-//     await expect(page.getByRole('menuitem', { name: 'Yaml' })).toBeVisible()
-//     await expect(page.getByRole('menuitem', { name: 'Edit' })).not.toBeVisible()
-//     await expect(page.getByRole('menuitem', { name: 'Explorer' })).toBeVisible()
-//   })
-//
-//   await test.step('Change back to admin', async () => {
-//     await page.getByRole('button', { name: 'Menu' }).nth(1).click()
-//     await page.getByRole('menuitem', { name: 'Yaml' }).first().click()
-//     await page.getByRole('button', { name: 'User' }).click()
-//     await page.getByLabel('admin').check()
-//     await page.getByRole('button', { name: 'Save' }).click()
-//     await page.getByRole('button', { name: 'Menu' }).nth(1).click()
-//     await expect(page.getByRole('menuitem', { name: 'Edit' })).toBeVisible()
-//   })
-// })
+import { expect, test } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('http://localhost:3000/')
+  await page.getByRole('button', { name: 'DemoDataSource' }).click()
+  await page.getByRole('button', { name: 'plugins' }).click()
+  await page.getByRole('button', { name: 'header' }).click()
+  await page.getByRole('button', { name: 'roles_header_example' }).click()
+  await page.getByRole('button', { name: 'elonMusk' }).click()
+})
+
+test('Admin role', async ({ page }) => {
+  await page.getByRole('button', { name: 'Menu' }).nth(1).click()
+  await expect(page.getByRole('menuitem', { name: 'Yaml' })).toBeVisible()
+  await expect(page.getByRole('menuitem', { name: 'Edit' })).toBeVisible()
+  await expect(page.getByRole('menuitem', { name: 'Explorer' })).toBeVisible()
+  await page.getByRole('menuitem', { name: 'Edit' }).click()
+  await expect(page.getByTestId('form-text-widget-Name')).toHaveValue(
+    'elonMusk'
+  )
+})
+
+test('Change to operator role and back', async ({ page }) => {
+  await test.step('Change role to operator', async () => {
+    await page.getByRole('button', { name: 'User' }).click()
+    await page.getByLabel('operator').check()
+    await page.getByRole('button', { name: 'Save' }).click()
+  })
+
+  await test.step('Edit option not visible', async () => {
+    await page.getByRole('button', { name: 'Menu' }).nth(1).click()
+    await expect(page.getByRole('menuitem', { name: 'Yaml' })).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: 'Edit' })).not.toBeVisible()
+    await expect(page.getByRole('menuitem', { name: 'Explorer' })).toBeVisible()
+  })
+
+  await test.step('Edit option not visible through Explorer', async () => {
+    await page.getByRole('menuitem', { name: 'Explorer' }).click()
+    await page
+      .locator('li')
+      .filter({ hasText: /^data sourceDemoDataSource$/ })
+      .getByRole('button')
+      .click()
+    await page
+      .locator('li')
+      .filter({ hasText: /^root packageplugins$/ })
+      .getByRole('button')
+      .click()
+    await page
+      .locator('li')
+      .filter({ hasText: /^packageheader$/ })
+      .getByRole('button')
+      .click()
+    await page
+      .locator('li')
+      .filter({ hasText: /^packageroles_header_example$/ })
+      .getByRole('button')
+      .click()
+    await page.getByRole('button', { name: 'file elonMusk' }).nth(1).click()
+    await page.getByRole('button', { name: 'Menu' }).nth(2).click()
+    await expect(page.getByRole('menuitem', { name: 'Yaml' })).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: 'Edit' })).not.toBeVisible()
+    await expect(page.getByRole('menuitem', { name: 'Explorer' })).toBeVisible()
+  })
+
+  await test.step('Change back to admin', async () => {
+    await page.getByRole('button', { name: 'Menu' }).nth(1).click()
+    await page.getByRole('menuitem', { name: 'Yaml' }).first().click()
+    await page.getByRole('button', { name: 'User' }).click()
+    await page.getByLabel('admin').check()
+    await page.getByRole('button', { name: 'Save' }).click()
+    await page.getByRole('button', { name: 'Menu' }).nth(1).click()
+    await expect(page.getByRole('menuitem', { name: 'Edit' })).toBeVisible()
+  })
+})

--- a/e2e/tests/plugin-header-roles_header_example.spec.ts
+++ b/e2e/tests/plugin-header-roles_header_example.spec.ts
@@ -1,75 +1,75 @@
-import { expect, test } from '@playwright/test'
-
-test.beforeEach(async ({ page }) => {
-  await page.goto('http://localhost:3000/')
-  await page.getByRole('button', { name: 'DemoDataSource' }).click()
-  await page.getByRole('button', { name: 'plugins' }).click()
-  await page.getByRole('button', { name: 'header' }).click()
-  await page.getByRole('button', { name: 'roles_header_example' }).click()
-  await page.getByRole('button', { name: 'elonMusk' }).click()
-})
-
-test('Admin role', async ({ page }) => {
-  await page.getByRole('button', { name: 'Menu' }).nth(1).click()
-  await expect(page.getByRole('menuitem', { name: 'Yaml' })).toBeVisible()
-  await expect(page.getByRole('menuitem', { name: 'Edit' })).toBeVisible()
-  await expect(page.getByRole('menuitem', { name: 'Explorer' })).toBeVisible()
-  await page.getByRole('menuitem', { name: 'Edit' }).click()
-  await expect(page.getByTestId('form-text-widget-Name')).toHaveValue(
-    'elonMusk'
-  )
-})
-
-test('Change to operator role and back', async ({ page }) => {
-  await test.step('Change role to operator', async () => {
-    await page.getByRole('button', { name: 'User' }).click()
-    await page.getByLabel('operator').check()
-    await page.getByRole('button', { name: 'Save' }).click()
-  })
-
-  await test.step('Edit option not visible', async () => {
-    await page.getByRole('button', { name: 'Menu' }).nth(1).click()
-    await expect(page.getByRole('menuitem', { name: 'Yaml' })).toBeVisible()
-    await expect(page.getByRole('menuitem', { name: 'Edit' })).not.toBeVisible()
-    await expect(page.getByRole('menuitem', { name: 'Explorer' })).toBeVisible()
-  })
-
-  await test.step('Edit option not visible through Explorer', async () => {
-    await page.getByRole('menuitem', { name: 'Explorer' }).click()
-    await page
-      .locator('li')
-      .filter({ hasText: /^data sourceDemoDataSource$/ })
-      .getByRole('button')
-      .click()
-    await page
-      .locator('li')
-      .filter({ hasText: /^root packageplugins$/ })
-      .getByRole('button')
-      .click()
-    await page
-      .locator('li')
-      .filter({ hasText: /^packageheader$/ })
-      .getByRole('button')
-      .click()
-    await page
-      .locator('li')
-      .filter({ hasText: /^packageroles_header_example$/ })
-      .getByRole('button')
-      .click()
-    await page.getByRole('button', { name: 'file elonMusk' }).nth(1).click()
-    await page.getByRole('button', { name: 'Menu' }).nth(2).click()
-    await expect(page.getByRole('menuitem', { name: 'Yaml' })).toBeVisible()
-    await expect(page.getByRole('menuitem', { name: 'Edit' })).not.toBeVisible()
-    await expect(page.getByRole('menuitem', { name: 'Explorer' })).toBeVisible()
-  })
-
-  await test.step('Change back to admin', async () => {
-    await page.getByRole('button', { name: 'Menu' }).nth(1).click()
-    await page.getByRole('menuitem', { name: 'Yaml' }).first().click()
-    await page.getByRole('button', { name: 'User' }).click()
-    await page.getByLabel('admin').check()
-    await page.getByRole('button', { name: 'Save' }).click()
-    await page.getByRole('button', { name: 'Menu' }).nth(1).click()
-    await expect(page.getByRole('menuitem', { name: 'Edit' })).toBeVisible()
-  })
-})
+// import { expect, test } from '@playwright/test'
+//
+// test.beforeEach(async ({ page }) => {
+//   await page.goto('http://localhost:3000/')
+//   await page.getByRole('button', { name: 'DemoDataSource' }).click()
+//   await page.getByRole('button', { name: 'plugins' }).click()
+//   await page.getByRole('button', { name: 'header' }).click()
+//   await page.getByRole('button', { name: 'roles_header_example' }).click()
+//   await page.getByRole('button', { name: 'elonMusk' }).click()
+// })
+//
+// test('Admin role', async ({ page }) => {
+//   await page.getByRole('button', { name: 'Menu' }).nth(1).click()
+//   await expect(page.getByRole('menuitem', { name: 'Yaml' })).toBeVisible()
+//   await expect(page.getByRole('menuitem', { name: 'Edit' })).toBeVisible()
+//   await expect(page.getByRole('menuitem', { name: 'Explorer' })).toBeVisible()
+//   await page.getByRole('menuitem', { name: 'Edit' }).click()
+//   await expect(page.getByTestId('form-text-widget-Name')).toHaveValue(
+//     'elonMusk'
+//   )
+// })
+//
+// test('Change to operator role and back', async ({ page }) => {
+//   await test.step('Change role to operator', async () => {
+//     await page.getByRole('button', { name: 'User' }).click()
+//     await page.getByLabel('operator').check()
+//     await page.getByRole('button', { name: 'Save' }).click()
+//   })
+//
+//   await test.step('Edit option not visible', async () => {
+//     await page.getByRole('button', { name: 'Menu' }).nth(1).click()
+//     await expect(page.getByRole('menuitem', { name: 'Yaml' })).toBeVisible()
+//     await expect(page.getByRole('menuitem', { name: 'Edit' })).not.toBeVisible()
+//     await expect(page.getByRole('menuitem', { name: 'Explorer' })).toBeVisible()
+//   })
+//
+//   await test.step('Edit option not visible through Explorer', async () => {
+//     await page.getByRole('menuitem', { name: 'Explorer' }).click()
+//     await page
+//       .locator('li')
+//       .filter({ hasText: /^data sourceDemoDataSource$/ })
+//       .getByRole('button')
+//       .click()
+//     await page
+//       .locator('li')
+//       .filter({ hasText: /^root packageplugins$/ })
+//       .getByRole('button')
+//       .click()
+//     await page
+//       .locator('li')
+//       .filter({ hasText: /^packageheader$/ })
+//       .getByRole('button')
+//       .click()
+//     await page
+//       .locator('li')
+//       .filter({ hasText: /^packageroles_header_example$/ })
+//       .getByRole('button')
+//       .click()
+//     await page.getByRole('button', { name: 'file elonMusk' }).nth(1).click()
+//     await page.getByRole('button', { name: 'Menu' }).nth(2).click()
+//     await expect(page.getByRole('menuitem', { name: 'Yaml' })).toBeVisible()
+//     await expect(page.getByRole('menuitem', { name: 'Edit' })).not.toBeVisible()
+//     await expect(page.getByRole('menuitem', { name: 'Explorer' })).toBeVisible()
+//   })
+//
+//   await test.step('Change back to admin', async () => {
+//     await page.getByRole('button', { name: 'Menu' }).nth(1).click()
+//     await page.getByRole('menuitem', { name: 'Yaml' }).first().click()
+//     await page.getByRole('button', { name: 'User' }).click()
+//     await page.getByLabel('admin').check()
+//     await page.getByRole('button', { name: 'Save' }).click()
+//     await page.getByRole('button', { name: 'Menu' }).nth(1).click()
+//     await expect(page.getByRole('menuitem', { name: 'Edit' })).toBeVisible()
+//   })
+// })

--- a/e2e/tests/plugin-header.spec.ts
+++ b/e2e/tests/plugin-header.spec.ts
@@ -50,6 +50,6 @@ test('About', async ({ page }) => {
 
 test('Recipe list', async ({ page }) => {
   await page.getByRole('button', { name: 'Menu' }).nth(1).click()
-  await page.getByRole('menuitem', { name: 'Edit' }).click()
+  await page.getByRole('button', { name: 'Edit' }).click()
   await expect(page.getByTestId('form-text-widget-Name')).toHaveValue('example')
 })

--- a/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/containers/equallySpacedSignal.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/containers/equallySpacedSignal.recipe.json
@@ -5,7 +5,6 @@
     "name": "UiRecipesSelector",
     "type": "CORE:UiRecipe",
     "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
-    "showRefreshButton": true,
     "config": {
       "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
       "items": [
@@ -34,7 +33,8 @@
     {
       "name": "Plot",
       "type": "CORE:UiRecipe",
-      "plugin": "marmo-ess-plot-view"
+      "plugin": "marmo-ess-plot-view",
+      "showRefreshButton": true
     },
     {
       "name": "Table",

--- a/packages/dm-core-plugins/src/header/HeaderPlugin.tsx
+++ b/packages/dm-core-plugins/src/header/HeaderPlugin.tsx
@@ -7,7 +7,7 @@ import {
   useDocument,
   useUiPlugins,
 } from '@development-framework/dm-core'
-import { Icon, Menu, TopBar } from '@equinor/eds-core-react'
+import { Button, Icon, Popover, TopBar } from '@equinor/eds-core-react'
 import React, { useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
 
@@ -73,6 +73,7 @@ export default (props: IUIPlugin): React.ReactElement => {
     component: () => <div></div>,
     config: {},
   })
+  const [selectedRecipeName, setSelectedRecipeName] = useState<string>('')
 
   function getRecipeConfigAndPlugin(
     recipeName: string
@@ -85,6 +86,7 @@ export default (props: IUIPlugin): React.ReactElement => {
       config: recipe?.config ?? {},
     }
   }
+
   const menuRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
     if (!isBlueprintLoading) {
@@ -94,6 +96,7 @@ export default (props: IUIPlugin): React.ReactElement => {
           )
         : uiRecipes[0]
       setSelectedRecipe(getRecipeConfigAndPlugin(defaultRecipe.name))
+      setSelectedRecipeName(defaultRecipe.name)
     }
     const handleMouseDown = (event: MouseEvent) => {
       if (menuRef.current && !menuRef.current.contains(event.target as Node))
@@ -115,7 +118,6 @@ export default (props: IUIPlugin): React.ReactElement => {
     config.uiRecipesList.length > 0
       ? config.uiRecipesList
       : uiRecipes.map((recipe: TUiRecipe) => recipe.name)
-
   return (
     <div>
       <TopBar
@@ -136,19 +138,40 @@ export default (props: IUIPlugin): React.ReactElement => {
           >
             <Icon data={menu} size={32} title="Menu" />
           </ClickableIcon>
-          <Menu open={appSelectorOpen} anchorEl={anchorEl} ref={menuRef}>
-            {recipeNames.map((recipe: string, index: number) => (
-              <Menu.Item
-                key={index}
-                onClick={() => {
-                  setSelectedRecipe(getRecipeConfigAndPlugin(recipe))
-                  setAppSelectorOpen(false)
+          <Popover
+            open={appSelectorOpen}
+            anchorEl={anchorEl}
+            ref={menuRef}
+            trapFocus
+            onClose={() => setAppSelectorOpen(false)}
+          >
+            <Popover.Content>
+              <div
+                style={{
+                  maxWidth: '300px',
+                  display: 'flex',
+                  flexWrap: 'wrap',
                 }}
               >
-                {recipe}
-              </Menu.Item>
-            ))}
-          </Menu>
+                {recipeNames.map((recipe: string, index: number) => (
+                  <Button
+                    style={{ flexBasis: '100%', marginTop: '5px' }}
+                    variant={
+                      selectedRecipeName == recipe ? 'contained' : 'outlined'
+                    }
+                    key={index}
+                    onClick={() => {
+                      setSelectedRecipe(getRecipeConfigAndPlugin(recipe))
+                      setSelectedRecipeName(recipe)
+                      setAppSelectorOpen(false)
+                    }}
+                  >
+                    {recipe}
+                  </Button>
+                ))}
+              </div>
+            </Popover.Content>
+          </Popover>
           <h4 style={{ paddingLeft: 10 }}>{entity.label}</h4>
         </TopBar.Header>
         <TopBar.Actions>

--- a/packages/dm-core-plugins/src/header/HeaderPlugin.tsx
+++ b/packages/dm-core-plugins/src/header/HeaderPlugin.tsx
@@ -7,11 +7,11 @@ import {
   useDocument,
   useUiPlugins,
 } from '@development-framework/dm-core'
-import { Button, Icon, Popover, TopBar } from '@equinor/eds-core-react'
+import { Icon, Popover, TopBar } from '@equinor/eds-core-react'
 import React, { useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
 
-import { account_circle, menu, info_circle } from '@equinor/eds-icons'
+import { account_circle, info_circle, menu } from '@equinor/eds-icons'
 
 import { AboutDialog } from './components/AboutDialog'
 import { UserInfoDialog } from './components/UserInfoDialog'
@@ -24,6 +24,23 @@ const Icons = styled.div`
 
   > * {
     margin-left: 40px;
+  }
+`
+
+const MenuButton = styled.button<{ $active: boolean }>`
+  appearance: none;
+  padding: 1rem 1rem;
+  background-color: ${(props) =>
+    props.$active ? 'rgba(222, 237, 238, 1)' : 'transparent'};
+  color: ${(props) => (props.$active ? 'rgba(0, 79, 85, 1)' : 'black')};
+  border: 0;
+  cursor: pointer;
+  text-align: left;
+  font-family: 'Equinor', sans-serif;
+
+  &:hover {
+    background-color: rgba(222, 237, 238, 1);
+    color: rgba(0, 79, 85, 1);
   }
 `
 
@@ -145,32 +162,21 @@ export default (props: IUIPlugin): React.ReactElement => {
             trapFocus
             onClose={() => setAppSelectorOpen(false)}
           >
-            <Popover.Content>
-              <div
-                style={{
-                  maxWidth: '300px',
-                  display: 'flex',
-                  flexWrap: 'wrap',
-                }}
-              >
-                {recipeNames.map((recipe: string, index: number) => (
-                  <Button
-                    style={{ flexBasis: '100%', marginTop: '5px' }}
-                    variant={
-                      selectedRecipeName == recipe ? 'contained' : 'outlined'
-                    }
-                    key={index}
-                    onClick={() => {
-                      setSelectedRecipe(getRecipeConfigAndPlugin(recipe))
-                      setSelectedRecipeName(recipe)
-                      setAppSelectorOpen(false)
-                    }}
-                  >
-                    {recipe}
-                  </Button>
-                ))}
-              </div>
-            </Popover.Content>
+            <div style={{ display: 'flex', flexDirection: 'column' }}>
+              {recipeNames.map((recipe: string, index: number) => (
+                <MenuButton
+                  $active={selectedRecipeName === recipe}
+                  key={index}
+                  onClick={() => {
+                    setSelectedRecipe(getRecipeConfigAndPlugin(recipe))
+                    setSelectedRecipeName(recipe)
+                    setAppSelectorOpen(false)
+                  }}
+                >
+                  {recipe}
+                </MenuButton>
+              ))}
+            </div>
           </Popover>
           <h4 style={{ paddingLeft: 10 }}>{entity.label}</h4>
         </TopBar.Header>

--- a/packages/dm-core-plugins/src/header/HeaderPlugin.tsx
+++ b/packages/dm-core-plugins/src/header/HeaderPlugin.tsx
@@ -7,7 +7,7 @@ import {
   useDocument,
   useUiPlugins,
 } from '@development-framework/dm-core'
-import { Icon, Popover, TopBar } from '@equinor/eds-core-react'
+import { Icon, Popover, TopBar, Typography } from '@equinor/eds-core-react'
 import React, { useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
 
@@ -29,18 +29,21 @@ const Icons = styled.div`
 
 const MenuButton = styled.button<{ $active: boolean }>`
   appearance: none;
-  padding: 1rem 1rem;
   background-color: ${(props) =>
-    props.$active ? 'rgba(222, 237, 238, 1)' : 'transparent'};
+    props.$active ? 'rgba(230,250,236,1)' : 'transparent'};
   color: ${(props) => (props.$active ? 'rgba(0, 79, 85, 1)' : 'black')};
   border: 0;
   cursor: pointer;
+  min-width: 150px;
   text-align: left;
+  padding: 1rem 3rem 1rem 3rem;
   font-family: 'Equinor', sans-serif;
 
   &:hover {
-    background-color: rgba(222, 237, 238, 1);
-    color: rgba(0, 79, 85, 1);
+    background-color: ${(props) =>
+      !props.$active ? 'rgba(220,220,220,255)' : 'rgba(230,250,236,1)'};
+    color: ${(props) =>
+      !props.$active ? 'rgba(61,61,61,255)' : 'rgba(0, 79, 85, 1)'};
   }
 `
 
@@ -173,7 +176,7 @@ export default (props: IUIPlugin): React.ReactElement => {
                     setAppSelectorOpen(false)
                   }}
                 >
-                  {recipe}
+                  <Typography>{recipe}</Typography>
                 </MenuButton>
               ))}
             </div>


### PR DESCRIPTION
## What does this pull request change?

Fixes bug where one can not select application again after switching. 
Did this by changing from eds.Menu to eds.Popover. 

Looks a bit different now as well. 

<img width="690" alt="image" src="https://github.com/equinor/dm-core-packages/assets/37016135/c50cf58a-4c56-4016-b971-7f0c0dc0a987">



## Why is this pull request needed?

## Issues related to this change
#771 

