### PR TITLE
refactor: avoid prop drilling

### DIFF
--- a/e2e/tests/plugin-form-Nested.spec.ts
+++ b/e2e/tests/plugin-form-Nested.spec.ts
@@ -35,7 +35,7 @@ test('Change owner', async () => {
     .fill('Jacob')
   await page
     .getByRole('tabpanel')
-    .getByTestId('form-text-widget-Phone Number (optional)')
+    .getByTestId('form-number-widget-Phone Number (optional)')
     .fill('1234')
   await page.getByRole('button', { name: 'Submit' }).click()
   await expect(page.getByRole('alert')).toHaveText(['Document updated'])
@@ -48,7 +48,7 @@ test('Change owner', async () => {
   await expect(
     page
       .getByRole('tabpanel')
-      .getByTestId('form-text-widget-Phone Number (optional)')
+      .getByTestId('form-number-widget-Phone Number (optional)')
   ).toHaveValue('1234')
 })
 
@@ -64,7 +64,7 @@ test('Hiring a CEO', async () => {
     .fill('Donald')
   await page
     .getByRole('tabpanel')
-    .getByTestId('form-text-widget-Phone Number (optional)')
+    .getByTestId('form-number-widget-Phone Number (optional)')
     .fill('99887766')
   await page.getByRole('button', { name: 'Submit' }).click()
   await expect(page.getByRole('alert')).toHaveText(['Document updated'])
@@ -78,7 +78,7 @@ test('Hiring a CEO', async () => {
   await expect(
     page
       .getByRole('tabpanel')
-      .getByTestId('form-text-widget-Phone Number (optional)')
+      .getByTestId('form-number-widget-Phone Number (optional)')
   ).toHaveValue('99887766')
   await page.getByLabel('Close ceo').click()
   await page
@@ -106,7 +106,7 @@ test('Adding a trainee', async () => {
   await page.getByTestId('trainee').getByLabel('Add and save').click()
   await trainee.getByTestId('form-text-widget-Name').fill('Peter Pan')
   await trainee
-    .getByTestId('form-text-widget-Phone Number (optional)')
+    .getByTestId('form-number-widget-Phone Number (optional)')
     .fill('123')
   await trainee.getByTestId('form-submit').click()
   await expect(page.getByRole('alert')).toHaveText(['Document updated'])
@@ -117,7 +117,7 @@ test('Adding a trainee', async () => {
     'Peter Pan'
   )
   await expect(
-    trainee.getByTestId('form-text-widget-Phone Number (optional)')
+    trainee.getByTestId('form-number-widget-Phone Number (optional)')
   ).toHaveValue('123')
 })
 
@@ -185,7 +185,7 @@ test('New customer', async () => {
   await lastTabPanel.getByRole('button', { name: 'Open item' }).last().click()
   await lastTabPanel.getByTestId('form-text-widget-Name').fill('Lewis')
   await lastTabPanel
-    .getByTestId('form-text-widget-Phone Number (optional)')
+    .getByTestId('form-number-widget-Phone Number (optional)')
     .fill('12345678')
   await lastTabPanel.getByRole('button', { name: 'Submit' }).click()
   await expect(page.getByRole('alert')).toHaveText(['Document updated'])
@@ -203,6 +203,6 @@ test('New customer', async () => {
     'Lewis'
   )
   await expect(
-    lastTabPanel.getByTestId('form-text-widget-Phone Number (optional)')
+    lastTabPanel.getByTestId('form-number-widget-Phone Number (optional)')
   ).toHaveValue('12345678')
 })

--- a/e2e/tests/plugin-form-model_uncontained-complex_attribute.spec.ts
+++ b/e2e/tests/plugin-form-model_uncontained-complex_attribute.spec.ts
@@ -24,7 +24,7 @@ test('Model uncontained complex attribute', async ({ page }) => {
       'CaptainJackSparrow'
     )
     await expect(
-      page.getByTestId('form-text-widget-Phone Number (optional)')
+      page.getByTestId('form-number-widget-Phone Number (optional)')
     ).toBeEmpty()
     await page.getByLabel('Close captain').click()
   })
@@ -66,7 +66,7 @@ test('Model uncontained complex attribute', async ({ page }) => {
       'Barbossa'
     )
     await expect(
-      page.getByTestId('form-text-widget-Phone Number (optional)')
+      page.getByTestId('form-number-widget-Phone Number (optional)')
     ).toHaveValue('12345678')
   })
 })

--- a/e2e/tests/plugin-view_selector-car_garage.spec.ts
+++ b/e2e/tests/plugin-view_selector-car_garage.spec.ts
@@ -93,7 +93,7 @@ test('View selector - car garage', async ({ page }) => {
       .click()
     await page.getByRole('tab', { name: 'Dimensions' }).click()
     await page
-      .getByTestId('form-text-widget-Length (mm) (optional)')
+      .getByTestId('form-number-widget-Length (mm) (optional)')
       .last()
       .fill('4250')
     await page.getByRole('button', { name: 'Submit' }).click()
@@ -144,7 +144,7 @@ test('View selector - car garage', async ({ page }) => {
     ).toHaveValue('2025-06-01')
     await page.getByRole('tab', { name: 'Dimensions' }).click()
     await expect(
-      page.getByTestId('form-text-widget-Length (mm) (optional)').last()
+      page.getByTestId('form-number-widget-Length (mm) (optional)').last()
     ).toHaveValue('4500')
     await page.getByRole('tab', { name: 'Home' }).click()
     await page

--- a/example/app/data/DemoDataSource/recipes/plugins/form/enums/enums.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/enums/enums.recipe.json
@@ -47,7 +47,7 @@
             "name": "singleString",
             "type": "PLUGINS:dm-core-plugins/form/fields/StringField",
             "widget": "SelectWidget",
-            "widgetConfig": {
+            "config": {
               "type": "PLUGINS:dm-core-plugins/form/widgets/SelectWidgetConfig",
               "multiline": false
             }
@@ -56,7 +56,7 @@
             "name": "manyStrings",
             "type": "PLUGINS:dm-core-plugins/form/fields/StringField",
             "widget": "SelectWidget",
-            "widgetConfig": {
+            "config": {
               "type": "PLUGINS:dm-core-plugins/form/widgets/SelectWidgetConfig",
               "multiline": true
             }

--- a/example/app/data/DemoDataSource/recipes/plugins/form/simple/simple.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/simple/simple.recipe.json
@@ -13,7 +13,7 @@
         {
           "name": "date",
           "type": "PLUGINS:dm-core-plugins/form/fields/StringField",
-          "format": "datetime"
+          "widget": "DateTimeWidget"
         }
       ]
     }

--- a/packages/dm-core-plugins/blueprints/form/fields/Field.json
+++ b/packages/dm-core-plugins/blueprints/form/fields/Field.json
@@ -23,7 +23,7 @@
       "attributeType": "boolean"
     },
     {
-      "name": "widgetConfig",
+      "name": "config",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
       "attributeType": "object",
       "contained": true,

--- a/packages/dm-core-plugins/src/form/FormPlugin.tsx
+++ b/packages/dm-core-plugins/src/form/FormPlugin.tsx
@@ -2,15 +2,15 @@ import * as React from 'react'
 
 import { IUIPlugin, Loading, useDocument } from '@development-framework/dm-core'
 import { Form } from './components/Form'
-import { TConfig } from './types'
+import { TFormConfig } from './types'
 
-export const defaultConfig: TConfig = {
+export const defaultConfig: TFormConfig = {
   attributes: [],
   fields: [],
 }
 
 export const FormPlugin = (props: IUIPlugin) => {
-  const config: TConfig = { ...defaultConfig, ...props.config }
+  const config: TFormConfig = { ...defaultConfig, ...props.config }
   const { document, isLoading, updateDocument, error } = useDocument<any>(
     props.idReference,
     0

--- a/packages/dm-core-plugins/src/form/FormPlugin.tsx
+++ b/packages/dm-core-plugins/src/form/FormPlugin.tsx
@@ -2,15 +2,8 @@ import * as React from 'react'
 
 import { IUIPlugin, Loading, useDocument } from '@development-framework/dm-core'
 import { Form } from './components/Form'
-import { TFormConfig } from './types'
-
-export const defaultConfig: TFormConfig = {
-  attributes: [],
-  fields: [],
-}
 
 export const FormPlugin = (props: IUIPlugin) => {
-  const config: TFormConfig = { ...defaultConfig, ...props.config }
   const { document, isLoading, updateDocument, error } = useDocument<any>(
     props.idReference,
     0
@@ -28,7 +21,7 @@ export const FormPlugin = (props: IUIPlugin) => {
       onOpen={props.onOpen}
       idReference={props.idReference}
       type={document.type}
-      config={config}
+      config={props.config}
       formData={document}
       onSubmit={handleOnSubmit}
     />

--- a/packages/dm-core-plugins/src/form/components/AttributeList.tsx
+++ b/packages/dm-core-plugins/src/form/components/AttributeList.tsx
@@ -1,16 +1,15 @@
 import { TAttribute, TBlueprint } from '@development-framework/dm-core'
 import React from 'react'
 import { AttributeField } from '../fields/AttributeField'
-import { TFormConfig } from '../types'
+import { useRegistryContext } from '../context/RegistryContext'
 
 export const AttributeList = (props: {
   namePath: string
-  config: TFormConfig | undefined
   blueprint: TBlueprint
 }) => {
-  const { namePath, config, blueprint } = props
+  const { namePath, blueprint } = props
   const prefix = namePath === '' ? `` : `${namePath}.`
-
+  const { config } = useRegistryContext()
   const attributes: TAttribute[] | undefined = blueprint.attributes
 
   let filteredAttributes =

--- a/packages/dm-core-plugins/src/form/components/AttributeList.tsx
+++ b/packages/dm-core-plugins/src/form/components/AttributeList.tsx
@@ -1,11 +1,11 @@
 import { TAttribute, TBlueprint } from '@development-framework/dm-core'
 import React from 'react'
 import { AttributeField } from '../fields/AttributeField'
-import { TConfig } from '../types'
+import { TFormConfig } from '../types'
 
 export const AttributeList = (props: {
   namePath: string
-  config: TConfig | undefined
+  config: TFormConfig | undefined
   blueprint: TBlueprint
 }) => {
   const { namePath, config, blueprint } = props
@@ -46,8 +46,6 @@ export const AttributeList = (props: {
               namePath={`${prefix}${attribute.name}`}
               attribute={attribute}
               uiAttribute={uiAttribute}
-              readOnly={config?.readOnly}
-              showExpanded={config?.showExpanded || true}
             />
           </div>
         )

--- a/packages/dm-core-plugins/src/form/components/Form.test.tsx
+++ b/packages/dm-core-plugins/src/form/components/Form.test.tsx
@@ -76,6 +76,7 @@ describe('Form', () => {
       ])
       const formData = {
         child: {
+          type: 'Child',
           bar: '',
         },
       }

--- a/packages/dm-core-plugins/src/form/components/Form.tsx
+++ b/packages/dm-core-plugins/src/form/components/Form.tsx
@@ -21,8 +21,15 @@ const Wrapper = styled.div`
   flex-direction: column;
 `
 
+export const defaultConfig: TFormConfig = {
+  attributes: [],
+  fields: [],
+  readOnly: false,
+  showExpanded: true,
+}
+
 export const Form = (props: TFormProps) => {
-  const { type, formData, config, onSubmit, idReference, onOpen } = props
+  const { type, formData, onSubmit, idReference, onOpen } = props
   const { blueprint, isLoading, error } = useBlueprint(type)
 
   const methods = useForm({
@@ -51,19 +58,14 @@ export const Form = (props: TFormProps) => {
 
   if (error) throw new Error(JSON.stringify(error, null, 2))
 
-  const defaultConfig: TFormConfig = {
-    attributes: [],
-    fields: [],
-    readOnly: false,
-    showExpanded: true,
-  }
+  const config: TFormConfig = { ...defaultConfig, ...props.config }
 
   return (
     <FormProvider {...methods}>
       <RegistryProvider
         onOpen={onOpen}
         idReference={idReference}
-        config={config ?? defaultConfig}
+        config={{ ...defaultConfig, ...props.config }}
       >
         <Wrapper>
           <AttributeList

--- a/packages/dm-core-plugins/src/form/components/Form.tsx
+++ b/packages/dm-core-plugins/src/form/components/Form.tsx
@@ -68,11 +68,7 @@ export const Form = (props: TFormProps) => {
         config={{ ...defaultConfig, ...props.config }}
       >
         <Wrapper>
-          <AttributeList
-            namePath={namePath}
-            config={config}
-            blueprint={blueprint}
-          />
+          <AttributeList namePath={namePath} blueprint={blueprint} />
           {!config?.readOnly && (
             <Button
               type="submit"

--- a/packages/dm-core-plugins/src/form/components/Form.tsx
+++ b/packages/dm-core-plugins/src/form/components/Form.tsx
@@ -9,7 +9,7 @@ import { Button } from '@equinor/eds-core-react'
 import { FormProvider, useForm } from 'react-hook-form'
 import styled from 'styled-components'
 import { RegistryProvider } from '../context/RegistryContext'
-import { TFormProps } from '../types'
+import { TFormConfig, TFormProps } from '../types'
 import { AttributeList } from './AttributeList'
 
 const Wrapper = styled.div`
@@ -51,9 +51,20 @@ export const Form = (props: TFormProps) => {
 
   if (error) throw new Error(JSON.stringify(error, null, 2))
 
+  const defaultConfig: TFormConfig = {
+    attributes: [],
+    fields: [],
+    readOnly: false,
+    showExpanded: true,
+  }
+
   return (
     <FormProvider {...methods}>
-      <RegistryProvider onOpen={onOpen} idReference={idReference}>
+      <RegistryProvider
+        onOpen={onOpen}
+        idReference={idReference}
+        config={config ?? defaultConfig}
+      >
         <Wrapper>
           <AttributeList
             namePath={namePath}

--- a/packages/dm-core-plugins/src/form/context/RegistryContext.tsx
+++ b/packages/dm-core-plugins/src/form/context/RegistryContext.tsx
@@ -1,9 +1,11 @@
 import { TOnOpen } from '@development-framework/dm-core'
 import React, { createContext, useContext } from 'react'
+import { TFormConfig } from '../types'
 
 type Props = {
   idReference: string
   onOpen?: TOnOpen
+  config: TFormConfig
 }
 
 const RegistryContext = createContext<Props | undefined>(undefined)

--- a/packages/dm-core-plugins/src/form/fields/ArrayField.test.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ArrayField.test.tsx
@@ -9,7 +9,7 @@ import {
 import React from 'react'
 import { Form } from '../components/Form'
 import { mockBlueprintGet, wrapper } from '../test-utils'
-import { TConfig } from '../types'
+import { TFormConfig } from '../types'
 
 const EntityViewMock = jest.fn()
 jest.mock('@development-framework/dm-core', () => ({
@@ -105,7 +105,7 @@ describe('List of objects', () => {
     config,
     onOpen,
   }: {
-    config?: TConfig
+    config?: TFormConfig
     onOpen?: TOnOpen
   }) => {
     const outer = {

--- a/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
@@ -23,13 +23,14 @@ import { AttributeField } from './AttributeField'
 import RemoveObject from '../components/RemoveObjectButton'
 import AddObject from '../components/AddObjectButton'
 import { getWidget } from '../context/WidgetContext'
+import { getDisplayLabel } from '../utils/getDisplayLabel'
 
 const isPrimitiveType = (value: string): boolean => {
   return ['string', 'number', 'integer', 'boolean'].includes(value)
 }
 
 const InlineList = (props: TArrayFieldProps) => {
-  const { namePath, displayLabel, uiAttribute, showExpanded, attribute } = props
+  const { namePath, uiAttribute, showExpanded, attribute } = props
   const { idReference, onOpen } = useRegistryContext()
   const [isExpanded, setIsExpanded] = useState(
     uiAttribute?.showExpanded !== undefined
@@ -40,7 +41,7 @@ const InlineList = (props: TArrayFieldProps) => {
   return (
     <Fieldset>
       <Legend>
-        <Typography bold={true}>{displayLabel}</Typography>
+        <Typography bold={true}>{getDisplayLabel(attribute)}</Typography>
         <TooltipButton
           title="Expand"
           button-variant="ghost_icon"
@@ -62,14 +63,7 @@ const InlineList = (props: TArrayFieldProps) => {
 }
 
 const PrimitiveList = (props: TArrayFieldProps) => {
-  const {
-    namePath,
-    displayLabel,
-    attribute,
-    readOnly,
-    uiAttribute,
-    showExpanded,
-  } = props
+  const { namePath, attribute, readOnly, uiAttribute, showExpanded } = props
 
   const { control } = useFormContext()
   const [isExpanded, setIsExpanded] = useState(
@@ -88,7 +82,7 @@ const PrimitiveList = (props: TArrayFieldProps) => {
   return (
     <Fieldset>
       <Legend>
-        <Typography bold={true}>{displayLabel}</Typography>
+        <Typography bold={true}>{getDisplayLabel(attribute)}</Typography>
         <TooltipButton
           title="Expand"
           button-variant="ghost_icon"
@@ -137,6 +131,7 @@ const PrimitiveList = (props: TArrayFieldProps) => {
                   <Stack grow={1}>
                     <AttributeField
                       namePath={`${namePath}.${pagedIndex}`}
+                      uiAttribute={uiAttribute}
                       attribute={{
                         attributeType: attribute.attributeType,
                         dimensions: '',
@@ -176,7 +171,7 @@ const PrimitiveList = (props: TArrayFieldProps) => {
 }
 
 const OpenList = (props: TArrayFieldProps) => {
-  const { namePath, displayLabel, attribute, uiAttribute, readOnly } = props
+  const { namePath, attribute, uiAttribute, readOnly } = props
 
   const { getValues, setValue } = useFormContext()
   const [initialValue, setInitialValue] = useState(getValues(namePath))
@@ -186,7 +181,7 @@ const OpenList = (props: TArrayFieldProps) => {
   return (
     <Fieldset>
       <Legend>
-        <Typography bold={true}>{displayLabel}</Typography>
+        <Typography bold={true}>{getDisplayLabel(attribute)}</Typography>
         {!readOnly &&
           (isDefined ? (
             <RemoveObject
@@ -220,29 +215,35 @@ const OpenList = (props: TArrayFieldProps) => {
 }
 
 export default function ArrayField(props: TArrayFieldProps) {
-  const { uiAttribute, namePath, attribute, displayLabel } = props
+  const { uiAttribute, namePath, attribute } = props
 
   const { onOpen, config } = useRegistryContext()
 
-  if (isPrimitiveType(attribute.attributeType)) {
+  if (isPrimitiveType(attribute.attributeType) && uiAttribute?.widget) {
     const { getValues, setValue } = useFormContext()
     const value = getValues(namePath)
-    const Widget =
-      uiAttribute && uiAttribute.widget
-        ? getWidget(uiAttribute.widget)
-        : PrimitiveList
-
+    const Widget = getWidget(uiAttribute.widget)
     return (
       <Widget
         id={namePath}
-        label={displayLabel}
         onChange={(values) => setValue(namePath, values)}
         config={uiAttribute?.config}
         enumType={attribute.enumType || undefined}
         value={value}
+        label={getDisplayLabel(attribute)}
+        {...props}
+      />
+    )
+  }
+
+  if (isPrimitiveType(attribute.attributeType)) {
+    return (
+      <PrimitiveList
+        namePath={namePath}
+        uiAttribute={uiAttribute}
+        attribute={attribute}
         readOnly={config.readOnly}
         showExpanded={config.showExpanded}
-        {...props}
       />
     )
   }

--- a/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
@@ -143,7 +143,6 @@ const PrimitiveList = (props: TArrayFieldProps) => {
                         name: '',
                         type: EBlueprint.ATTRIBUTE,
                       }}
-                      readOnly={readOnly}
                       leftAdornments={String(pagedIndex)}
                       rightAdornments={
                         <Icon
@@ -223,7 +222,7 @@ const OpenList = (props: TArrayFieldProps) => {
 export default function ArrayField(props: TArrayFieldProps) {
   const { uiAttribute, namePath, attribute, displayLabel } = props
 
-  const { onOpen } = useRegistryContext()
+  const { onOpen, config } = useRegistryContext()
 
   if (isPrimitiveType(attribute.attributeType)) {
     const { getValues, setValue } = useFormContext()
@@ -240,6 +239,8 @@ export default function ArrayField(props: TArrayFieldProps) {
         config={uiAttribute?.config}
         enumType={attribute.enumType || undefined}
         value={value}
+        readOnly={config.readOnly}
+        showExpanded={config.showExpanded}
         {...props}
       />
     )

--- a/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
@@ -231,6 +231,7 @@ export default function ArrayField(props: TArrayFieldProps) {
       uiAttribute && uiAttribute.widget
         ? getWidget(uiAttribute.widget)
         : PrimitiveList
+
     return (
       <Widget
         id={namePath}

--- a/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
@@ -29,14 +29,7 @@ const isPrimitiveType = (value: string): boolean => {
 }
 
 const InlineList = (props: TArrayFieldProps) => {
-  const {
-    namePath,
-    displayLabel,
-    type,
-    uiAttribute,
-    dimensions,
-    showExpanded,
-  } = props
+  const { namePath, displayLabel, uiAttribute, showExpanded, attribute } = props
   const { idReference, onOpen } = useRegistryContext()
   const [isExpanded, setIsExpanded] = useState(
     uiAttribute?.showExpanded !== undefined
@@ -59,9 +52,9 @@ const InlineList = (props: TArrayFieldProps) => {
         <EntityView
           recipeName={uiRecipeName}
           idReference={`${idReference}.${namePath}`}
-          type={type}
+          type={attribute.attributeType}
           onOpen={onOpen}
-          dimensions={dimensions}
+          dimensions={attribute.dimensions}
         />
       )}
     </Fieldset>
@@ -69,8 +62,14 @@ const InlineList = (props: TArrayFieldProps) => {
 }
 
 const PrimitiveList = (props: TArrayFieldProps) => {
-  const { namePath, displayLabel, type, readOnly, uiAttribute, showExpanded } =
-    props
+  const {
+    namePath,
+    displayLabel,
+    attribute,
+    readOnly,
+    uiAttribute,
+    showExpanded,
+  } = props
 
   const { control } = useFormContext()
   const [isExpanded, setIsExpanded] = useState(
@@ -101,11 +100,11 @@ const PrimitiveList = (props: TArrayFieldProps) => {
             title="Add"
             button-variant="ghost_icon"
             button-onClick={() => {
-              if (type === 'boolean') {
+              if (attribute.attributeType === 'boolean') {
                 append(true)
                 return
               }
-              append(isPrimitive(type) ? ' ' : {})
+              append(isPrimitive(attribute.attributeType) ? ' ' : {})
             }}
             icon={add}
           />
@@ -139,7 +138,7 @@ const PrimitiveList = (props: TArrayFieldProps) => {
                     <AttributeField
                       namePath={`${namePath}.${pagedIndex}`}
                       attribute={{
-                        attributeType: type,
+                        attributeType: attribute.attributeType,
                         dimensions: '',
                         name: '',
                         type: EBlueprint.ATTRIBUTE,
@@ -178,7 +177,7 @@ const PrimitiveList = (props: TArrayFieldProps) => {
 }
 
 const OpenList = (props: TArrayFieldProps) => {
-  const { namePath, displayLabel, type, uiAttribute, readOnly } = props
+  const { namePath, displayLabel, attribute, uiAttribute, readOnly } = props
 
   const { getValues, setValue } = useFormContext()
   const [initialValue, setInitialValue] = useState(getValues(namePath))
@@ -201,7 +200,7 @@ const OpenList = (props: TArrayFieldProps) => {
           ) : (
             <AddObject
               namePath={namePath}
-              type={type}
+              type={attribute.attributeType}
               defaultValue={[]}
               onAdd={() => setInitialValue([])}
             />
@@ -222,11 +221,11 @@ const OpenList = (props: TArrayFieldProps) => {
 }
 
 export default function ArrayField(props: TArrayFieldProps) {
-  const { type, uiAttribute, namePath, attribute, displayLabel } = props
+  const { uiAttribute, namePath, attribute, displayLabel } = props
 
   const { onOpen } = useRegistryContext()
 
-  if (isPrimitiveType(type)) {
+  if (isPrimitiveType(attribute.attributeType)) {
     const { getValues, setValue } = useFormContext()
     const value = getValues(namePath)
     const Widget =
@@ -238,7 +237,7 @@ export default function ArrayField(props: TArrayFieldProps) {
         id={namePath}
         label={displayLabel}
         onChange={(values) => setValue(namePath, values)}
-        widgetConfig={uiAttribute?.widgetConfig}
+        config={uiAttribute?.config}
         enumType={attribute.enumType || undefined}
         value={value}
         {...props}

--- a/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
@@ -248,7 +248,19 @@ export default function ArrayField(props: TArrayFieldProps) {
   }
 
   if (onOpen && !uiAttribute?.showInline) {
-    return <OpenList {...props} />
+    return (
+      <OpenList
+        {...props}
+        readOnly={config.readOnly}
+        showExpanded={config.showExpanded}
+      />
+    )
   }
-  return <InlineList {...props} />
+  return (
+    <InlineList
+      {...props}
+      readOnly={config.readOnly}
+      showExpanded={config.showExpanded}
+    />
+  )
 }

--- a/packages/dm-core-plugins/src/form/fields/AttributeField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/AttributeField.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 
-import { TAttributeFieldProps } from '../types'
 import { isArray, isPrimitive } from '../utils'
 import ArrayField from './ArrayField'
 import { BinaryField } from './BinaryField'
@@ -8,6 +7,7 @@ import { BooleanField } from './BooleanField'
 import { NumberField } from './NumberField'
 import { ObjectField } from './ObjectField'
 import { StringField } from './StringField'
+import { TField } from '../types'
 
 const getFieldType = (attribute: any) => {
   const { attributeType, dimensions } = attribute
@@ -27,14 +27,6 @@ const getFieldType = (attribute: any) => {
   }
 }
 
-const getDisplayLabel = (attribute: any): string => {
-  const { name, label, optional } = attribute
-
-  const displayLabel = label === undefined || label === '' ? name : label
-
-  return optional ? `${displayLabel} (optional)` : displayLabel
-}
-
 const ATTRIBUTE_FIELD_MAPPING: Record<string, any> = {
   binary: BinaryField,
   object: ObjectField,
@@ -47,16 +39,14 @@ const ATTRIBUTE_FIELD_MAPPING: Record<string, any> = {
 
 const getField = (fieldType: string) => ATTRIBUTE_FIELD_MAPPING[fieldType]
 
-export const AttributeField = (props: TAttributeFieldProps) => {
+export const AttributeField = (props: TField) => {
   const { namePath, attribute, uiAttribute, leftAdornments, rightAdornments } =
     props
   const fieldType = getFieldType(attribute)
-  const displayLabel = getDisplayLabel(attribute)
   const Field = getField(fieldType)
   return (
     <Field
       namePath={namePath}
-      displayLabel={displayLabel}
       uiAttribute={uiAttribute}
       leftAdornments={leftAdornments}
       rightAdornments={rightAdornments}

--- a/packages/dm-core-plugins/src/form/fields/AttributeField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/AttributeField.tsx
@@ -36,15 +36,8 @@ const getDisplayLabel = (attribute: any): string => {
 }
 
 export const AttributeField = (props: TAttributeFieldProps) => {
-  const {
-    namePath,
-    attribute,
-    uiAttribute,
-    readOnly,
-    leftAdornments,
-    rightAdornments,
-    showExpanded,
-  } = props
+  const { namePath, attribute, uiAttribute, leftAdornments, rightAdornments } =
+    props
 
   const fieldType = getFieldType(attribute)
 
@@ -68,8 +61,6 @@ export const AttributeField = (props: TAttributeFieldProps) => {
           namePath={namePath}
           displayLabel={displayLabel}
           uiAttribute={uiAttribute}
-          readOnly={readOnly}
-          showExpanded={showExpanded}
           attribute={attribute}
         />
       )
@@ -80,8 +71,6 @@ export const AttributeField = (props: TAttributeFieldProps) => {
           namePath={namePath}
           displayLabel={displayLabel}
           uiAttribute={uiAttribute}
-          readOnly={readOnly}
-          showExpanded={showExpanded}
           attribute={attribute}
         />
       )
@@ -92,7 +81,6 @@ export const AttributeField = (props: TAttributeFieldProps) => {
           namePath={namePath}
           displayLabel={displayLabel}
           uiAttribute={uiAttribute}
-          readOnly={readOnly}
           leftAdornments={leftAdornments}
           rightAdornments={rightAdornments}
           attribute={attribute}
@@ -104,7 +92,6 @@ export const AttributeField = (props: TAttributeFieldProps) => {
           namePath={namePath}
           displayLabel={displayLabel}
           uiAttribute={uiAttribute}
-          readOnly={readOnly}
           leftAdornments={leftAdornments}
           rightAdornments={rightAdornments}
           attribute={attribute}
@@ -117,7 +104,6 @@ export const AttributeField = (props: TAttributeFieldProps) => {
           namePath={namePath}
           displayLabel={displayLabel}
           uiAttribute={uiAttribute}
-          readOnly={readOnly}
           leftAdornments={leftAdornments}
           rightAdornments={rightAdornments}
           attribute={attribute}

--- a/packages/dm-core-plugins/src/form/fields/AttributeField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/AttributeField.tsx
@@ -56,8 +56,6 @@ export const AttributeField = (props: TAttributeFieldProps) => {
         <BinaryField
           namePath={namePath}
           displayLabel={displayLabel}
-          defaultValue={attribute.default}
-          optional={attribute.optional ?? false}
           uiAttribute={uiAttribute}
           attribute={attribute}
         />
@@ -69,13 +67,10 @@ export const AttributeField = (props: TAttributeFieldProps) => {
         <ObjectField
           namePath={namePath}
           displayLabel={displayLabel}
-          contained={attribute.contained ?? true}
-          type={attribute.attributeType}
-          optional={attribute.optional ?? false}
           uiAttribute={uiAttribute}
-          defaultValue={attribute.default}
           readOnly={readOnly}
           showExpanded={showExpanded}
+          attribute={attribute}
         />
       )
 
@@ -84,9 +79,7 @@ export const AttributeField = (props: TAttributeFieldProps) => {
         <ArrayField
           namePath={namePath}
           displayLabel={displayLabel}
-          type={attribute.attributeType}
           uiAttribute={uiAttribute}
-          dimensions={attribute.dimensions}
           readOnly={readOnly}
           showExpanded={showExpanded}
           attribute={attribute}
@@ -98,8 +91,6 @@ export const AttributeField = (props: TAttributeFieldProps) => {
         <StringField
           namePath={namePath}
           displayLabel={displayLabel}
-          defaultValue={attribute.default}
-          optional={attribute.optional ?? false}
           uiAttribute={uiAttribute}
           readOnly={readOnly}
           leftAdornments={leftAdornments}
@@ -112,11 +103,11 @@ export const AttributeField = (props: TAttributeFieldProps) => {
         <BooleanField
           namePath={namePath}
           displayLabel={displayLabel}
-          defaultValue={attribute.default}
           uiAttribute={uiAttribute}
           readOnly={readOnly}
           leftAdornments={leftAdornments}
           rightAdornments={rightAdornments}
+          attribute={attribute}
         />
       )
     case 'integer':
@@ -126,11 +117,10 @@ export const AttributeField = (props: TAttributeFieldProps) => {
           namePath={namePath}
           displayLabel={displayLabel}
           uiAttribute={uiAttribute}
-          defaultValue={attribute.default}
-          optional={attribute.optional ?? false}
           readOnly={readOnly}
           leftAdornments={leftAdornments}
           rightAdornments={rightAdornments}
+          attribute={attribute}
         />
       )
     default:

--- a/packages/dm-core-plugins/src/form/fields/AttributeField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/AttributeField.tsx
@@ -35,81 +35,32 @@ const getDisplayLabel = (attribute: any): string => {
   return optional ? `${displayLabel} (optional)` : displayLabel
 }
 
+const ATTRIBUTE_FIELD_MAPPING: Record<string, any> = {
+  binary: BinaryField,
+  object: ObjectField,
+  array: ArrayField,
+  string: StringField,
+  boolean: BooleanField,
+  integer: NumberField,
+  number: NumberField,
+}
+
+const getField = (fieldType: string) => ATTRIBUTE_FIELD_MAPPING[fieldType]
+
 export const AttributeField = (props: TAttributeFieldProps) => {
   const { namePath, attribute, uiAttribute, leftAdornments, rightAdornments } =
     props
-
   const fieldType = getFieldType(attribute)
-
   const displayLabel = getDisplayLabel(attribute)
-
-  switch (fieldType) {
-    case 'binary':
-      return (
-        <BinaryField
-          namePath={namePath}
-          displayLabel={displayLabel}
-          uiAttribute={uiAttribute}
-          attribute={attribute}
-        />
-      )
-
-    case 'object':
-      // Get the ui recipe name that should be used for nested
-      return (
-        <ObjectField
-          namePath={namePath}
-          displayLabel={displayLabel}
-          uiAttribute={uiAttribute}
-          attribute={attribute}
-        />
-      )
-
-    case 'array':
-      return (
-        <ArrayField
-          namePath={namePath}
-          displayLabel={displayLabel}
-          uiAttribute={uiAttribute}
-          attribute={attribute}
-        />
-      )
-    case 'string':
-    case 'datetime':
-      return (
-        <StringField
-          namePath={namePath}
-          displayLabel={displayLabel}
-          uiAttribute={uiAttribute}
-          leftAdornments={leftAdornments}
-          rightAdornments={rightAdornments}
-          attribute={attribute}
-        />
-      )
-    case 'boolean':
-      return (
-        <BooleanField
-          namePath={namePath}
-          displayLabel={displayLabel}
-          uiAttribute={uiAttribute}
-          leftAdornments={leftAdornments}
-          rightAdornments={rightAdornments}
-          attribute={attribute}
-        />
-      )
-    case 'integer':
-    case 'number':
-      return (
-        <NumberField
-          namePath={namePath}
-          displayLabel={displayLabel}
-          uiAttribute={uiAttribute}
-          leftAdornments={leftAdornments}
-          rightAdornments={rightAdornments}
-          attribute={attribute}
-        />
-      )
-    default:
-      return <>UnknownField</>
-  }
+  const Field = getField(fieldType)
+  return (
+    <Field
+      namePath={namePath}
+      displayLabel={displayLabel}
+      uiAttribute={uiAttribute}
+      leftAdornments={leftAdornments}
+      rightAdornments={rightAdornments}
+      attribute={attribute}
+    />
+  )
 }

--- a/packages/dm-core-plugins/src/form/fields/BinaryField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/BinaryField.tsx
@@ -9,7 +9,8 @@ import { AxiosError, AxiosResponse } from 'axios'
 import React from 'react'
 import { useFormContext } from 'react-hook-form'
 import { useRegistryContext } from '../context/RegistryContext'
-import { TStringFieldProps } from '../types'
+import { TField } from '../types'
+import { getDisplayLabel } from '../utils/getDisplayLabel'
 
 const getTarget = (initialValue: any) => {
   const { idReference } = useRegistryContext()
@@ -28,7 +29,7 @@ const DownloadBinary = (props: {
   displayLabel: string
   initialValue: TGenericObject & { address: string }
 }) => {
-  const { namePath, displayLabel, initialValue } = props
+  const { namePath, initialValue, displayLabel } = props
   const dmssAPI = useDMSS()
   const [data_source_id, blob_id] = getTarget(initialValue)
 
@@ -67,8 +68,8 @@ const DownloadBinary = (props: {
   )
 }
 
-export const BinaryField = (props: TStringFieldProps) => {
-  const { namePath } = props
+export const BinaryField = (props: TField) => {
+  const { namePath, attribute } = props
   const { getValues } = useFormContext()
 
   const fileId = getValues(namePath.split('.').slice(-1).join('.'))
@@ -80,6 +81,7 @@ export const BinaryField = (props: TStringFieldProps) => {
         <DownloadBinary
           {...props}
           fileId={fileId}
+          displayLabel={getDisplayLabel(attribute)}
           initialValue={initialValue}
         />
       )}

--- a/packages/dm-core-plugins/src/form/fields/BooleanField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/BooleanField.tsx
@@ -38,6 +38,7 @@ export const BooleanField = (props: TBooleanFieldProps) => {
           label={displayLabel}
           helperText={error?.message}
           variant={invalid ? 'error' : undefined}
+          config={uiAttribute?.config}
         />
       )}
     />

--- a/packages/dm-core-plugins/src/form/fields/BooleanField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/BooleanField.tsx
@@ -14,15 +14,12 @@ export const BooleanField = (props: TBooleanFieldProps) => {
     attribute,
   } = props
 
-  // We need to convert default values coming from the API since they are always strings
-  const usedDefaultValue = attribute.default == 'True' ? true : false
-
   const Widget = getWidget(uiAttribute?.widget ?? 'CheckboxWidget')
   const { config } = useRegistryContext()
   return (
     <Controller
       name={namePath}
-      defaultValue={usedDefaultValue}
+      defaultValue={attribute.default == 'True'} // we need to convert default values coming from the API since they are always strings
       render={({
         field: { ref, value, ...props },
         fieldState: { invalid, error },

--- a/packages/dm-core-plugins/src/form/fields/BooleanField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/BooleanField.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Controller } from 'react-hook-form'
 import { getWidget } from '../context/WidgetContext'
 import { TBooleanFieldProps } from '../types'
+import { useRegistryContext } from '../context/RegistryContext'
 
 export const BooleanField = (props: TBooleanFieldProps) => {
   const {
@@ -10,7 +11,6 @@ export const BooleanField = (props: TBooleanFieldProps) => {
     uiAttribute,
     leftAdornments,
     rightAdornments,
-    readOnly,
     attribute,
   } = props
 
@@ -18,6 +18,7 @@ export const BooleanField = (props: TBooleanFieldProps) => {
   const usedDefaultValue = attribute.default == 'True' ? true : false
 
   const Widget = getWidget(uiAttribute?.widget ?? 'CheckboxWidget')
+  const { config } = useRegistryContext()
   return (
     <Controller
       name={namePath}
@@ -30,7 +31,7 @@ export const BooleanField = (props: TBooleanFieldProps) => {
           {...props}
           leftAdornments={leftAdornments}
           rightAdornments={rightAdornments}
-          readOnly={readOnly}
+          readOnly={config.readOnly}
           id={namePath}
           value={value}
           inputRef={ref}

--- a/packages/dm-core-plugins/src/form/fields/BooleanField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/BooleanField.tsx
@@ -7,15 +7,15 @@ export const BooleanField = (props: TBooleanFieldProps) => {
   const {
     namePath,
     displayLabel,
-    defaultValue,
     uiAttribute,
     leftAdornments,
     rightAdornments,
     readOnly,
+    attribute,
   } = props
 
   // We need to convert default values coming from the API since they are always strings
-  const usedDefaultValue = defaultValue == 'True' ? true : false
+  const usedDefaultValue = attribute.default == 'True' ? true : false
 
   const Widget = getWidget(uiAttribute?.widget ?? 'CheckboxWidget')
   return (

--- a/packages/dm-core-plugins/src/form/fields/BooleanField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/BooleanField.tsx
@@ -1,18 +1,13 @@
 import React from 'react'
 import { Controller } from 'react-hook-form'
 import { getWidget } from '../context/WidgetContext'
-import { TBooleanFieldProps } from '../types'
+import { TField } from '../types'
 import { useRegistryContext } from '../context/RegistryContext'
+import { getDisplayLabel } from '../utils/getDisplayLabel'
 
-export const BooleanField = (props: TBooleanFieldProps) => {
-  const {
-    namePath,
-    displayLabel,
-    uiAttribute,
-    leftAdornments,
-    rightAdornments,
-    attribute,
-  } = props
+export const BooleanField = (props: TField) => {
+  const { namePath, uiAttribute, leftAdornments, rightAdornments, attribute } =
+    props
 
   const Widget = getWidget(uiAttribute?.widget ?? 'CheckboxWidget')
   const { config } = useRegistryContext()
@@ -32,7 +27,7 @@ export const BooleanField = (props: TBooleanFieldProps) => {
           id={namePath}
           value={value}
           inputRef={ref}
-          label={displayLabel}
+          label={getDisplayLabel(attribute)}
           helperText={error?.message}
           variant={invalid ? 'error' : undefined}
           config={uiAttribute?.config}

--- a/packages/dm-core-plugins/src/form/fields/NumberField.test.tsx
+++ b/packages/dm-core-plugins/src/form/fields/NumberField.test.tsx
@@ -33,20 +33,20 @@ const setup = async (props: { initialValue?: string; optional?: boolean }) => {
   const utils = render(
     <NumberField
       attribute={{
-        name: '',
+        name: 'number',
         type: EBlueprint.ATTRIBUTE,
         attributeType: 'number',
         default: initialValue,
         optional: optional,
       }}
       namePath="number"
-      displayLabel="number"
       uiAttribute={undefined}
     />,
     { wrapper }
   )
   return await waitFor(() => {
-    const inputElement = screen.getByLabelText<HTMLInputElement>('number')
+    const labelToFind = optional ? 'number (optional)' : 'number'
+    const inputElement = screen.getByLabelText<HTMLInputElement>(labelToFind)
     const setValue = (value: string) =>
       fireEvent.change(inputElement, { target: { value: value } })
     const submit = () =>

--- a/packages/dm-core-plugins/src/form/fields/NumberField.test.tsx
+++ b/packages/dm-core-plugins/src/form/fields/NumberField.test.tsx
@@ -9,6 +9,8 @@ import React from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { NumberField } from './NumberField'
 import { EBlueprint } from '@development-framework/dm-core'
+import { RegistryProvider } from '../context/RegistryContext'
+import { defaultConfig } from '../components/Form'
 
 afterEach(() => cleanup())
 
@@ -19,10 +21,12 @@ const setup = async (props: { initialValue?: string; optional?: boolean }) => {
     const methods = useForm()
     return (
       <FormProvider {...methods}>
-        <form onSubmit={methods.handleSubmit(onSubmit)}>
-          {props.children}
-          <button type="submit">Submit</button>
-        </form>
+        <RegistryProvider idReference="" config={defaultConfig}>
+          <form onSubmit={methods.handleSubmit(onSubmit)}>
+            {props.children}
+            <button type="submit">Submit</button>
+          </form>
+        </RegistryProvider>
       </FormProvider>
     )
   }

--- a/packages/dm-core-plugins/src/form/fields/NumberField.test.tsx
+++ b/packages/dm-core-plugins/src/form/fields/NumberField.test.tsx
@@ -8,6 +8,7 @@ import {
 import React from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { NumberField } from './NumberField'
+import { EBlueprint } from '@development-framework/dm-core'
 
 afterEach(() => cleanup())
 
@@ -27,8 +28,13 @@ const setup = async (props: { initialValue?: string; optional?: boolean }) => {
   }
   const utils = render(
     <NumberField
-      defaultValue={initialValue}
-      optional={optional}
+      attribute={{
+        name: '',
+        type: EBlueprint.ATTRIBUTE,
+        attributeType: 'number',
+        default: initialValue,
+        optional: optional,
+      }}
       namePath="number"
       displayLabel="number"
       uiAttribute={undefined}

--- a/packages/dm-core-plugins/src/form/fields/NumberField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/NumberField.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Controller } from 'react-hook-form'
 import { getWidget } from '../context/WidgetContext'
 import { TNumberFieldProps } from '../types'
+import { useRegistryContext } from '../context/RegistryContext'
 const REGEX_FLOAT = /^\d+(\.\d+)?([eE][-+]?\d+)?$/
 
 export const NumberField = (props: TNumberFieldProps) => {
@@ -9,13 +10,13 @@ export const NumberField = (props: TNumberFieldProps) => {
     namePath,
     displayLabel,
     uiAttribute,
-    readOnly,
     leftAdornments,
     rightAdornments,
     attribute,
   } = props
 
   const Widget = getWidget(uiAttribute?.widget ?? 'TextWidget')
+  const { config } = useRegistryContext()
   return (
     <Controller
       name={namePath}
@@ -37,7 +38,7 @@ export const NumberField = (props: TNumberFieldProps) => {
             config={{ format: 'number' }}
             leftAdornments={leftAdornments}
             rightAdornments={rightAdornments}
-            readOnly={readOnly}
+            readOnly={config.readOnly}
             style={{ textAlignLast: 'right' }}
             onChange={(event: unknown) =>
               onChange(event ? Number(event) : null)

--- a/packages/dm-core-plugins/src/form/fields/NumberField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/NumberField.tsx
@@ -1,19 +1,14 @@
 import React from 'react'
 import { Controller } from 'react-hook-form'
 import { getWidget } from '../context/WidgetContext'
-import { TNumberFieldProps } from '../types'
+import { TField } from '../types'
 import { useRegistryContext } from '../context/RegistryContext'
+import { getDisplayLabel } from '../utils/getDisplayLabel'
 const REGEX_FLOAT = /^\d+(\.\d+)?([eE][-+]?\d+)?$/
 
-export const NumberField = (props: TNumberFieldProps) => {
-  const {
-    namePath,
-    displayLabel,
-    uiAttribute,
-    leftAdornments,
-    rightAdornments,
-    attribute,
-  } = props
+export const NumberField = (props: TField) => {
+  const { namePath, uiAttribute, leftAdornments, rightAdornments, attribute } =
+    props
 
   const Widget = getWidget(uiAttribute?.widget ?? 'NumberWidget')
   const { config } = useRegistryContext()
@@ -43,7 +38,7 @@ export const NumberField = (props: TNumberFieldProps) => {
             }
             value={props.value ?? ''}
             id={namePath}
-            label={displayLabel}
+            label={getDisplayLabel(attribute)}
             inputRef={ref}
             helperText={error?.message || error?.type}
             variant={invalid ? 'error' : undefined}

--- a/packages/dm-core-plugins/src/form/fields/NumberField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/NumberField.tsx
@@ -15,7 +15,7 @@ export const NumberField = (props: TNumberFieldProps) => {
     attribute,
   } = props
 
-  const Widget = getWidget(uiAttribute?.widget ?? 'TextWidget')
+  const Widget = getWidget(uiAttribute?.widget ?? 'NumberWidget')
   const { config } = useRegistryContext()
   return (
     <Controller
@@ -35,11 +35,9 @@ export const NumberField = (props: TNumberFieldProps) => {
         return (
           <Widget
             {...props}
-            config={{ format: 'number' }}
             leftAdornments={leftAdornments}
             rightAdornments={rightAdornments}
             readOnly={config.readOnly}
-            style={{ textAlignLast: 'right' }}
             onChange={(event: unknown) =>
               onChange(event ? Number(event) : null)
             }
@@ -50,6 +48,7 @@ export const NumberField = (props: TNumberFieldProps) => {
             helperText={error?.message || error?.type}
             variant={invalid ? 'error' : undefined}
             isDirty={props.value !== null ? isDirty : false}
+            config={uiAttribute?.config}
           />
         )
       }}

--- a/packages/dm-core-plugins/src/form/fields/NumberField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/NumberField.tsx
@@ -8,12 +8,11 @@ export const NumberField = (props: TNumberFieldProps) => {
   const {
     namePath,
     displayLabel,
-    defaultValue,
-    optional,
     uiAttribute,
     readOnly,
     leftAdornments,
     rightAdornments,
+    attribute,
   } = props
 
   const Widget = getWidget(uiAttribute?.widget ?? 'TextWidget')
@@ -21,13 +20,13 @@ export const NumberField = (props: TNumberFieldProps) => {
     <Controller
       name={namePath}
       rules={{
-        required: optional ? false : 'Required',
+        required: attribute.optional ? false : 'Required',
         pattern: {
           value: REGEX_FLOAT,
           message: 'Only numbers allowed',
         },
       }}
-      defaultValue={defaultValue || null}
+      defaultValue={attribute.default || null}
       render={({
         field: { ref, onChange, ...props },
         fieldState: { invalid, error, isDirty },

--- a/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
@@ -87,12 +87,11 @@ const SelectReference = (props: {
 }
 
 export const StorageUncontainedAttribute = (props: TContentProps) => {
-  const { namePath, uiRecipe, displayLabel, attribute, readOnly, uiAttribute } =
-    props
+  const { namePath, uiRecipe, displayLabel, attribute, uiAttribute } = props
   const { watch, setValue } = useFormContext()
   const { idReference, onOpen } = useRegistryContext()
   const { dataSource, documentPath } = splitAddress(idReference)
-
+  const { config } = useRegistryContext()
   const value = watch(namePath)
   const address = resolveRelativeAddress(
     value.address,
@@ -109,13 +108,13 @@ export const StorageUncontainedAttribute = (props: TContentProps) => {
     <Fieldset>
       <Legend>
         <Typography bold={true}>{displayLabel}</Typography>
-        {!readOnly && (
+        {!config.readOnly && (
           <SelectReference
             attributeType={attribute.attributeType}
             namePath={namePath}
           />
         )}
-        {attribute.optional && address && !readOnly && (
+        {attribute.optional && address && !config.readOnly && (
           <RemoveObject address={address} namePath={namePath} />
         )}
         {address && onOpen && !uiAttribute?.showInline && (
@@ -150,16 +149,15 @@ export const ContainedAttribute = (
     displayLabel = '',
     uiAttribute,
     uiRecipe,
-    readOnly,
-    showExpanded,
     attribute,
   } = props
   const { watch } = useFormContext()
-  const { idReference, onOpen } = useRegistryContext()
+  const { idReference, onOpen, config } = useRegistryContext()
+
   const [isExpanded, setIsExpanded] = useState(
     uiAttribute?.showExpanded !== undefined
       ? uiAttribute?.showExpanded
-      : showExpanded
+      : config.showExpanded
   )
   const value = watch(namePath)
   const isDefined = value && Object.keys(value).length > 0
@@ -168,7 +166,7 @@ export const ContainedAttribute = (
       <Legend>
         <Typography bold={true}>{displayLabel}</Typography>
         {attribute.optional &&
-          !readOnly &&
+          !config.readOnly &&
           (isDefined ? (
             <RemoveObject namePath={namePath} />
           ) : (
@@ -213,21 +211,13 @@ export const ContainedAttribute = (
 export const UncontainedAttribute = (
   props: TContentProps
 ): React.ReactElement => {
-  const {
-    namePath,
-    displayLabel,
-    uiAttribute,
-    uiRecipe,
-    readOnly,
-    showExpanded,
-    attribute,
-  } = props
+  const { namePath, displayLabel, uiAttribute, uiRecipe, attribute } = props
   const { watch } = useFormContext()
-  const { idReference, onOpen } = useRegistryContext()
+  const { idReference, onOpen, config } = useRegistryContext()
   const [isExpanded, setIsExpanded] = useState(
     uiAttribute?.showExpanded !== undefined
       ? uiAttribute?.showExpanded
-      : showExpanded
+      : config.showExpanded
   )
   const value = watch(namePath)
   const { dataSource, documentPath } = splitAddress(idReference)
@@ -239,13 +229,13 @@ export const UncontainedAttribute = (
     <Fieldset>
       <Legend>
         <Typography bold={true}>{displayLabel}</Typography>
-        {!readOnly && (
+        {!config.readOnly && (
           <SelectReference
             attributeType={attribute.attributeType}
             namePath={namePath}
           />
         )}
-        {attribute.optional && address && !readOnly && (
+        {attribute.optional && address && !config.readOnly && (
           <RemoveObject namePath={namePath} />
         )}
         {address && !(onOpen && !uiAttribute?.showInline) && (
@@ -311,14 +301,7 @@ export const ObjectField = (props: TObjectFieldProps): React.ReactElement => {
 export const ObjectTypeSelector = (
   props: TObjectFieldProps
 ): React.ReactElement => {
-  const {
-    namePath,
-    displayLabel,
-    uiAttribute,
-    attribute,
-    readOnly,
-    showExpanded,
-  } = props
+  const { namePath, displayLabel, uiAttribute, attribute } = props
   const { blueprint, uiRecipes, isLoading, error } = useBlueprint(
     attribute.attributeType
   )
@@ -370,8 +353,6 @@ export const ObjectTypeSelector = (
       blueprint={blueprint}
       uiRecipe={uiRecipe}
       uiAttribute={uiAttribute}
-      readOnly={readOnly}
-      showExpanded={showExpanded}
     />
   )
 }

--- a/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
@@ -18,7 +18,6 @@ import { AxiosError } from 'axios'
 import React, { useEffect, useState } from 'react'
 import { useFormContext } from 'react-hook-form'
 import TooltipButton from '../../common/TooltipButton'
-import { defaultConfig } from '../FormPlugin'
 import { OpenObjectButton } from '../components/OpenObjectButton'
 import { useRegistryContext } from '../context/RegistryContext'
 import { getWidget } from '../context/WidgetContext'
@@ -26,6 +25,7 @@ import { Fieldset, Legend } from '../styles'
 import { TContentProps, TObjectFieldProps, TUiRecipeForm } from '../types'
 import RemoveObject from '../components/RemoveObjectButton'
 import AddObject from '../components/AddObjectButton'
+import { defaultConfig } from '../components/Form'
 
 const SelectReference = (props: {
   attributeType: string

--- a/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
@@ -273,8 +273,6 @@ export const UncontainedAttribute = (
 export const ObjectField = (props: TObjectFieldProps): React.ReactElement => {
   const { namePath, uiAttribute, displayLabel, attribute } = props
   const { getValues } = useFormContext()
-
-  // Be able to override the object field
   const Widget =
     uiAttribute && uiAttribute.widget
       ? getWidget(uiAttribute.widget)
@@ -284,16 +282,19 @@ export const ObjectField = (props: TObjectFieldProps): React.ReactElement => {
     values !== undefined &&
     'referenceType' in values &&
     values['referenceType'] === 'storage'
-  // If the attribute type is an object, we need to find the correct type from the values.
   return (
     <Widget
       {...props}
       onChange={() => null}
       id={valuesIsStorageReference ? values['address'] : namePath}
       label={displayLabel}
-      //type={attribute.type === 'object' && values ? values.type : type}
-      //defaultValue={defaultValue}
-      attribute={attribute}
+      attribute={{
+        ...attribute,
+        attributeType:
+          values && values.type !== EBlueprint.REFERENCE && 'type' in values
+            ? values.type
+            : attribute.attributeType,
+      }} // if the attribute type is an object, we need to find the correct type from the values.
     />
   )
 }

--- a/packages/dm-core-plugins/src/form/fields/StringField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/StringField.tsx
@@ -2,19 +2,19 @@ import React from 'react'
 import { Controller } from 'react-hook-form'
 import { getWidget } from '../context/WidgetContext'
 import { TStringFieldProps } from '../types'
+import { useRegistryContext } from '../context/RegistryContext'
 
 export const StringField = (props: TStringFieldProps) => {
   const {
     namePath,
     displayLabel,
     uiAttribute,
-    readOnly,
     leftAdornments,
     rightAdornments,
     attribute,
   } = props
   const Widget = getWidget(uiAttribute?.widget ?? 'TextWidget')
-
+  const { config } = useRegistryContext()
   return (
     <Controller
       name={namePath}
@@ -30,7 +30,7 @@ export const StringField = (props: TStringFieldProps) => {
           <Widget
             enumType={attribute.enumType || undefined}
             isDirty={value !== null ? isDirty : false}
-            readOnly={readOnly}
+            readOnly={config.readOnly}
             {...props}
             value={value ?? ''}
             id={namePath}

--- a/packages/dm-core-plugins/src/form/fields/StringField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/StringField.tsx
@@ -40,12 +40,7 @@ export const StringField = (props: TStringFieldProps) => {
             inputRef={ref}
             helperText={error?.message || error?.type}
             variant={invalid ? 'error' : undefined}
-            config={{
-              format:
-                uiAttribute && 'format' in uiAttribute
-                  ? uiAttribute.format
-                  : 'string',
-            }}
+            config={uiAttribute?.config}
           />
         )
       }}

--- a/packages/dm-core-plugins/src/form/fields/StringField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/StringField.tsx
@@ -1,18 +1,13 @@
 import React from 'react'
 import { Controller } from 'react-hook-form'
 import { getWidget } from '../context/WidgetContext'
-import { TStringFieldProps } from '../types'
+import { TField } from '../types'
 import { useRegistryContext } from '../context/RegistryContext'
+import { getDisplayLabel } from '../utils/getDisplayLabel'
 
-export const StringField = (props: TStringFieldProps) => {
-  const {
-    namePath,
-    displayLabel,
-    uiAttribute,
-    leftAdornments,
-    rightAdornments,
-    attribute,
-  } = props
+export const StringField = (props: TField) => {
+  const { namePath, uiAttribute, leftAdornments, rightAdornments, attribute } =
+    props
   const Widget = getWidget(uiAttribute?.widget ?? 'TextWidget')
   const { config } = useRegistryContext()
   return (
@@ -36,7 +31,7 @@ export const StringField = (props: TStringFieldProps) => {
             id={namePath}
             leftAdornments={leftAdornments}
             rightAdornments={rightAdornments}
-            label={displayLabel}
+            label={getDisplayLabel(attribute)}
             inputRef={ref}
             helperText={error?.message || error?.type}
             variant={invalid ? 'error' : undefined}

--- a/packages/dm-core-plugins/src/form/fields/StringField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/StringField.tsx
@@ -7,8 +7,6 @@ export const StringField = (props: TStringFieldProps) => {
   const {
     namePath,
     displayLabel,
-    defaultValue,
-    optional,
     uiAttribute,
     readOnly,
     leftAdornments,
@@ -21,9 +19,9 @@ export const StringField = (props: TStringFieldProps) => {
     <Controller
       name={namePath}
       rules={{
-        required: optional ? false : 'Required',
+        required: attribute.optional ? false : 'Required',
       }}
-      defaultValue={defaultValue ?? ''}
+      defaultValue={attribute.default ?? ''}
       render={({
         field: { ref, value, ...props },
         fieldState: { invalid, error, isDirty },
@@ -48,7 +46,6 @@ export const StringField = (props: TStringFieldProps) => {
                   ? uiAttribute.format
                   : 'string',
             }}
-            widgetConfig={uiAttribute?.widgetConfig}
           />
         )
       }}

--- a/packages/dm-core-plugins/src/form/types.tsx
+++ b/packages/dm-core-plugins/src/form/types.tsx
@@ -1,6 +1,7 @@
 import {
   TAttribute,
   TBlueprint,
+  TGenericObject,
   TOnOpen,
   TUiRecipe,
 } from '@development-framework/dm-core'
@@ -20,6 +21,7 @@ export type TObjectFieldProps = {
   displayLabel: string
   uiAttribute: TAttributeObject | undefined
   attribute: TAttribute
+  value: TGenericObject
 }
 
 export type TContentProps = {

--- a/packages/dm-core-plugins/src/form/types.tsx
+++ b/packages/dm-core-plugins/src/form/types.tsx
@@ -61,7 +61,6 @@ export type TNumberFieldProps = {
   namePath: string
   displayLabel: string
   uiAttribute: TAttributeConfig | undefined
-  readOnly?: boolean
   leftAdornments?: React.ReactElement | string
   rightAdornments?: React.ReactElement | string
   attribute: TAttribute
@@ -71,7 +70,6 @@ export type TBooleanFieldProps = {
   namePath: string
   displayLabel: string
   uiAttribute: TAttributeConfig | undefined
-  readOnly?: boolean
   leftAdornments?: React.ReactElement | string
   rightAdornments?: React.ReactElement | string
   attribute: TAttribute

--- a/packages/dm-core-plugins/src/form/types.tsx
+++ b/packages/dm-core-plugins/src/form/types.tsx
@@ -1,7 +1,6 @@
 import {
   TAttribute,
   TBlueprint,
-  TGenericObject,
   TOnOpen,
   TUiRecipe,
 } from '@development-framework/dm-core'
@@ -18,15 +17,12 @@ export type TFormProps = {
 
 export type TObjectFieldProps = {
   namePath: string
-  displayLabel: string
   uiAttribute: TAttributeObject | undefined
   attribute: TAttribute
-  value: TGenericObject
 }
 
 export type TContentProps = {
   namePath: string
-  displayLabel: string
   blueprint: TBlueprint | undefined
   uiRecipe: TUiRecipeForm
   uiAttribute: TAttributeObject | undefined
@@ -35,42 +31,14 @@ export type TContentProps = {
 
 export type TArrayFieldProps = {
   namePath: string
-  displayLabel: string
   uiAttribute: TAttributeArray | undefined
   readOnly?: boolean
   showExpanded?: boolean
   attribute: TAttribute
 }
 
-export type TAttributeFieldProps = {
+export type TField = {
   namePath: string
-  attribute: TAttribute
-  uiAttribute?: TAttributeConfig
-  leftAdornments?: React.ReactElement | string
-  rightAdornments?: React.ReactElement | string
-}
-
-export type TStringFieldProps = {
-  namePath: string
-  displayLabel: string
-  uiAttribute: TAttributeConfig | undefined
-  leftAdornments?: React.ReactElement | string
-  rightAdornments?: React.ReactElement | string
-  attribute: TAttribute
-}
-
-export type TNumberFieldProps = {
-  namePath: string
-  displayLabel: string
-  uiAttribute: TAttributeConfig | undefined
-  leftAdornments?: React.ReactElement | string
-  rightAdornments?: React.ReactElement | string
-  attribute: TAttribute
-}
-
-export type TBooleanFieldProps = {
-  namePath: string
-  displayLabel: string
   uiAttribute: TAttributeConfig | undefined
   leftAdornments?: React.ReactElement | string
   rightAdornments?: React.ReactElement | string

--- a/packages/dm-core-plugins/src/form/types.tsx
+++ b/packages/dm-core-plugins/src/form/types.tsx
@@ -16,40 +16,32 @@ export type TFormProps = {
 }
 
 export type TObjectFieldProps = {
-  contained: boolean
   namePath: string
-  type: string
   displayLabel: string
-  optional: boolean
   uiAttribute: TAttributeObject | undefined
   readOnly?: boolean
-  defaultValue?: any
   showExpanded?: boolean
+  attribute: TAttribute
 }
 
 export type TContentProps = {
-  type: string
   namePath: string
   displayLabel: string
-  optional: boolean
   blueprint: TBlueprint | undefined
   uiRecipe: TUiRecipeForm
   uiAttribute: TAttributeObject | undefined
   readOnly?: boolean
-  defaultValue?: any
   showExpanded?: boolean
+  attribute: TAttribute
 }
 
 export type TArrayFieldProps = {
   namePath: string
   displayLabel: string
-  type: string
   uiAttribute: TAttributeArray | undefined
-  dimensions: string | undefined
   readOnly?: boolean
   showExpanded?: boolean
   attribute: TAttribute
-  widgetConfig?: any
 }
 
 export type TAttributeFieldProps = {
@@ -65,43 +57,39 @@ export type TAttributeFieldProps = {
 export type TStringFieldProps = {
   namePath: string
   displayLabel: string
-  defaultValue: string
-  optional: boolean
   uiAttribute: TAttributeConfig | undefined
   readOnly?: boolean
   format?: 'string' | 'date' | 'datetime'
   leftAdornments?: React.ReactElement | string
   rightAdornments?: React.ReactElement | string
   attribute: TAttribute
-  widgetConfig?: any
 }
 
 export type TNumberFieldProps = {
   namePath: string
   displayLabel: string
-  defaultValue: string
-  optional: boolean
   uiAttribute: TAttributeConfig | undefined
   readOnly?: boolean
   leftAdornments?: React.ReactElement | string
   rightAdornments?: React.ReactElement | string
+  attribute: TAttribute
 }
 
 export type TBooleanFieldProps = {
   namePath: string
   displayLabel: string
-  defaultValue: string
   uiAttribute: TAttributeConfig | undefined
   readOnly?: boolean
   leftAdornments?: React.ReactElement | string
   rightAdornments?: React.ReactElement | string
+  attribute: TAttribute
 }
 
 type TAttributeBasis = {
   name: string
   type: string
   showInline?: boolean
-  widgetConfig?: any
+  config?: Record<any, any>
 }
 type TAttributeString = TAttributeBasis & {
   widget: string
@@ -111,7 +99,6 @@ type TAttributeArray = TAttributeBasis & {
   widget?: string
   uiRecipe?: string
   showExpanded?: boolean
-  widgetConfig?: any
 }
 type TAttributeObject = TAttributeBasis & {
   widget?: string
@@ -127,7 +114,6 @@ export type TConfig = {
   fields: string[]
   readOnly?: boolean
   showExpanded?: boolean
-  widgetConfig?: any
 }
 
 export type TUiRecipeForm = Omit<TUiRecipe, 'config'> & {
@@ -138,12 +124,11 @@ export declare type Variants = 'error' | 'success' | 'warning'
 
 export type TWidget = {
   label: string
-  value?: any
-  onChange: (value: unknown) => void
-  onClick?: (value: any) => void
-  id: string
-  inputRef?: any
-  helperText?: string
+  value?: any // set up input initial and updated value
+  onChange: (value: unknown) => void // send data back to hook form
+  id: string // unique id to ensure accessibility
+  inputRef?: any // allow input to be focused with error
+  helperText?: string // show error messages as helper text
   variant?: Variants
   readOnly?: boolean
   config?: Record<any, any>
@@ -152,7 +137,6 @@ export type TWidget = {
   style?: any
   isDirty?: boolean
   enumType?: any
-  widgetConfig?: any
 }
 
 export type TWidgets = {

--- a/packages/dm-core-plugins/src/form/types.tsx
+++ b/packages/dm-core-plugins/src/form/types.tsx
@@ -10,7 +10,7 @@ export type TFormProps = {
   idReference: string
   type: string
   formData?: any
-  config?: TConfig
+  config?: TFormConfig
   onOpen?: TOnOpen
   onSubmit?: (data: any) => void
 }
@@ -19,8 +19,6 @@ export type TObjectFieldProps = {
   namePath: string
   displayLabel: string
   uiAttribute: TAttributeObject | undefined
-  readOnly?: boolean
-  showExpanded?: boolean
   attribute: TAttribute
 }
 
@@ -30,8 +28,6 @@ export type TContentProps = {
   blueprint: TBlueprint | undefined
   uiRecipe: TUiRecipeForm
   uiAttribute: TAttributeObject | undefined
-  readOnly?: boolean
-  showExpanded?: boolean
   attribute: TAttribute
 }
 
@@ -48,8 +44,6 @@ export type TAttributeFieldProps = {
   namePath: string
   attribute: TAttribute
   uiAttribute?: TAttributeConfig
-  readOnly?: boolean
-  showExpanded?: boolean
   leftAdornments?: React.ReactElement | string
   rightAdornments?: React.ReactElement | string
 }
@@ -58,8 +52,6 @@ export type TStringFieldProps = {
   namePath: string
   displayLabel: string
   uiAttribute: TAttributeConfig | undefined
-  readOnly?: boolean
-  format?: 'string' | 'date' | 'datetime'
   leftAdornments?: React.ReactElement | string
   rightAdornments?: React.ReactElement | string
   attribute: TAttribute
@@ -85,22 +77,22 @@ export type TBooleanFieldProps = {
   attribute: TAttribute
 }
 
-type TAttributeBasis = {
+type TAttributeBase = {
   name: string
   type: string
   showInline?: boolean
   config?: Record<any, any>
 }
-type TAttributeString = TAttributeBasis & {
+type TAttributeString = TAttributeBase & {
   widget: string
   format: string
 }
-type TAttributeArray = TAttributeBasis & {
+type TAttributeArray = TAttributeBase & {
   widget?: string
   uiRecipe?: string
   showExpanded?: boolean
 }
-type TAttributeObject = TAttributeBasis & {
+type TAttributeObject = TAttributeBase & {
   widget?: string
   uiRecipe?: string
   showExpanded?: boolean
@@ -109,7 +101,8 @@ export type TAttributeConfig =
   | TAttributeArray
   | TAttributeObject
   | TAttributeString
-export type TConfig = {
+
+export type TFormConfig = {
   attributes: TAttributeConfig[]
   fields: string[]
   readOnly?: boolean
@@ -117,7 +110,7 @@ export type TConfig = {
 }
 
 export type TUiRecipeForm = Omit<TUiRecipe, 'config'> & {
-  config: TConfig
+  config: TFormConfig
 }
 
 export declare type Variants = 'error' | 'success' | 'warning'

--- a/packages/dm-core-plugins/src/form/utils/getDisplayLabel.tsx
+++ b/packages/dm-core-plugins/src/form/utils/getDisplayLabel.tsx
@@ -1,0 +1,9 @@
+import { TAttribute } from '@development-framework/dm-core'
+
+export const getDisplayLabel = (attribute: TAttribute): string => {
+  const { name, label, optional } = attribute
+
+  const displayLabel = label === undefined || label === '' ? name : label
+
+  return optional ? `${displayLabel} (optional)` : displayLabel
+}

--- a/packages/dm-core-plugins/src/form/widgets/DateTimeWidget.tsx
+++ b/packages/dm-core-plugins/src/form/widgets/DateTimeWidget.tsx
@@ -1,18 +1,22 @@
 import React from 'react'
-import { TextField } from '@equinor/eds-core-react'
-import { TWidget } from '../types'
 
-const TextWidget = (props: TWidget) => {
+import { TextField } from '@equinor/eds-core-react'
+
+import { TWidget } from '../types'
+import { DateTime } from 'luxon'
+
+const DateTimeWidget = (props: TWidget) => {
   const { label, onChange, leftAdornments, rightAdornments, isDirty } = props
   const onChangeHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
-    onChange?.(event.target.value === '' ? null : event.target.value)
+    onChange?.(new Date(event.target.value).toISOString())
   }
 
   return (
     <TextField
       id={props.id}
       readOnly={props.readOnly}
-      defaultValue={props.value}
+      defaultValue={DateTime.fromISO(props.value).toFormat("yyyy-MM-dd'T'T")}
+      //@ts-ignore
       leftAdornments={leftAdornments}
       rightAdornments={rightAdornments}
       inputRef={props.inputRef}
@@ -20,8 +24,8 @@ const TextWidget = (props: TWidget) => {
       helperText={props.helperText}
       onChange={onChangeHandler}
       label={label}
-      type="string"
-      data-testid={`form-text-widget-${label}`}
+      type="datetime-local"
+      data-testid={`form-datetime-widget-${label}`}
       style={
         isDirty && props.variant !== 'error'
           ? {
@@ -34,4 +38,4 @@ const TextWidget = (props: TWidget) => {
   )
 }
 
-export default TextWidget
+export default DateTimeWidget

--- a/packages/dm-core-plugins/src/form/widgets/NumberWidget.tsx
+++ b/packages/dm-core-plugins/src/form/widgets/NumberWidget.tsx
@@ -1,11 +1,14 @@
 import React from 'react'
+
 import { TextField } from '@equinor/eds-core-react'
+
 import { TWidget } from '../types'
 
-const TextWidget = (props: TWidget) => {
+const NumberWidget = (props: TWidget) => {
   const { label, onChange, leftAdornments, rightAdornments, isDirty } = props
   const onChangeHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
-    onChange?.(event.target.value === '' ? null : event.target.value)
+    const value = event.target.value
+    onChange?.(value === '' ? null : value)
   }
 
   return (
@@ -20,8 +23,8 @@ const TextWidget = (props: TWidget) => {
       helperText={props.helperText}
       onChange={onChangeHandler}
       label={label}
-      type="string"
-      data-testid={`form-text-widget-${label}`}
+      type="number"
+      data-testid={`form-number-widget-${label}`}
       style={
         isDirty && props.variant !== 'error'
           ? {
@@ -34,4 +37,4 @@ const TextWidget = (props: TWidget) => {
   )
 }
 
-export default TextWidget
+export default NumberWidget

--- a/packages/dm-core-plugins/src/form/widgets/SelectWidget.tsx
+++ b/packages/dm-core-plugins/src/form/widgets/SelectWidget.tsx
@@ -12,11 +12,13 @@ type TOption = {
 }
 
 const SelectWidget = (props: TWidget) => {
-  const { label, onChange, isDirty, enumType, widgetConfig } = props
+  const { label, onChange, isDirty, enumType, config } = props
 
   const { document, isLoading } = useDocument<TEnum>(enumType)
 
-  const isMultiselect = widgetConfig && widgetConfig.multiline
+  if (isLoading) return <></>
+
+  const isMultiselect = config && config.multiline
 
   const onChangeHandler = (value: AutocompleteChanges<TOption>) => {
     if (isMultiselect) {
@@ -47,7 +49,6 @@ const SelectWidget = (props: TWidget) => {
       loading={isLoading}
       readOnly={props.readOnly}
       initialSelectedOptions={initialSelectedOptions}
-      onClick={props.onClick}
       inputRef={props.inputRef}
       variant={props.variant}
       helperText={props.helperText}

--- a/packages/dm-core-plugins/src/form/widgets/TextWidget.tsx
+++ b/packages/dm-core-plugins/src/form/widgets/TextWidget.tsx
@@ -35,7 +35,6 @@ const TextWidget = (props: TWidget) => {
       //@ts-ignore
       leftAdornments={leftAdornments}
       rightAdornments={rightAdornments}
-      onClick={props.onClick}
       inputRef={props.inputRef}
       variant={props.variant}
       helperText={props.helperText}

--- a/packages/dm-core-plugins/src/form/widgets/TypeWidget.tsx
+++ b/packages/dm-core-plugins/src/form/widgets/TypeWidget.tsx
@@ -1,7 +1,7 @@
 import { Loading, useBlueprint } from '@development-framework/dm-core'
 import React from 'react'
 import { TWidget } from '../types'
-import TextWidget from './TextWidget'
+import { TextField } from '@equinor/eds-core-react'
 
 const TypeWidget = (props: TWidget) => {
   const { id, label, value } = props
@@ -14,22 +14,20 @@ const TypeWidget = (props: TWidget) => {
   const datasourceId = value.split('/')[0]
 
   return (
-    <>
-      <TextWidget
-        id={id}
-        label={label}
-        readOnly={true}
-        value={value}
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        onChange={() => {}}
-        onClick={() => {
-          // @ts-ignore
-          window
-            .open(`dmt/view/${datasourceId}/${blueprint.uid}`, '_blank')
-            .focus()
-        }}
-      />
-    </>
+    <TextField
+      id={id}
+      label={label}
+      readOnly={true}
+      value={value}
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      onChange={() => {}}
+      onClick={() => {
+        // @ts-ignore
+        window
+          .open(`dmt/view/${datasourceId}/${blueprint.uid}`, '_blank')
+          .focus()
+      }}
+    />
   )
 }
 

--- a/packages/dm-core-plugins/src/form/widgets/index.ts
+++ b/packages/dm-core-plugins/src/form/widgets/index.ts
@@ -6,6 +6,8 @@ import TextareaWidget from './TextareaWidget'
 import TypeWidget from './TypeWidget'
 import SwitchWidget from './SwitchWidget'
 import SelectWidget from './SelectWidget'
+import NumberWidget from './NumberWidget'
+import DateTimeWidget from './DateTimeWidget'
 
 const widgets: TWidgets = {
   CheckboxWidget,
@@ -15,6 +17,8 @@ const widgets: TWidgets = {
   TypeWidget,
   SwitchWidget,
   SelectWidget,
+  NumberWidget,
+  DateTimeWidget,
 }
 
 export default widgets


### PR DESCRIPTION
## What does this pull request change?

* Avoid prop drilling, only pass what is needed
  * Use context to provide the `FormConfig` to fields, instead of passing them down as props (the read only and show expanded setting)
  * Add util `getDisplayLabel` to provide a way to have common labels for all fields, instead of passing it down as a prop
  * Just pass the `attribute` down instead of splitting it up and passing down parts of it
* Make `StringField` less complex by
  * Add `NumberWidget` to handle numbers
  * Add  `DateTimeWidget` to handle date time

> **NOTE**: The overall goal of this PR is to make it clear what props are needed for each field (StringField, NumberField etc.). This PR focuses mostly on primitive fields.  The PR is quite large already, since we are renaming and removing stuff, so will not include everything in this PR, more to come....

## Why is this pull request needed?

## Issues related to this change

