### PR TITLE
fix: header ui

### DIFF
--- a/e2e/tests/plugin-form-model_uncontained-complex_attribute.spec.ts
+++ b/e2e/tests/plugin-form-model_uncontained-complex_attribute.spec.ts
@@ -18,6 +18,7 @@ test('Model uncontained complex attribute', async ({ page }) => {
     await page.getByRole('button', { name: 'Edit' }).click()
     await expect(page.getByLabel('Name')).toHaveValue('TheBlackPearl')
     await page.getByRole('button', { name: 'Open in tab', exact: true }).click()
+    await expect(page.getByRole('tab', { name: 'captain' })).toBeVisible()
     await expect(page.getByRole('code')).toBeVisible()
     await page.getByRole('button', { name: 'Edit' }).nth(1).click()
     await expect(page.getByTestId('form-text-widget-name').nth(1)).toHaveValue(
@@ -27,39 +28,27 @@ test('Model uncontained complex attribute', async ({ page }) => {
       page.getByTestId('form-number-widget-Phone Number (optional)')
     ).toHaveValue('0')
     await page.getByLabel('Close captain').click()
+    await expect(page.getByRole('tab', { name: 'captain' })).not.toBeVisible()
   })
 
   await test.step('Update model uncontained', async () => {
     await page
       .getByRole('button', { name: 'Edit and save', exact: true })
       .click()
-    await page
-      .getByTestId('captain')
-      .getByRole('button', { name: 'DemoDataSource' })
-      .click()
-    await page
-      .getByTestId('captain')
-      .getByRole('button', { name: 'plugins' })
-      .click()
-    await page
-      .getByTestId('captain')
-      .getByRole('button', { name: 'form' })
-      .click()
-    await page
-      .getByTestId('captain')
-      .getByRole('button', { name: 'model_uncontained' })
-      .click()
-    await page
-      .getByTestId('captain')
-      .getByRole('button', { name: 'complex_attribute' })
-      .click()
-    await page
-      .getByTestId('captain')
-      .getByRole('button', { name: 'Barbossa' })
-      .click()
-    await page.getByRole('button', { name: 'Select', exact: true }).click()
-    await page.waitForTimeout(1000)
+
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+    await dialog.getByRole('button', { name: 'DemoDataSource' }).click()
+    await dialog.getByRole('button', { name: 'plugins' }).click()
+    await dialog.getByRole('button', { name: 'form' }).click()
+    await dialog.getByRole('button', { name: 'model_uncontained' }).click()
+    await dialog.getByRole('button', { name: 'complex_attribute' }).click()
+    await dialog.getByRole('button', { name: 'Barbossa' }).click()
+    await dialog.getByRole('button', { name: 'Select', exact: true }).click()
+    await expect(dialog).not.toBeVisible()
+
     await page.getByRole('button', { name: 'Open in tab', exact: true }).click()
+    await expect(page.getByRole('tab', { name: 'captain' })).toBeVisible()
     await expect(page.getByRole('code')).toBeVisible()
     await page.getByRole('button', { name: 'Edit' }).nth(1).click()
     await expect(page.getByTestId('form-text-widget-name').nth(1)).toHaveValue(

--- a/e2e/tests/plugin-header.spec.ts
+++ b/e2e/tests/plugin-header.spec.ts
@@ -13,9 +13,7 @@ test.beforeEach(async ({ page }) => {
 
 test('Load header', async ({ page }) => {
   await expect(page.getByLabel('AppSelector').nth(1)).toBeVisible()
-  await expect(
-    page.getByRole('heading', { name: 'Data Modelling Example App' })
-  ).toBeVisible()
+  await expect(page.getByLabel('main-heading').nth(1)).toBeVisible()
   await expect(page.getByRole('button', { name: 'User' }).nth(1)).toBeVisible()
   await expect(page.getByRole('button', { name: 'About' }).nth(1)).toBeVisible()
 })

--- a/packages/dm-core-plugins/src/header/HeaderPlugin.tsx
+++ b/packages/dm-core-plugins/src/header/HeaderPlugin.tsx
@@ -27,12 +27,13 @@ const Icons = styled.div`
     margin-left: 40px;
   }
 `
-const Logo = styled.h2`
+const Logo = styled.span`
   paddinginline: 10;
   color: #007079;
   font-weight: 500;
   margin-right: 3rem;
   margin-left: 0.5rem;
+  font-size: 18px;
 `
 
 const ClickableIcon = styled.button`
@@ -129,11 +130,11 @@ export default (props: IUIPlugin): React.ReactElement => {
       >
         <TopBar.Header
           style={{
-            position: 'relative',
             display: 'flex',
+            alignContent: 'center',
           }}
         >
-          <Logo>{entity.label}</Logo>
+          <Logo aria-label="main-heading">{entity.label}</Logo>
           <AppSelector
             items={recipeNames}
             onSelectItem={(item) =>

--- a/packages/dm-core-plugins/src/header/components/AppSelector.tsx
+++ b/packages/dm-core-plugins/src/header/components/AppSelector.tsx
@@ -34,6 +34,7 @@ const AppSelectorButton = styled.button`
   marginleft: 60px;
   border: 0;
   appearance: none;
+  align-content: center;
   background-color: transparent;
   &:hover {
     color: gray;
@@ -55,9 +56,9 @@ export const AppSelector = ({
         onClick={() => setAppSelectorOpen(!appSelectorOpen)}
         aria-label="AppSelector"
       >
-        <h4>{currentItem}</h4>
+        <span className="text-xs font-bold self-center">{currentItem}</span>
         <Icon
-          style={{ marginTop: '13px' }}
+          className="mt-0.5"
           data={appSelectorOpen ? chevron_up : chevron_down}
         ></Icon>
       </AppSelectorButton>


### PR DESCRIPTION
## What does this pull request change?
<img width="491" alt="image" src="https://github.com/equinor/dm-core-packages/assets/37016135/d507a898-9c73-4c0a-ae09-e598fc2483a9">


after tailwind made h2 and h4 not styled anymore
<img width="463" alt="image" src="https://github.com/equinor/dm-core-packages/assets/37016135/faad9fc4-53ca-4411-9ad4-cfa1d89ff3d5">


## Why is this pull request needed?

## Issues related to this change

