### PR TITLE
fix(Sidebar): parnet menu items shouldn't be clickable

### DIFF
--- a/packages/dm-core-plugins/src/view_selector/Sidebar.tsx
+++ b/packages/dm-core-plugins/src/view_selector/Sidebar.tsx
@@ -34,8 +34,6 @@ export const Sidebar = (props: {
                   }
                   label={config.label}
                   role="tab"
-                  onClick={() => setSelectedViewId(config.viewId)}
-                  active={selectedViewId === config.viewId}
                 >
                   {config.subItems.map((subConfig: TItemData, index) => {
                     const subViewId = config.viewId + subConfig.viewConfig.scope


### PR DESCRIPTION
Make parent menu entries in Sidebar™ not be clickable.