### PR TITLE
bug: re enable job controls on remove cancelation

### DIFF
--- a/packages/dm-core-plugins/src/job/CrateFromRecipe.tsx
+++ b/packages/dm-core-plugins/src/job/CrateFromRecipe.tsx
@@ -72,6 +72,7 @@ export const CrateFromRecipe = (
   const [asCronJob, setAsCronJob] = useState<boolean>(config.recurring ?? false)
   const [schedule, setSchedule] = useState<TSchedule>(scheduleTemplate())
   const [showRemoveDialog, setShowRemoveDialog] = useState<boolean>(false)
+  const [disableControls, setDisableControls] = useState<boolean>(false)
 
   const jobEntity: TJob | TRecurringJob = useMemo(
     () =>
@@ -130,6 +131,20 @@ export const CrateFromRecipe = (
     if (jobDocument.type === EBlueprint.RECURRING_JOB) setAsCronJob(true)
   }, [isLoading, jobEntityError, jobDocument])
 
+  useEffect(() => {
+    setDisableControls(false)
+  }, [status])
+
+  const getVariant = (status: JobStatus) => {
+    switch (status) {
+      case JobStatus.Failed:
+        return 'error'
+      case JobStatus.Completed:
+        return 'active'
+      default:
+        return 'default'
+    }
+  }
   return (
     <div>
       {asCronJob && (
@@ -149,6 +164,8 @@ export const CrateFromRecipe = (
           createJob={createAndStartJob}
           remove={remove}
           confirmRemove={() => setShowRemoveDialog(true)}
+          disableControls={disableControls}
+          afterClick={() => setDisableControls(true)}
           asCronJob={asCronJob}
           exists={exists}
         />
@@ -191,6 +208,7 @@ export const CrateFromRecipe = (
         onConfirm={remove}
         close={() => {
           setShowRemoveDialog(false)
+          setDisableControls(false)
         }}
       />
     </div>

--- a/packages/dm-core-plugins/src/job/JobControlButton.tsx
+++ b/packages/dm-core-plugins/src/job/JobControlButton.tsx
@@ -8,17 +8,27 @@ export const JobControlButton = (props: {
   createJob: () => void
   remove: () => void
   confirmRemove: () => void
+  disableControls: boolean
+  afterClick: () => void
   asCronJob: boolean
   exists: boolean
 }) => {
-  const { jobStatus, createJob, asCronJob, exists, remove, confirmRemove } =
-    props
+  const {
+    jobStatus,
+    createJob,
+    asCronJob,
+    exists,
+    remove,
+    confirmRemove,
+    disableControls,
+    afterClick,
+  } = props
   const [hovering, setHovering] = useState(false)
   const [buttonColor, setButtonColor] = useState<
     'primary' | 'secondary' | 'danger'
   >('primary')
   const [buttonIcon, setButtonIcon] = useState<IconData>(play)
-  const [recentlyClicked, setRecentlyClicked] = useState<boolean>(false)
+  const buttonRef: MutableRefObject<HTMLButtonElement | undefined> = useRef()
 
   useEffect(() => {
     switch (jobStatus) {
@@ -39,13 +49,12 @@ export const JobControlButton = (props: {
         setButtonColor('primary')
         setButtonIcon(asCronJob ? save : play)
     }
-    setRecentlyClicked(false)
   }, [jobStatus, asCronJob])
 
   return (
     <Button
       variant='contained_icon'
-      disable={recentlyClicked}
+      disabled={disableControls}
       aria-label='Run'
       onMouseEnter={() => setHovering(true)}
       onMouseLeave={() => setHovering(false)}
@@ -73,9 +82,8 @@ export const JobControlButton = (props: {
         } else {
           createJob()
         }
-        setRecentlyClicked(true)
+        afterClick()
       }}
-      disabled={recentlyClicked}
     >
       {jobStatus === JobStatus.Running && !hovering ? (
         <CircularProgress size={16} variant='indeterminate' color='neutral' />


### PR DESCRIPTION
## What does this pull request change?
Bug where job control button in JobPlugin remained disabled when the user clicks cancel on the confirm delete prompt

## Why is this pull request needed?

## Issues related to this change

