### PR TITLE
fix: model uncontained and media_viewer tests

### DIFF
--- a/e2e/tests/plugin-form-Media_viewer.spec.ts
+++ b/e2e/tests/plugin-form-Media_viewer.spec.ts
@@ -27,16 +27,16 @@ test('Media viewer', async ({ page }) => {
   })
   await test.step('gif', async () => {
     await page.getByRole('button', { name: 'fast' }).click()
+    await expect(page.locator('img')).toHaveJSProperty('complete', true)
+    await expect(page.locator('img')).not.toHaveJSProperty('naturalWidth', 0)
     await expect(page.getByRole('img', { name: 'fast' })).toBeVisible()
     await page.getByRole('button', { name: 'view meta info' }).click()
-
     const page1Promise = page.waitForEvent('popup')
     await expect(dialog.getByText('image/gif')).toBeVisible()
     await dialog.getByRole('link', { name: 'New tab' }).click()
     const newTab = await page1Promise
     await expect(newTab.getByRole('img')).toBeVisible()
     await newTab.close()
-
     const downloadPromise = page.waitForEvent('download')
     await page.getByRole('link', { name: 'Download' }).click()
     const download = await downloadPromise
@@ -45,6 +45,8 @@ test('Media viewer', async ({ page }) => {
 
   await test.step('image', async () => {
     await page.getByRole('button', { name: 'beauty' }).click()
+    await expect(page.locator('img')).toHaveJSProperty('complete', true)
+    await expect(page.locator('img')).not.toHaveJSProperty('naturalWidth', 0)
     await expect(page.getByRole('img', { name: 'beauty' })).toBeVisible()
     await page.getByRole('button', { name: 'view meta info' }).click()
 

--- a/e2e/tests/plugin-form-model_uncontained-complex_attribute.spec.ts
+++ b/e2e/tests/plugin-form-model_uncontained-complex_attribute.spec.ts
@@ -18,6 +18,7 @@ test('Model uncontained complex attribute', async ({ page }) => {
     await page.getByRole('button', { name: 'Edit' }).click()
     await expect(page.getByLabel('Name')).toHaveValue('TheBlackPearl')
     await page.getByRole('button', { name: 'Open in tab', exact: true }).click()
+    await expect(page.getByRole('tab', { name: 'captain' })).toBeVisible()
     await expect(page.getByRole('code')).toBeVisible()
     await page.getByRole('button', { name: 'Edit' }).nth(1).click()
     await expect(page.getByTestId('form-text-widget-name').nth(1)).toHaveValue(
@@ -27,39 +28,27 @@ test('Model uncontained complex attribute', async ({ page }) => {
       page.getByTestId('form-number-widget-Phone Number (optional)')
     ).toHaveValue('0')
     await page.getByLabel('Close captain').click()
+    await expect(page.getByRole('tab', { name: 'captain' })).not.toBeVisible()
   })
 
   await test.step('Update model uncontained', async () => {
     await page
       .getByRole('button', { name: 'Edit and save', exact: true })
       .click()
-    await page
-      .getByTestId('captain')
-      .getByRole('button', { name: 'DemoDataSource' })
-      .click()
-    await page
-      .getByTestId('captain')
-      .getByRole('button', { name: 'plugins' })
-      .click()
-    await page
-      .getByTestId('captain')
-      .getByRole('button', { name: 'form' })
-      .click()
-    await page
-      .getByTestId('captain')
-      .getByRole('button', { name: 'model_uncontained' })
-      .click()
-    await page
-      .getByTestId('captain')
-      .getByRole('button', { name: 'complex_attribute' })
-      .click()
-    await page
-      .getByTestId('captain')
-      .getByRole('button', { name: 'Barbossa' })
-      .click()
-    await page.getByRole('button', { name: 'Select', exact: true }).click()
-    await page.waitForTimeout(1000)
+
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+    await dialog.getByRole('button', { name: 'DemoDataSource' }).click()
+    await dialog.getByRole('button', { name: 'plugins' }).click()
+    await dialog.getByRole('button', { name: 'form' }).click()
+    await dialog.getByRole('button', { name: 'model_uncontained' }).click()
+    await dialog.getByRole('button', { name: 'complex_attribute' }).click()
+    await dialog.getByRole('button', { name: 'Barbossa' }).click()
+    await dialog.getByRole('button', { name: 'Select', exact: true }).click()
+    await expect(dialog).not.toBeVisible()
+
     await page.getByRole('button', { name: 'Open in tab', exact: true }).click()
+    await expect(page.getByRole('tab', { name: 'captain' })).toBeVisible()
     await expect(page.getByRole('code')).toBeVisible()
     await page.getByRole('button', { name: 'Edit' }).nth(1).click()
     await expect(page.getByTestId('form-text-widget-name').nth(1)).toHaveValue(


### PR DESCRIPTION
## What does this pull request change?
Added some extra asserts and other changes to try to make the test more stabile.

If the media_viewer test still is flaky, we could try to use expect.toPass to retry the assertions. The reason the test was flaky seem to be that the test proceeded before the image was completely loaded.

## Why is this pull request needed?
Tests were flaky.

## Issues related to this change

