### PR TITLE
feat: Removes up-down arrows in numberfields

### DIFF
--- a/packages/dm-core-plugins/src/form/components/NumberFieldWithoutArrows.tsx
+++ b/packages/dm-core-plugins/src/form/components/NumberFieldWithoutArrows.tsx
@@ -1,0 +1,16 @@
+import styled from 'styled-components'
+import { TextField } from '@equinor/eds-core-react'
+
+export const NumberFieldWithoutArrows = styled(TextField)`
+  /* Chrome, Safari, Edge, Opera */
+  input::-webkit-outer-spin-button,
+  input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+
+  /* Firefox */
+  input[type=number] {
+    -moz-appearance: textfield;
+  }
+  `

--- a/packages/dm-core-plugins/src/form/widgets/DimensionalScalarWidget.tsx
+++ b/packages/dm-core-plugins/src/form/widgets/DimensionalScalarWidget.tsx
@@ -1,6 +1,7 @@
 import React, { useState, ChangeEvent } from 'react'
 import { TWidget } from '../types'
 import { TextField, Tooltip, Typography } from '@equinor/eds-core-react'
+import { NumberFieldWithoutArrows } from '../components/NumberFieldWithoutArrows'
 
 const DimensionalScalarWidget = ({
   value: entity,
@@ -16,6 +17,7 @@ const DimensionalScalarWidget = ({
     ? typeof entity === 'number'
     : typeof entity?.value === 'number'
 
+  const InputField = isNumber ? NumberFieldWithoutArrows : TextField
   return (
     <div style={widgetConfig?.width ? { maxWidth: widgetConfig?.width } : {}}>
       <div
@@ -35,7 +37,7 @@ const DimensionalScalarWidget = ({
           </Typography>
         </Tooltip>
       </div>
-      <TextField
+      <InputField
         unit={widgetConfig?.unit || entity?.unit}
         type={isNumber ? 'number' : undefined}
         meta={widgetConfig?.meta || entity?.meta}

--- a/packages/dm-core-plugins/src/form/widgets/NumberWidget.tsx
+++ b/packages/dm-core-plugins/src/form/widgets/NumberWidget.tsx
@@ -1,23 +1,6 @@
 import React from 'react'
-
-import { TextField } from '@equinor/eds-core-react'
-
+import { NumberFieldWithoutArrows } from '../components/NumberFieldWithoutArrows'
 import { TWidget } from '../types'
-import styled from 'styled-components'
-
-const NumberFieldWithoutArrows = styled(TextField)`
-  /* Chrome, Safari, Edge, Opera */
-  input::-webkit-outer-spin-button,
-  input::-webkit-inner-spin-button {
-    -webkit-appearance: none;
-    margin: 0;
-  }
-
-  /* Firefox */
-  input[type=number] {
-    -moz-appearance: textfield;
-  }
-`
 
 const NumberWidget = (props: TWidget) => {
   const { label, onChange, isDirty } = props

--- a/packages/dm-core-plugins/src/form/widgets/NumberWidget.tsx
+++ b/packages/dm-core-plugins/src/form/widgets/NumberWidget.tsx
@@ -3,6 +3,21 @@ import React from 'react'
 import { TextField } from '@equinor/eds-core-react'
 
 import { TWidget } from '../types'
+import styled from 'styled-components'
+
+const NumberFieldWithoutArrows = styled(TextField)`
+  /* Chrome, Safari, Edge, Opera */
+  input::-webkit-outer-spin-button,
+  input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+
+  /* Firefox */
+  input[type=number] {
+    -moz-appearance: textfield;
+  }
+`
 
 const NumberWidget = (props: TWidget) => {
   const { label, onChange, isDirty } = props
@@ -10,7 +25,7 @@ const NumberWidget = (props: TWidget) => {
     onChange?.(Number(event.target.value))
 
   return (
-    <TextField
+    <NumberFieldWithoutArrows
       id={props.id}
       readOnly={props.readOnly}
       defaultValue={props.value}
@@ -18,8 +33,8 @@ const NumberWidget = (props: TWidget) => {
       variant={props.variant}
       helperText={props.helperText}
       onChange={onChangeHandler}
+      type={'number'}
       label={label}
-      type='number'
       data-testid={`form-number-widget-${label}`}
       style={
         isDirty && props.variant !== 'error'


### PR DESCRIPTION
## What does this pull request change?

No arrows, looks nicer. 

<img width="256" alt="image" src="https://github.com/equinor/dm-core-packages/assets/37016135/7896c9a8-5c74-4b53-bf60-c7786900c22c">

## Why is this pull request needed?

## Issues related to this change
#893 
