### PR TITLE
feat: update table on any submits in expanded or table views

### DIFF
--- a/e2e/tests/plugin-table-car_list.spec.ts
+++ b/e2e/tests/plugin-table-car_list.spec.ts
@@ -15,6 +15,9 @@ test('Table car list example', async ({ page }) => {
   await navigate()
 
   await test.step('Add a new car by using expand', async () => {
+    await expect(
+      page.getByRole('button', { name: 'Open expandable row' })
+    ).toHaveCount(1)
     await page.getByRole('button', { name: 'Add new row' }).click()
     await expect(
       page.getByRole('button', { name: 'Open expandable row' })

--- a/packages/dm-core-plugins/src/grid/GridElement.tsx
+++ b/packages/dm-core-plugins/src/grid/GridElement.tsx
@@ -3,6 +3,8 @@ import React from 'react'
 import styled from 'styled-components'
 import { TItemBorder, TGridItem } from './types'
 import { Typography } from '@equinor/eds-core-react'
+import { toast } from 'react-toastify'
+import onChange = toast.onChange
 
 type TElementProps = {
   item: TGridItem
@@ -30,10 +32,13 @@ type TGridItemProps = {
   type: string
   itemBorder: TItemBorder
   showItemBorders: boolean
+  onSubmit?: (data: any) => void
+  onChange?: (data: any) => void
 }
 
 export const GridElement = (props: TGridItemProps): React.ReactElement => {
-  const { idReference, item, itemBorder, showItemBorders } = props
+  const { idReference, item, itemBorder, showItemBorders, onSubmit, onChange } =
+    props
 
   return (
     <Element
@@ -43,7 +48,12 @@ export const GridElement = (props: TGridItemProps): React.ReactElement => {
       itemBorder={itemBorder}
     >
       {item?.title && <Typography variant='h4'>{item.title}</Typography>}
-      <ViewCreator idReference={idReference} viewConfig={item.viewConfig} />
+      <ViewCreator
+        idReference={idReference}
+        viewConfig={item.viewConfig}
+        onSubmit={onSubmit}
+        onChange={onChange}
+      />
     </Element>
   )
 }

--- a/packages/dm-core-plugins/src/grid/GridItems.tsx
+++ b/packages/dm-core-plugins/src/grid/GridItems.tsx
@@ -8,10 +8,20 @@ type GridItemsProps = {
   type: string
   itemBorder: TItemBorder
   showItemBorders: boolean
+  onSubmit?: (data: any) => void
+  onChange?: (data: any) => void
 }
 
 export const GridItems = (props: GridItemsProps) => {
-  const { idReference, items, type, itemBorder, showItemBorders } = props
+  const {
+    idReference,
+    items,
+    type,
+    itemBorder,
+    showItemBorders,
+    onChange,
+    onSubmit,
+  } = props
   const elements = items.map((item: TGridItem, index) => {
     return (
       <GridElement
@@ -21,6 +31,8 @@ export const GridItems = (props: GridItemsProps) => {
         type={type}
         itemBorder={itemBorder}
         showItemBorders={showItemBorders}
+        onSubmit={onSubmit}
+        onChange={onChange}
       />
     )
   })

--- a/packages/dm-core-plugins/src/grid/GridPlugin.tsx
+++ b/packages/dm-core-plugins/src/grid/GridPlugin.tsx
@@ -42,7 +42,7 @@ const defaultConfig: TGridPluginConfig = {
 export const GridPlugin = (
   props: IUIPlugin & { config: TGridPluginConfig }
 ): React.ReactElement => {
-  const { config, idReference, type } = props
+  const { config, idReference, type, onSubmit, onChange } = props
 
   const internalConfig: TGridPluginConfig = {
     ...defaultConfig,
@@ -59,6 +59,8 @@ export const GridPlugin = (
         itemBorder={internalConfig.itemBorder}
         showItemBorders={internalConfig.showItemBorders}
         type={type}
+        onSubmit={onSubmit}
+        onChange={onChange}
       />
     </Grid>
   )

--- a/packages/dm-core-plugins/src/table/TablePlugin.tsx
+++ b/packages/dm-core-plugins/src/table/TablePlugin.tsx
@@ -15,6 +15,7 @@ export const TablePlugin = (props: IUIPlugin) => {
   const {
     items,
     setItems,
+    updateItem,
     isLoading,
     error,
     dirtyState,
@@ -39,6 +40,7 @@ export const TablePlugin = (props: IUIPlugin) => {
       saveTable={save}
       setDirtyState={setDirtyState}
       setItems={setItems}
+      updateItem={updateItem}
       type={props.type}
     />
   )

--- a/packages/dm-core/src/components/Table/Table.tsx
+++ b/packages/dm-core/src/components/Table/Table.tsx
@@ -36,6 +36,7 @@ export function Table(props: TableProps) {
     items,
     removeItem,
     setItems,
+    updateItem,
     config,
     setDirtyState,
     loadingState,
@@ -146,6 +147,7 @@ export function Table(props: TableProps) {
                       setDirtyState={setDirtyState}
                       setItems={setItems}
                       tableVariant={tableVariant}
+                      updateItem={updateItem}
                     />
                   </ConditionalWrapper>
                 ))}

--- a/packages/dm-core/src/components/Table/TableRow/TableRow.tsx
+++ b/packages/dm-core/src/components/Table/TableRow/TableRow.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { EdsProvider, Icon, Table } from '@equinor/eds-core-react'
-import { ViewCreator } from '../../../'
+import { TGenericObject, TItem, ViewCreator } from '../../../'
 import { TableRowProps, TTableColumnConfig } from '../types'
 import * as utils from '../utils'
 import * as Styled from './styles'
@@ -20,6 +20,7 @@ export function TableRow(props: TableRowProps) {
     item,
     items,
     setItems,
+    updateItem,
     setDirtyState,
     tableVariant,
     ...dragProps
@@ -32,15 +33,21 @@ export function TableRow(props: TableRowProps) {
     tableVariant
   )
 
+  const handleItemUpdate = (itemToChange: TItem<any>, data: any) => {
+    updateItem(itemToChange, data, false)
+  }
+
   function openItemAsTab() {
     props.onOpen(
       crypto.randomUUID(),
       { label: item?.data?.name, type: 'ViewConfig' },
-      `${idReference}[${index}]`
+      `${idReference}[${index}]`,
+      false,
+      (data: any) => handleItemUpdate(item, data)
     )
   }
 
-  function updateItem(
+  function updateCell(
     attribute: string,
     newValue: string | number | boolean,
     attributeType: string
@@ -88,7 +95,7 @@ export function TableRow(props: TableRowProps) {
               item={item}
               openItemAsTab={openItemAsTab}
               setIsExpanded={setIsExpanded}
-              updateItem={updateItem}
+              updateItem={updateCell}
             ></TableCell>
           ))}
           {functionalityConfig?.delete && (
@@ -105,6 +112,7 @@ export function TableRow(props: TableRowProps) {
           <Table.Cell colSpan={columnsLength}>
             <ViewCreator
               idReference={`${idReference}[${item.index}]`}
+              onSubmit={(data: TGenericObject) => handleItemUpdate(item, data)}
               viewConfig={
                 config.expandableRecipeViewConfig
                   ? config.expandableRecipeViewConfig

--- a/packages/dm-core/src/components/Table/types.ts
+++ b/packages/dm-core/src/components/Table/types.ts
@@ -63,6 +63,11 @@ export type TableProps = {
   ) => Promise<void>
   saveTable: (items: TItem<TGenericObject>[]) => void
   setItems: React.Dispatch<React.SetStateAction<TItem<TGenericObject>[]>>
+  updateItem: (
+    itemToUpdate: TItem<TGenericObject>,
+    newDocument: TGenericObject,
+    saveOnUpdate?: boolean
+  ) => Promise<void>
   setDirtyState: React.Dispatch<React.SetStateAction<boolean>>
 } & IUIPlugin
 
@@ -92,6 +97,11 @@ export type TableRowProps = {
   rowsPerPage: number
   setDirtyState: React.Dispatch<React.SetStateAction<boolean>>
   setItems: React.Dispatch<React.SetStateAction<TItem<TGenericObject>[]>>
+  updateItem: (
+    itemToUpdate: TItem<TGenericObject>,
+    newDocument: TGenericObject,
+    saveOnUpdate?: boolean
+  ) => Promise<void>
   tableVariant: TableVariantNameEnum
 } & TSortableItem
 


### PR DESCRIPTION
## What does this pull request change?

* `TablePlugin` listen to onSubmit in expanded or opened views
* `GridPlugin` passes down `onSubmit` and `onChange` to grid items

## Why is this pull request needed?

## Issues related to this change

