### PR TITLE
test: close model after called on change

### DIFF
--- a/packages/dm-core/src/components/Pickers/EntityPickerDialog.tsx
+++ b/packages/dm-core/src/components/Pickers/EntityPickerDialog.tsx
@@ -61,8 +61,8 @@ export const EntityPickerDialog = (props: {
     selectedTreeNode
       .fetch()
       .then((doc: any) => {
-        setShowModal(false)
         onChange(selectedTreeNode.nodeId, doc)
+        setShowModal(false)
       })
       .catch((error: any) => {
         console.error(error)


### PR DESCRIPTION
## What does this pull request change?

* Close the model after calling on an update to make the test more stable.

<img width="896" alt="image" src="https://github.com/equinor/dm-core-packages/assets/1190419/eec7f072-4da6-441b-abcc-4bacd8657301">


## Why is this pull request needed?

## Issues related to this change

