### PR TITLE
refactor: add templates to divide code more up

### DIFF
--- a/packages/dm-core-plugins/src/form/components/SelectReference.tsx
+++ b/packages/dm-core-plugins/src/form/components/SelectReference.tsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react'
+import { useFormContext } from 'react-hook-form'
+import {
+  EBlueprint,
+  EntityPickerDialog,
+  ErrorResponse,
+  TLinkReference,
+  useDMSS,
+} from '@development-framework/dm-core'
+import { useRegistryContext } from '../context/RegistryContext'
+import { AxiosError } from 'axios/index'
+import TooltipButton from '../../common/TooltipButton'
+import { add, edit } from '@equinor/eds-icons'
+
+export const SelectReference = (props: {
+  attributeType: string
+  namePath: string
+}) => {
+  const [showModal, setShowModal] = useState<boolean>(false)
+  const { setValue, watch } = useFormContext()
+  const dmssAPI = useDMSS()
+  const { idReference } = useRegistryContext()
+  const value = watch(props.namePath)
+
+  const onChange = (address: string) => {
+    const reference: TLinkReference = {
+      type: EBlueprint.REFERENCE,
+      referenceType: 'link',
+      address: address,
+    }
+    const options = {
+      shouldValidate: true,
+      shouldDirty: true,
+      shouldTouch: true,
+    }
+
+    const request = value
+      ? dmssAPI.documentUpdate({
+          idAddress: `${idReference}.${props.namePath}`,
+          data: JSON.stringify(reference),
+        })
+      : dmssAPI.documentAdd({
+          address: `${idReference}.${props.namePath}`,
+          document: JSON.stringify(reference),
+        })
+    request
+      .then(() => {
+        setValue(props.namePath, reference, options)
+      })
+      .catch((error: AxiosError<ErrorResponse>) => {
+        console.error(error)
+      })
+  }
+
+  return (
+    <>
+      <TooltipButton
+        title={`${value ? 'Edit' : 'Add'} and save`}
+        button-variant="ghost_icon"
+        button-onClick={() => setShowModal(true)}
+        icon={value ? edit : add}
+      />
+      <EntityPickerDialog
+        data-testid={`select-${props.namePath}`}
+        onChange={onChange}
+        typeFilter={props.attributeType}
+        showModal={showModal}
+        setShowModal={setShowModal}
+      />
+    </>
+  )
+}

--- a/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
@@ -1,223 +1,14 @@
-import {
-  EBlueprint,
-  EntityView,
-  getKey,
-  Stack,
-} from '@development-framework/dm-core'
-import { Icon, Pagination, Typography } from '@equinor/eds-core-react'
-import React, { useState } from 'react'
-import { useFieldArray, useFormContext } from 'react-hook-form'
-import {
-  add,
-  remove_outlined,
-  chevron_down,
-  chevron_up,
-} from '@equinor/eds-icons'
-import TooltipButton from '../../common/TooltipButton'
-import { OpenObjectButton } from '../components/OpenObjectButton'
-import { useRegistryContext } from '../context/RegistryContext'
-import { Fieldset, Legend } from '../styles'
-import { TArrayFieldProps } from '../types'
-import { isPrimitive } from '../utils'
-import { AttributeField } from './AttributeField'
-import RemoveObject from '../components/RemoveObjectButton'
-import AddObject from '../components/AddObjectButton'
+import React from 'react'
+import { useFormContext } from 'react-hook-form'
+import { TArrayTemplate } from '../types'
 import { getWidget } from '../context/WidgetContext'
 import { getDisplayLabel } from '../utils/getDisplayLabel'
+import { ArrayComplexTemplate } from '../templates/ArrayComplexTemplate'
+import { isPrimitiveType } from '../utils/isPrimitiveType'
+import { ArrayPrimitiveTemplate } from '../templates/ArrayPrimitiveTemplate'
 
-const isPrimitiveType = (value: string): boolean => {
-  return ['string', 'number', 'integer', 'boolean'].includes(value)
-}
-
-const InlineList = (props: TArrayFieldProps) => {
-  const { namePath, uiAttribute, showExpanded, attribute } = props
-  const { idReference, onOpen } = useRegistryContext()
-  const [isExpanded, setIsExpanded] = useState(
-    uiAttribute?.showExpanded !== undefined
-      ? uiAttribute?.showExpanded
-      : showExpanded
-  )
-  const uiRecipeName = getKey<string>(uiAttribute, 'uiRecipe', 'string')
-  return (
-    <Fieldset>
-      <Legend>
-        <Typography bold={true}>{getDisplayLabel(attribute)}</Typography>
-        <TooltipButton
-          title="Expand"
-          button-variant="ghost_icon"
-          button-onClick={() => setIsExpanded(!isExpanded)}
-          icon={isExpanded ? chevron_up : chevron_down}
-        />
-      </Legend>
-      {isExpanded && (
-        <EntityView
-          recipeName={uiRecipeName}
-          idReference={`${idReference}.${namePath}`}
-          type={attribute.attributeType}
-          onOpen={onOpen}
-          dimensions={attribute.dimensions}
-        />
-      )}
-    </Fieldset>
-  )
-}
-
-const PrimitiveList = (props: TArrayFieldProps) => {
-  const { namePath, attribute, readOnly, uiAttribute, showExpanded } = props
-
-  const { control } = useFormContext()
-  const [isExpanded, setIsExpanded] = useState(
-    uiAttribute?.showExpanded !== undefined
-      ? uiAttribute?.showExpanded
-      : showExpanded
-  )
-
-  const { fields, append, remove } = useFieldArray({
-    control,
-    name: namePath,
-  })
-  const [currentPageIndex, setCurrentPageIndex] = useState(0)
-  const itemsPerPage = 30
-
-  return (
-    <Fieldset>
-      <Legend>
-        <Typography bold={true}>{getDisplayLabel(attribute)}</Typography>
-        <TooltipButton
-          title="Expand"
-          button-variant="ghost_icon"
-          button-onClick={() => setIsExpanded(!isExpanded)}
-          icon={isExpanded ? chevron_up : chevron_down}
-        />
-        {!readOnly && isExpanded && (
-          <TooltipButton
-            title="Add"
-            button-variant="ghost_icon"
-            button-onClick={() => {
-              if (attribute.attributeType === 'boolean') {
-                append(true)
-                return
-              }
-              append(isPrimitive(attribute.attributeType) ? ' ' : {})
-            }}
-            icon={add}
-          />
-        )}
-      </Legend>
-      {isExpanded && (
-        <div
-          style={{
-            display: 'flex',
-            flexFlow: 'column wrap',
-            maxHeight: '23em',
-            alignContent: 'flex-start',
-          }}
-        >
-          {fields
-            .slice(
-              currentPageIndex * itemsPerPage,
-              currentPageIndex * itemsPerPage + itemsPerPage
-            )
-            .map((item: any, index: number) => {
-              const pagedIndex = itemsPerPage * currentPageIndex + index
-              return (
-                <Stack
-                  key={item.id}
-                  direction="row"
-                  spacing={0.5}
-                  alignSelf="stretch"
-                  alignItems="flex-end"
-                >
-                  <Stack grow={1}>
-                    <AttributeField
-                      namePath={`${namePath}.${pagedIndex}`}
-                      uiAttribute={uiAttribute}
-                      attribute={{
-                        attributeType: attribute.attributeType,
-                        dimensions: '',
-                        name: '',
-                        type: EBlueprint.ATTRIBUTE,
-                      }}
-                      leftAdornments={String(pagedIndex)}
-                      rightAdornments={
-                        <Icon
-                          data={remove_outlined}
-                          size={18}
-                          // @ts-ignore
-                          onClick={() => remove(pagedIndex)}
-                          style={{ cursor: 'pointer' }}
-                          data-testid={`form-text-widget-remove-${pagedIndex}`}
-                        />
-                      }
-                    />
-                  </Stack>
-                </Stack>
-              )
-            })}
-        </div>
-      )}
-      {isExpanded && fields.length > itemsPerPage && (
-        <div>
-          <Pagination
-            totalItems={fields.length}
-            itemsPerPage={itemsPerPage}
-            defaultPage={currentPageIndex + 1}
-            onChange={(e, p) => setCurrentPageIndex(p - 1)}
-          />
-        </div>
-      )}
-    </Fieldset>
-  )
-}
-
-const OpenList = (props: TArrayFieldProps) => {
-  const { namePath, attribute, uiAttribute, readOnly } = props
-
-  const { getValues, setValue } = useFormContext()
-  const [initialValue, setInitialValue] = useState(getValues(namePath))
-  const uiRecipeName = getKey<string>(uiAttribute, 'uiRecipe', 'string')
-  const isDefined = initialValue !== undefined
-
-  return (
-    <Fieldset>
-      <Legend>
-        <Typography bold={true}>{getDisplayLabel(attribute)}</Typography>
-        {!readOnly &&
-          (isDefined ? (
-            <RemoveObject
-              namePath={namePath}
-              onRemove={() => {
-                setInitialValue(undefined)
-                setValue(namePath, undefined)
-              }}
-            />
-          ) : (
-            <AddObject
-              namePath={namePath}
-              type={attribute.attributeType}
-              defaultValue={[]}
-              onAdd={() => setInitialValue([])}
-            />
-          ))}
-        {!readOnly && isDefined && (
-          <OpenObjectButton
-            viewId={namePath}
-            viewConfig={{
-              type: 'ReferenceViewConfig',
-              scope: namePath,
-              recipe: uiRecipeName,
-            }}
-          />
-        )}
-      </Legend>
-    </Fieldset>
-  )
-}
-
-export default function ArrayField(props: TArrayFieldProps) {
+export default function ArrayField(props: TArrayTemplate) {
   const { uiAttribute, namePath, attribute } = props
-
-  const { onOpen, config } = useRegistryContext()
 
   if (isPrimitiveType(attribute.attributeType) && uiAttribute?.widget) {
     const { getValues, setValue } = useFormContext()
@@ -238,30 +29,19 @@ export default function ArrayField(props: TArrayFieldProps) {
 
   if (isPrimitiveType(attribute.attributeType)) {
     return (
-      <PrimitiveList
+      <ArrayPrimitiveTemplate
         namePath={namePath}
         uiAttribute={uiAttribute}
         attribute={attribute}
-        readOnly={config.readOnly}
-        showExpanded={config.showExpanded}
       />
     )
   }
 
-  if (onOpen && !uiAttribute?.showInline) {
-    return (
-      <OpenList
-        {...props}
-        readOnly={config.readOnly}
-        showExpanded={config.showExpanded}
-      />
-    )
-  }
   return (
-    <InlineList
-      {...props}
-      readOnly={config.readOnly}
-      showExpanded={config.showExpanded}
+    <ArrayComplexTemplate
+      namePath={namePath}
+      uiAttribute={uiAttribute}
+      attribute={attribute}
     />
   )
 }

--- a/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
@@ -1,275 +1,24 @@
 import {
   EBlueprint,
-  EntityPickerDialog,
-  EntityView,
-  ErrorResponse,
   getKey,
   Loading,
-  resolveRelativeAddress,
-  splitAddress,
-  TLinkReference,
   useBlueprint,
-  useDMSS,
-  useDocument,
 } from '@development-framework/dm-core'
-import { Typography } from '@equinor/eds-core-react'
-import { add, chevron_down, chevron_up, edit } from '@equinor/eds-icons'
-import { AxiosError } from 'axios'
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import { useFormContext } from 'react-hook-form'
-import TooltipButton from '../../common/TooltipButton'
-import { OpenObjectButton } from '../components/OpenObjectButton'
-import { useRegistryContext } from '../context/RegistryContext'
 import { getWidget } from '../context/WidgetContext'
-import { Fieldset, Legend } from '../styles'
-import { TContentProps, TObjectFieldProps, TUiRecipeForm } from '../types'
-import RemoveObject from '../components/RemoveObjectButton'
-import AddObject from '../components/AddObjectButton'
+import { TField, TUiRecipeForm } from '../types'
 import { defaultConfig } from '../components/Form'
 import { getDisplayLabel } from '../utils/getDisplayLabel'
+import { ObjectStorageUncontainedTemplate } from '../templates/ObjectStorageUncontainedTemplate'
+import { ObjectModelContainedTemplate } from '../templates/ObjectModelContainedTemplate'
+import { ObjectModelUncontainedTemplate } from '../templates/ObjectModelUncontainedTemplate'
 
-const SelectReference = (props: {
-  attributeType: string
-  namePath: string
-}) => {
-  const [showModal, setShowModal] = useState<boolean>(false)
-  const { setValue, watch } = useFormContext()
-  const dmssAPI = useDMSS()
-  const { idReference } = useRegistryContext()
-  const value = watch(props.namePath)
-
-  const onChange = (address: string) => {
-    const reference: TLinkReference = {
-      type: EBlueprint.REFERENCE,
-      referenceType: 'link',
-      address: address,
-    }
-    const options = {
-      shouldValidate: true,
-      shouldDirty: true,
-      shouldTouch: true,
-    }
-
-    const request = value
-      ? dmssAPI.documentUpdate({
-          idAddress: `${idReference}.${props.namePath}`,
-          data: JSON.stringify(reference),
-        })
-      : dmssAPI.documentAdd({
-          address: `${idReference}.${props.namePath}`,
-          document: JSON.stringify(reference),
-        })
-    request
-      .then(() => {
-        setValue(props.namePath, reference, options)
-      })
-      .catch((error: AxiosError<ErrorResponse>) => {
-        console.error(error)
-      })
-  }
-
-  return (
-    <>
-      <TooltipButton
-        title={`${value ? 'Edit' : 'Add'} and save`}
-        button-variant="ghost_icon"
-        button-onClick={() => setShowModal(true)}
-        icon={value ? edit : add}
-      />
-      <EntityPickerDialog
-        data-testid={`select-${props.namePath}`}
-        onChange={onChange}
-        typeFilter={props.attributeType}
-        showModal={showModal}
-        setShowModal={setShowModal}
-      />
-    </>
-  )
-}
-
-export const StorageUncontainedAttribute = (props: TContentProps) => {
-  const { namePath, uiRecipe, attribute, uiAttribute } = props
-  const { watch, setValue } = useFormContext()
-  const { idReference, onOpen } = useRegistryContext()
-  const { dataSource, documentPath } = splitAddress(idReference)
-  const { config } = useRegistryContext()
-  const value = watch(namePath)
-  const address = resolveRelativeAddress(
-    value.address,
-    documentPath,
-    dataSource
-  )
-  const { document, isLoading } = useDocument<any>(address, 1)
-
-  useEffect(() => {
-    if (!isLoading && document) setValue(namePath, document)
-  }, [document])
-
-  return (
-    <Fieldset>
-      <Legend>
-        <Typography bold={true}>{getDisplayLabel(attribute)}</Typography>
-        {!config.readOnly && (
-          <SelectReference
-            attributeType={attribute.attributeType}
-            namePath={namePath}
-          />
-        )}
-        {attribute.optional && address && !config.readOnly && (
-          <RemoveObject address={address} namePath={namePath} />
-        )}
-        {address && onOpen && !uiAttribute?.showInline && (
-          <OpenObjectButton
-            viewId={namePath}
-            viewConfig={{
-              type: 'ReferenceViewConfig',
-              scope: '',
-              recipe: uiRecipe?.name,
-            }}
-            idReference={address}
-          />
-        )}
-      </Legend>
-      {address && !(onOpen && !uiAttribute?.showInline) && (
-        <EntityView
-          idReference={address}
-          type={attribute.attributeType}
-          recipeName={uiRecipe?.name}
-          onOpen={onOpen}
-        />
-      )}
-    </Fieldset>
-  )
-}
-
-export const ContainedAttribute = (
-  props: TContentProps
-): React.ReactElement => {
-  const { namePath, uiAttribute, uiRecipe, attribute } = props
-  const { watch } = useFormContext()
-  const { idReference, onOpen, config } = useRegistryContext()
-
-  const [isExpanded, setIsExpanded] = useState(
-    uiAttribute?.showExpanded !== undefined
-      ? uiAttribute?.showExpanded
-      : config.showExpanded
-  )
-  const value = watch(namePath)
-  const isDefined = value && Object.keys(value).length > 0
-  return (
-    <Fieldset>
-      <Legend>
-        <Typography bold={true}>{getDisplayLabel(attribute)}</Typography>
-        {attribute.optional &&
-          !config.readOnly &&
-          (isDefined ? (
-            <RemoveObject namePath={namePath} />
-          ) : (
-            <AddObject
-              namePath={namePath}
-              type={attribute.attributeType}
-              defaultValue={attribute.default}
-            />
-          ))}
-        {isDefined && !(onOpen && !uiAttribute?.showInline) && (
-          <TooltipButton
-            title="Expand"
-            button-variant="ghost_icon"
-            button-onClick={() => setIsExpanded(!isExpanded)}
-            icon={isExpanded ? chevron_up : chevron_down}
-          />
-        )}
-        {isDefined && onOpen && !uiAttribute?.showInline && (
-          <OpenObjectButton
-            viewId={namePath}
-            idReference={idReference}
-            viewConfig={{
-              type: 'ReferenceViewConfig',
-              scope: namePath,
-              recipe: uiRecipe?.name,
-            }}
-          />
-        )}
-      </Legend>
-      {isDefined && !(onOpen && !uiAttribute?.showInline) && isExpanded && (
-        <EntityView
-          recipeName={uiRecipe.name}
-          idReference={`${idReference}.${namePath}`}
-          type={attribute.attributeType}
-          onOpen={onOpen}
-        />
-      )}
-    </Fieldset>
-  )
-}
-
-export const UncontainedAttribute = (
-  props: TContentProps
-): React.ReactElement => {
-  const { namePath, uiAttribute, uiRecipe, attribute } = props
-  const { watch } = useFormContext()
-  const { idReference, onOpen, config } = useRegistryContext()
-  const [isExpanded, setIsExpanded] = useState(
-    uiAttribute?.showExpanded !== undefined
-      ? uiAttribute?.showExpanded
-      : config.showExpanded
-  )
-  const value = watch(namePath)
-  const { dataSource, documentPath } = splitAddress(idReference)
-  const address =
-    value && value.address && value.referenceType === 'link'
-      ? resolveRelativeAddress(value.address, documentPath, dataSource)
-      : undefined
-  return (
-    <Fieldset>
-      <Legend>
-        <Typography bold={true}>{getDisplayLabel(attribute)}</Typography>
-        {!config.readOnly && (
-          <SelectReference
-            attributeType={attribute.attributeType}
-            namePath={namePath}
-          />
-        )}
-        {attribute.optional && address && !config.readOnly && (
-          <RemoveObject namePath={namePath} />
-        )}
-        {address && !(onOpen && !uiAttribute?.showInline) && (
-          <TooltipButton
-            title="Expand"
-            button-variant="ghost_icon"
-            button-onClick={() => setIsExpanded(!isExpanded)}
-            icon={isExpanded ? chevron_up : chevron_down}
-          />
-        )}
-        {address && onOpen && !uiAttribute?.showInline && (
-          <OpenObjectButton
-            viewId={namePath}
-            viewConfig={{
-              type: 'ReferenceViewConfig',
-              scope: '',
-              recipe: uiRecipe?.name,
-            }}
-            idReference={address}
-          />
-        )}
-      </Legend>
-      {address && !(onOpen && !uiAttribute?.showInline) && isExpanded && (
-        <EntityView
-          idReference={address}
-          type={attribute.attributeType}
-          recipeName={uiRecipe?.name}
-          onOpen={onOpen}
-        />
-      )}
-    </Fieldset>
-  )
-}
-
-export const ObjectField = (props: TObjectFieldProps): React.ReactElement => {
+export const ObjectField = (props: TField): React.ReactElement => {
   const { namePath, uiAttribute, attribute } = props
   const { getValues } = useFormContext()
   const values = getValues(namePath)
-  const valuesIsStorageReference =
+  const isStorageUncontained =
     values !== undefined &&
     'referenceType' in values &&
     values['referenceType'] === 'storage'
@@ -281,15 +30,15 @@ export const ObjectField = (props: TObjectFieldProps): React.ReactElement => {
         {...props}
         label={getDisplayLabel(attribute)}
         onChange={() => null}
-        id={valuesIsStorageReference ? values['address'] : namePath}
+        id={isStorageUncontained ? values['address'] : namePath}
         // if the attribute type is an object, we need to find the correct type from the values.
       />
     )
   }
 
   return (
-    <ObjectTypeSelector
-      uiAttribute={uiAttribute}
+    <ObjectTemplateSelector
+      namePath={namePath}
       attribute={{
         ...attribute,
         attributeType:
@@ -297,14 +46,12 @@ export const ObjectField = (props: TObjectFieldProps): React.ReactElement => {
             ? values.type
             : attribute.attributeType,
       }}
-      namePath={namePath}
+      uiAttribute={uiAttribute}
     />
   )
 }
 
-export const ObjectTypeSelector = (
-  props: TObjectFieldProps
-): React.ReactElement => {
+export const ObjectTemplateSelector = (props: TField): React.ReactElement => {
   const { namePath, uiAttribute, attribute } = props
   const { blueprint, uiRecipes, isLoading, error } = useBlueprint(
     attribute.attributeType
@@ -317,7 +64,7 @@ export const ObjectTypeSelector = (
       `Failed to fetch blueprint for '${attribute.attributeType}'`
     )
   if (blueprint === undefined) return <div>Could not find the blueprint</div>
-  const attributeIsStorageReference =
+  const isStorageUncontained =
     value !== undefined &&
     'referenceType' in value &&
     value['referenceType'] === 'storage'
@@ -343,14 +90,16 @@ export const ObjectTypeSelector = (
       `No UiRecipe named "${uiRecipeName}" could be found for type "${attribute.attributeType}"`
     )
 
-  const Content = attributeIsStorageReference
-    ? StorageUncontainedAttribute
-    : attribute.contained ?? true
-    ? ContainedAttribute
-    : UncontainedAttribute
+  const isModelContained = attribute.contained ?? true
+
+  const Template = isStorageUncontained
+    ? ObjectStorageUncontainedTemplate
+    : isModelContained
+    ? ObjectModelContainedTemplate
+    : ObjectModelUncontainedTemplate
 
   return (
-    <Content
+    <Template
       attribute={attribute}
       namePath={namePath}
       blueprint={blueprint}

--- a/packages/dm-core-plugins/src/form/templates/ArrayComplexTemplate.tsx
+++ b/packages/dm-core-plugins/src/form/templates/ArrayComplexTemplate.tsx
@@ -1,0 +1,84 @@
+import { TArrayTemplate } from '../types'
+import { useFormContext } from 'react-hook-form'
+import { useRegistryContext } from '../context/RegistryContext'
+import React, { useState } from 'react'
+import { EntityView, getKey } from '@development-framework/dm-core'
+import { Fieldset, Legend } from '../styles'
+import { Typography } from '@equinor/eds-core-react'
+import { getDisplayLabel } from '../utils/getDisplayLabel'
+import RemoveObject from '../components/RemoveObjectButton'
+import AddObject from '../components/AddObjectButton'
+import TooltipButton from '../../common/TooltipButton'
+import { chevron_down, chevron_up } from '@equinor/eds-icons'
+import { OpenObjectButton } from '../components/OpenObjectButton'
+
+export const ArrayComplexTemplate = (props: TArrayTemplate) => {
+  const { namePath, attribute, uiAttribute } = props
+
+  const { getValues, setValue } = useFormContext()
+  const { idReference, onOpen, config } = useRegistryContext()
+  const [initialValue, setInitialValue] = useState(getValues(namePath))
+  const [isExpanded, setIsExpanded] = useState(
+    uiAttribute?.showExpanded !== undefined
+      ? uiAttribute?.showExpanded
+      : config.showExpanded
+  )
+  const uiRecipeName = getKey<string>(uiAttribute, 'uiRecipe', 'string')
+  const isDefined = initialValue !== undefined
+
+  return (
+    <Fieldset>
+      <Legend>
+        <Typography bold={true}>{getDisplayLabel(attribute)}</Typography>
+        {attribute.optional &&
+          !config.readOnly &&
+          (isDefined ? (
+            <RemoveObject
+              namePath={namePath}
+              onRemove={() => {
+                setInitialValue(undefined)
+                setValue(namePath, undefined)
+              }}
+            />
+          ) : (
+            <AddObject
+              namePath={namePath}
+              type={attribute.attributeType}
+              defaultValue={[]}
+              onAdd={() => setInitialValue([])}
+            />
+          ))}
+        {isDefined && !(onOpen && !uiAttribute?.showInline) && (
+          <TooltipButton
+            title="Expand"
+            button-variant="ghost_icon"
+            button-onClick={() => setIsExpanded(!isExpanded)}
+            icon={isExpanded ? chevron_up : chevron_down}
+          />
+        )}
+        {!config.readOnly &&
+          isDefined &&
+          onOpen &&
+          !uiAttribute?.showInline && (
+            <OpenObjectButton
+              viewId={namePath}
+              viewConfig={{
+                type: 'ReferenceViewConfig',
+                scope: namePath,
+                recipe: uiRecipeName,
+              }}
+            />
+          )}
+      </Legend>
+      {isDefined && !(onOpen && !uiAttribute?.showInline) && isExpanded && (
+        <EntityView
+          recipeName={uiRecipeName}
+          idReference={`${idReference}.${namePath}`}
+          type={attribute.attributeType}
+          onOpen={onOpen}
+          dimensions={attribute.dimensions}
+        />
+      )}
+    </Fieldset>
+  )
+}

--- a/packages/dm-core-plugins/src/form/templates/ArrayPrimitiveTemplate.tsx
+++ b/packages/dm-core-plugins/src/form/templates/ArrayPrimitiveTemplate.tsx
@@ -1,0 +1,126 @@
+import { TArrayTemplate } from '../types'
+import { useFieldArray, useFormContext } from 'react-hook-form'
+import { useRegistryContext } from '../context/RegistryContext'
+import React, { useState } from 'react'
+import { Fieldset, Legend } from '../styles'
+import { Icon, Pagination, Typography } from '@equinor/eds-core-react'
+import { getDisplayLabel } from '../utils/getDisplayLabel'
+import TooltipButton from '../../common/TooltipButton'
+import {
+  add,
+  chevron_down,
+  chevron_up,
+  remove_outlined,
+} from '@equinor/eds-icons'
+import { isPrimitive } from '../utils'
+import { EBlueprint, Stack } from '@development-framework/dm-core'
+import { AttributeField } from '../fields/AttributeField'
+
+export const ArrayPrimitiveTemplate = (props: TArrayTemplate) => {
+  const { namePath, attribute, uiAttribute } = props
+
+  const { control } = useFormContext()
+  const { config } = useRegistryContext()
+  const [isExpanded, setIsExpanded] = useState(
+    uiAttribute?.showExpanded !== undefined
+      ? uiAttribute?.showExpanded
+      : config.showExpanded
+  )
+
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: namePath,
+  })
+  const [currentPageIndex, setCurrentPageIndex] = useState(0)
+  const itemsPerPage = 30
+
+  return (
+    <Fieldset>
+      <Legend>
+        <Typography bold={true}>{getDisplayLabel(attribute)}</Typography>
+        <TooltipButton
+          title="Expand"
+          button-variant="ghost_icon"
+          button-onClick={() => setIsExpanded(!isExpanded)}
+          icon={isExpanded ? chevron_up : chevron_down}
+        />
+        {!config.readOnly && isExpanded && (
+          <TooltipButton
+            title="Add"
+            button-variant="ghost_icon"
+            button-onClick={() => {
+              if (attribute.attributeType === 'boolean') {
+                append(true)
+                return
+              }
+              append(isPrimitive(attribute.attributeType) ? ' ' : {})
+            }}
+            icon={add}
+          />
+        )}
+      </Legend>
+      {isExpanded && (
+        <div
+          style={{
+            display: 'flex',
+            flexFlow: 'column wrap',
+            maxHeight: '23em',
+            alignContent: 'flex-start',
+          }}
+        >
+          {fields
+            .slice(
+              currentPageIndex * itemsPerPage,
+              currentPageIndex * itemsPerPage + itemsPerPage
+            )
+            .map((item: any, index: number) => {
+              const pagedIndex = itemsPerPage * currentPageIndex + index
+              return (
+                <Stack
+                  key={item.id}
+                  direction="row"
+                  spacing={0.5}
+                  alignSelf="stretch"
+                  alignItems="flex-end"
+                >
+                  <Stack grow={1}>
+                    <AttributeField
+                      namePath={`${namePath}.${pagedIndex}`}
+                      uiAttribute={uiAttribute}
+                      attribute={{
+                        attributeType: attribute.attributeType,
+                        dimensions: '',
+                        name: '',
+                        type: EBlueprint.ATTRIBUTE,
+                      }}
+                      leftAdornments={String(pagedIndex)}
+                      rightAdornments={
+                        <Icon
+                          data={remove_outlined}
+                          size={18}
+                          // @ts-ignore
+                          onClick={() => remove(pagedIndex)}
+                          style={{ cursor: 'pointer' }}
+                          data-testid={`form-text-widget-remove-${pagedIndex}`}
+                        />
+                      }
+                    />
+                  </Stack>
+                </Stack>
+              )
+            })}
+        </div>
+      )}
+      {isExpanded && fields.length > itemsPerPage && (
+        <div>
+          <Pagination
+            totalItems={fields.length}
+            itemsPerPage={itemsPerPage}
+            defaultPage={currentPageIndex + 1}
+            onChange={(e, p) => setCurrentPageIndex(p - 1)}
+          />
+        </div>
+      )}
+    </Fieldset>
+  )
+}

--- a/packages/dm-core-plugins/src/form/templates/ObjectModelContainedTemplate.tsx
+++ b/packages/dm-core-plugins/src/form/templates/ObjectModelContainedTemplate.tsx
@@ -1,0 +1,74 @@
+import { TObjectTemplate } from '../types'
+import React, { useState } from 'react'
+import { useFormContext } from 'react-hook-form'
+import { useRegistryContext } from '../context/RegistryContext'
+import { Fieldset, Legend } from '../styles'
+import { Typography } from '@equinor/eds-core-react'
+import { getDisplayLabel } from '../utils/getDisplayLabel'
+import RemoveObject from '../components/RemoveObjectButton'
+import AddObject from '../components/AddObjectButton'
+import TooltipButton from '../../common/TooltipButton'
+import { chevron_down, chevron_up } from '@equinor/eds-icons'
+import { OpenObjectButton } from '../components/OpenObjectButton'
+import { EntityView } from '@development-framework/dm-core'
+
+export const ObjectModelContainedTemplate = (
+  props: TObjectTemplate
+): React.ReactElement => {
+  const { namePath, uiAttribute, uiRecipe, attribute } = props
+  const { watch } = useFormContext()
+  const { idReference, onOpen, config } = useRegistryContext()
+
+  const [isExpanded, setIsExpanded] = useState(
+    uiAttribute?.showExpanded !== undefined
+      ? uiAttribute?.showExpanded
+      : config.showExpanded
+  )
+  const value = watch(namePath)
+  const isDefined = value && Object.keys(value).length > 0
+  return (
+    <Fieldset>
+      <Legend>
+        <Typography bold={true}>{getDisplayLabel(attribute)}</Typography>
+        {attribute.optional &&
+          !config.readOnly &&
+          (isDefined ? (
+            <RemoveObject namePath={namePath} />
+          ) : (
+            <AddObject
+              namePath={namePath}
+              type={attribute.attributeType}
+              defaultValue={attribute.default}
+            />
+          ))}
+        {isDefined && !(onOpen && !uiAttribute?.showInline) && (
+          <TooltipButton
+            title="Expand"
+            button-variant="ghost_icon"
+            button-onClick={() => setIsExpanded(!isExpanded)}
+            icon={isExpanded ? chevron_up : chevron_down}
+          />
+        )}
+        {isDefined && onOpen && !uiAttribute?.showInline && (
+          <OpenObjectButton
+            viewId={namePath}
+            idReference={idReference}
+            viewConfig={{
+              type: 'ReferenceViewConfig',
+              scope: namePath,
+              recipe: uiRecipe?.name,
+            }}
+          />
+        )}
+      </Legend>
+      {isDefined && !(onOpen && !uiAttribute?.showInline) && isExpanded && (
+        <EntityView
+          recipeName={uiRecipe.name}
+          idReference={`${idReference}.${namePath}`}
+          type={attribute.attributeType}
+          onOpen={onOpen}
+        />
+      )}
+    </Fieldset>
+  )
+}

--- a/packages/dm-core-plugins/src/form/templates/ObjectModelUncontainedTemplate.tsx
+++ b/packages/dm-core-plugins/src/form/templates/ObjectModelUncontainedTemplate.tsx
@@ -1,0 +1,79 @@
+import { TObjectTemplate } from '../types'
+import React, { useState } from 'react'
+import { useFormContext } from 'react-hook-form'
+import { useRegistryContext } from '../context/RegistryContext'
+import {
+  EntityView,
+  resolveRelativeAddress,
+  splitAddress,
+} from '@development-framework/dm-core'
+import { Fieldset, Legend } from '../styles'
+import { Typography } from '@equinor/eds-core-react'
+import { getDisplayLabel } from '../utils/getDisplayLabel'
+import RemoveObject from '../components/RemoveObjectButton'
+import TooltipButton from '../../common/TooltipButton'
+import { chevron_down, chevron_up } from '@equinor/eds-icons'
+import { OpenObjectButton } from '../components/OpenObjectButton'
+import { SelectReference } from '../components/SelectReference'
+
+export const ObjectModelUncontainedTemplate = (
+  props: TObjectTemplate
+): React.ReactElement => {
+  const { namePath, uiAttribute, uiRecipe, attribute } = props
+  const { watch } = useFormContext()
+  const { idReference, onOpen, config } = useRegistryContext()
+  const [isExpanded, setIsExpanded] = useState(
+    uiAttribute?.showExpanded !== undefined
+      ? uiAttribute?.showExpanded
+      : config.showExpanded
+  )
+  const value = watch(namePath)
+  const { dataSource, documentPath } = splitAddress(idReference)
+  const address =
+    value && value.address && value.referenceType === 'link'
+      ? resolveRelativeAddress(value.address, documentPath, dataSource)
+      : undefined
+  return (
+    <Fieldset>
+      <Legend>
+        <Typography bold={true}>{getDisplayLabel(attribute)}</Typography>
+        {!config.readOnly && (
+          <SelectReference
+            attributeType={attribute.attributeType}
+            namePath={namePath}
+          />
+        )}
+        {attribute.optional && address && !config.readOnly && (
+          <RemoveObject namePath={namePath} />
+        )}
+        {address && !(onOpen && !uiAttribute?.showInline) && (
+          <TooltipButton
+            title="Expand"
+            button-variant="ghost_icon"
+            button-onClick={() => setIsExpanded(!isExpanded)}
+            icon={isExpanded ? chevron_up : chevron_down}
+          />
+        )}
+        {address && onOpen && !uiAttribute?.showInline && (
+          <OpenObjectButton
+            viewId={namePath}
+            viewConfig={{
+              type: 'ReferenceViewConfig',
+              scope: '',
+              recipe: uiRecipe?.name,
+            }}
+            idReference={address}
+          />
+        )}
+      </Legend>
+      {address && !(onOpen && !uiAttribute?.showInline) && isExpanded && (
+        <EntityView
+          idReference={address}
+          type={attribute.attributeType}
+          recipeName={uiRecipe?.name}
+          onOpen={onOpen}
+        />
+      )}
+    </Fieldset>
+  )
+}

--- a/packages/dm-core-plugins/src/form/templates/ObjectStorageUncontainedTemplate.tsx
+++ b/packages/dm-core-plugins/src/form/templates/ObjectStorageUncontainedTemplate.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect } from 'react'
+import { useFormContext } from 'react-hook-form'
+import {
+  EntityView,
+  resolveRelativeAddress,
+  splitAddress,
+  useDocument,
+} from '@development-framework/dm-core'
+import { useRegistryContext } from '../context/RegistryContext'
+import { TObjectTemplate } from '../types'
+import { Fieldset, Legend } from '../styles'
+import { Typography } from '@equinor/eds-core-react'
+import { getDisplayLabel } from '../utils/getDisplayLabel'
+import RemoveObject from '../components/RemoveObjectButton'
+import { OpenObjectButton } from '../components/OpenObjectButton'
+import { SelectReference } from '../components/SelectReference'
+
+export const ObjectStorageUncontainedTemplate = (props: TObjectTemplate) => {
+  const { namePath, uiRecipe, attribute, uiAttribute } = props
+  const { watch, setValue } = useFormContext()
+  const { idReference, onOpen } = useRegistryContext()
+  const { dataSource, documentPath } = splitAddress(idReference)
+  const { config } = useRegistryContext()
+  const value = watch(namePath)
+  const address = resolveRelativeAddress(
+    value.address,
+    documentPath,
+    dataSource
+  )
+  const { document, isLoading } = useDocument<any>(address, 1)
+
+  useEffect(() => {
+    if (!isLoading && document) setValue(namePath, document)
+  }, [document])
+
+  return (
+    <Fieldset>
+      <Legend>
+        <Typography bold={true}>{getDisplayLabel(attribute)}</Typography>
+        {!config.readOnly && (
+          <SelectReference
+            attributeType={attribute.attributeType}
+            namePath={namePath}
+          />
+        )}
+        {attribute.optional && address && !config.readOnly && (
+          <RemoveObject address={address} namePath={namePath} />
+        )}
+        {address && onOpen && !uiAttribute?.showInline && (
+          <OpenObjectButton
+            viewId={namePath}
+            viewConfig={{
+              type: 'ReferenceViewConfig',
+              scope: '',
+              recipe: uiRecipe?.name,
+            }}
+            idReference={address}
+          />
+        )}
+      </Legend>
+      {address && !(onOpen && !uiAttribute?.showInline) && (
+        <EntityView
+          idReference={address}
+          type={attribute.attributeType}
+          recipeName={uiRecipe?.name}
+          onOpen={onOpen}
+        />
+      )}
+    </Fieldset>
+  )
+}

--- a/packages/dm-core-plugins/src/form/types.tsx
+++ b/packages/dm-core-plugins/src/form/types.tsx
@@ -15,13 +15,7 @@ export type TFormProps = {
   onSubmit?: (data: any) => void
 }
 
-export type TObjectFieldProps = {
-  namePath: string
-  uiAttribute: TAttributeObject | undefined
-  attribute: TAttribute
-}
-
-export type TContentProps = {
+export type TObjectTemplate = {
   namePath: string
   blueprint: TBlueprint | undefined
   uiRecipe: TUiRecipeForm
@@ -29,11 +23,9 @@ export type TContentProps = {
   attribute: TAttribute
 }
 
-export type TArrayFieldProps = {
+export type TArrayTemplate = {
   namePath: string
   uiAttribute: TAttributeArray | undefined
-  readOnly?: boolean
-  showExpanded?: boolean
   attribute: TAttribute
 }
 
@@ -58,7 +50,7 @@ type TAttributeString = TAttributeBase & {
 type TAttributeArray = TAttributeBase & {
   widget?: string
   uiRecipe?: string
-  showExpanded?: boolean
+  showExpanded: boolean
 }
 type TAttributeObject = TAttributeBase & {
   widget?: string

--- a/packages/dm-core-plugins/src/form/utils/isPrimitiveType.tsx
+++ b/packages/dm-core-plugins/src/form/utils/isPrimitiveType.tsx
@@ -1,0 +1,3 @@
+export const isPrimitiveType = (value: string): boolean => {
+  return ['string', 'number', 'integer', 'boolean'].includes(value)
+}


### PR DESCRIPTION
## What does this pull request change?

* Add templates to divide the code more up and more easy to understand/maintaine

<img width="347" alt="image" src="https://github.com/equinor/dm-core-packages/assets/1190419/87a43534-22ea-4951-82b7-92dd1f5b8cf3">

> **NOTE**: This PR is based on #807, so that needs to be taken in first.

## Why is this pull request needed?

## Issues related to this change

