### PR TITLE
fix(header): Did not rerender views since key was not set on <UiPlugin>

### DIFF
--- a/example/app/data/DemoDataSource/recipes/apps/ExampleApplication/ExampleApplication.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/apps/ExampleApplication/ExampleApplication.recipe.json
@@ -9,8 +9,7 @@
       "type": "PLUGINS:dm-core-plugins/header/HeaderPluginConfig",
       "uiRecipesList": [
         "ExampleApplication",
-        "Example",
-        "ViewMedia"
+        "Example"
       ],
       "hideAbout": false,
       "hideUserInfo": false

--- a/packages/dm-core-plugins/src/header/HeaderPlugin.tsx
+++ b/packages/dm-core-plugins/src/header/HeaderPlugin.tsx
@@ -87,6 +87,7 @@ export default (props: IUIPlugin): React.ReactElement => {
     const recipe = uiRecipes.find(
       (recipe: TUiRecipe) => recipe.name === recipeName
     )
+    if (!recipe) throw new Error(`Failed to find recipe named '${recipeName}'`)
     return {
       component: getUiPlugin(recipe.plugin),
       config: recipe?.config ?? {},
@@ -107,6 +108,7 @@ export default (props: IUIPlugin): React.ReactElement => {
 
   const UIPlugin: (props: IUIPlugin) => React.ReactElement =
     selectedRecipe.component
+
   if (isLoading || !entity || isBlueprintLoading) {
     return <Loading />
   }
@@ -168,6 +170,7 @@ export default (props: IUIPlugin): React.ReactElement => {
         applicationEntity={entity}
       />
       <UIPlugin
+        key={idReference + selectedRecipe.name}
         idReference={idReference}
         type={entity.type}
         config={selectedRecipe.config}


### PR DESCRIPTION
## What does this pull request change?
- Adds "key" with recipe name for <UiPlugin>. This is needed as the other props might not change.

## Why is this pull request needed?
- bug

## Issues related to this change
closes #https://github.com/equinor/dm-app-simpos/issues/57
