### PR TITLE
refactor: use Icon data instead of name

### DIFF
--- a/packages/dm-core-plugins/src/form/widgets/TextareaWidget.tsx
+++ b/packages/dm-core-plugins/src/form/widgets/TextareaWidget.tsx
@@ -1,11 +1,7 @@
 import React from 'react'
 
-import { Icon, TextField } from '@equinor/eds-core-react'
-
-import { error_filled } from '@equinor/eds-icons'
+import { TextField } from '@equinor/eds-core-react'
 import { TWidget } from '../types'
-
-Icon.add({ error_filled })
 
 const TextareaWidget = (props: TWidget) => {
   const { label, onChange } = props

--- a/packages/dm-core-plugins/src/role_filter/RoleFilterPlugin.tsx
+++ b/packages/dm-core-plugins/src/role_filter/RoleFilterPlugin.tsx
@@ -5,9 +5,7 @@ import {
 } from '@development-framework/dm-core'
 import React, { useContext, useEffect, useState } from 'react'
 import { Banner, Icon } from '@equinor/eds-core-react'
-import { edit_text, save, thumbs_down } from '@equinor/eds-icons'
-
-Icon.add({ thumbs_down, save, edit_text })
+import { thumbs_down } from '@equinor/eds-icons'
 
 type FilteredView = {
   type: string

--- a/packages/dm-core-plugins/src/role_filter/RoleFilterPlugin.tsx
+++ b/packages/dm-core-plugins/src/role_filter/RoleFilterPlugin.tsx
@@ -75,7 +75,7 @@ export const RoleFilterPlugin = (props: IUIPlugin): React.ReactElement => {
         // The user does not have any role matching any view, so there is nothing to show
         <Banner>
           <Banner.Icon variant='warning'>
-            <Icon name='thumbs_down' />
+            <Icon data={thumbs_down} />
           </Banner.Icon>
           <Banner.Message>
             {`No views found, since you currently have role [${selectedRole}]. Please switch to one of these roles: [${allowedRoles}]`}

--- a/packages/dm-core/src/components/AccessControl/ACLOwnerPanel.tsx
+++ b/packages/dm-core/src/components/AccessControl/ACLOwnerPanel.tsx
@@ -1,8 +1,9 @@
 import { Icon, Input } from '@equinor/eds-core-react'
 import { ACLSelect } from './ACLSelect'
-import { AccessLevel, AccessControlList } from '../../services'
+import { AccessControlList, AccessLevel } from '../../services'
 import React from 'react'
 import { CenteredRow } from './AccessControlListComponent'
+import { edit_text } from '@equinor/eds-icons'
 
 interface IACLOwnerPanelProps {
   acl: AccessControlList
@@ -24,7 +25,7 @@ export const ACLOwnerPanel = ({
             handleChange({ owner: event.target.value })
           }
         />
-        <Icon name='edit_text' size={24} style={{ color: 'teal' }} />
+        <Icon data={edit_text} size={24} style={{ color: 'teal' }} />
       </CenteredRow>
       <CenteredRow width={'160px'}>
         Others:

--- a/packages/dm-core/src/components/AccessControl/AccessControlListComponent.tsx
+++ b/packages/dm-core/src/components/AccessControl/AccessControlListComponent.tsx
@@ -1,5 +1,5 @@
 import { Button, Checkbox, Icon, Progress, Tabs } from '@equinor/eds-core-react'
-import { edit_text, save } from '@equinor/eds-icons'
+import { save } from '@equinor/eds-icons'
 import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
 
@@ -16,8 +16,6 @@ import {
 } from '../../utils/UsernameConversion'
 import { ACLOwnerPanel } from './ACLOwnerPanel'
 import { ACLUserRolesPanel } from './ACLUserRolesPanel'
-
-Icon.add({ edit_text, save })
 
 const ACLWrapper = styled.div`
   max-width: 650px;
@@ -263,7 +261,7 @@ export const AccessControlListComponent = (props: {
       <CenteredRow>
         <Button onClick={() => saveAccessControlList(documentACL)}>
           {(loading && <Progress.Dots color='neutral' />) || 'Save'}
-          {!loading && <Icon name='save' title='save' size={24} />}
+          {!loading && <Icon data={save} title='save' size={24} />}
         </Button>
         <Checkbox
           checked={storeACLRecursively}

--- a/packages/dm-core/src/components/Table/TableHead/TableHead.tsx
+++ b/packages/dm-core/src/components/Table/TableHead/TableHead.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from 'react'
 import { Button, Icon, Menu, Table } from '@equinor/eds-core-react'
-import { more_vertical } from '@equinor/eds-icons'
+import { arrow_down, arrow_up, more_vertical } from '@equinor/eds-icons'
 import {
-  TTableColumnConfig,
   TableHeadProps,
   TableVariantNameEnum,
+  TTableColumnConfig,
 } from '../types'
 import { SortCell } from './styles'
 
@@ -64,8 +64,8 @@ export function TableHead(props: TableHeadProps) {
               {column.sortable &&
                 tableVariant === TableVariantNameEnum.View && (
                   <Icon
-                    name={
-                      sortDirection === 'descending' ? 'arrow_down' : 'arrow_up'
+                    data={
+                      sortDirection === 'descending' ? arrow_down : arrow_up
                     }
                   />
                 )}

--- a/packages/dm-core/src/components/Table/TableRow/TableRow.tsx
+++ b/packages/dm-core/src/components/Table/TableRow/TableRow.tsx
@@ -1,11 +1,12 @@
 import React, { useState } from 'react'
 import { EdsProvider, Icon, Table } from '@equinor/eds-core-react'
 import { ViewCreator } from '../../../'
-import { TTableColumnConfig, TableRowProps } from '../types'
+import { TableRowProps, TTableColumnConfig } from '../types'
 import * as utils from '../utils'
 import * as Styled from './styles'
 import { TableRowActions } from './TableRowActions/TableRowActions'
 import { TableCell } from './TableCell/TableCell'
+import { add } from '@equinor/eds-icons'
 
 export function TableRow(props: TableRowProps) {
   const {
@@ -67,7 +68,7 @@ export function TableRow(props: TableRowProps) {
               onClick={() => addItem(index)}
             >
               <span className='resting_state_indicator' />
-              <Icon name='add' color='white' />
+              <Icon data={add} color='white' />
             </Styled.InsertRowButton>
           </Table.Cell>
         </Table.Row>


### PR DESCRIPTION
## What does this pull request change?
Changes the usage of icon to use the data prop instead of the name
## Why is this pull request needed?

## Issues related to this change

