### PR TITLE
fix(Dialog): DialogActions float over content

### DIFF
--- a/packages/dm-core/src/components/Dialog.tsx
+++ b/packages/dm-core/src/components/Dialog.tsx
@@ -13,6 +13,7 @@ Dialog.Header = styled(EdsDialog.Header)``
 Dialog.Title = styled(EdsDialog.Title)``
 Dialog.CustomContent = styled(EdsDialog.CustomContent)`
   flex-grow: 2;
+  min-height: auto;
 `
 Dialog.Actions = styled(EdsDialog.Actions)`
   display: flex;


### PR DESCRIPTION
Bug with EDS Dialog and Dialog actions floating over content when dialog becomes scrollable

## Issues related to this change
closes #752 

