### PR TITLE
fix: format logs from job as lines

### DIFF
--- a/packages/dm-core-plugins/src/job/LogBlock.tsx
+++ b/packages/dm-core-plugins/src/job/LogBlock.tsx
@@ -52,7 +52,11 @@ export const LogBlock = (props: LogBlockProps) => {
         </Typography>
       </div>
       <FormattedLogContainer style={style}>
-        <pre>{JSON.stringify(content, null, 2)}</pre>
+        {content.constructor === Array ? (
+          content.map((line) => <pre key={line}>{line}</pre>)
+        ) : (
+          <pre>{JSON.stringify(content, null, 2)}</pre>
+        )}
       </FormattedLogContainer>
     </>
   )


### PR DESCRIPTION
## What does this pull request change?
Formats the logs from jobs as lines instead of array

## Why is this pull request needed?

## Issues related to this change

