### PR TITLE
fix: added titles to expandable buttons

### DIFF
--- a/packages/dm-core-plugins/src/form/templates/ArrayComplexTemplate.tsx
+++ b/packages/dm-core-plugins/src/form/templates/ArrayComplexTemplate.tsx
@@ -50,7 +50,7 @@ export const ArrayComplexTemplate = (props: TArrayTemplate) => {
           ))}
         {isDefined && !(onOpen && !uiAttribute?.showInline) && (
           <TooltipButton
-            title='Expand'
+            title={isExpanded ? 'Collapse' : 'Expand'}
             button-variant='ghost_icon'
             button-onClick={() => setIsExpanded(!isExpanded)}
             icon={isExpanded ? chevron_up : chevron_down}

--- a/packages/dm-core-plugins/src/form/templates/ArrayPrimitiveTemplate.tsx
+++ b/packages/dm-core-plugins/src/form/templates/ArrayPrimitiveTemplate.tsx
@@ -72,7 +72,7 @@ export const ArrayPrimitiveTemplate = (
       <Legend>
         <Typography bold={true}>{getDisplayLabel(attribute)}</Typography>
         <TooltipButton
-          title='Expand'
+          title={isExpanded ? 'Collapse' : 'Expand'}
           button-variant='ghost_icon'
           button-onClick={() => setIsExpanded(!isExpanded)}
           icon={isExpanded ? chevron_up : chevron_down}

--- a/packages/dm-core-plugins/src/form/templates/ObjectModelContainedTemplate.tsx
+++ b/packages/dm-core-plugins/src/form/templates/ObjectModelContainedTemplate.tsx
@@ -43,7 +43,7 @@ export const ObjectModelContainedTemplate = (
           ))}
         {isDefined && !(onOpen && !uiAttribute?.showInline) && (
           <TooltipButton
-            title='Expand'
+            title={isExpanded ? 'Collapse' : 'Expand'}
             button-variant='ghost_icon'
             button-onClick={() => setIsExpanded(!isExpanded)}
             icon={isExpanded ? chevron_up : chevron_down}

--- a/packages/dm-core-plugins/src/form/templates/ObjectModelUncontainedTemplate.tsx
+++ b/packages/dm-core-plugins/src/form/templates/ObjectModelUncontainedTemplate.tsx
@@ -48,7 +48,7 @@ export const ObjectModelUncontainedTemplate = (
         )}
         {address && !(onOpen && !uiAttribute?.showInline) && (
           <TooltipButton
-            title='Expand'
+            title={isExpanded ? 'Collapse' : 'Expand'}
             button-variant='ghost_icon'
             button-onClick={() => setIsExpanded(!isExpanded)}
             icon={isExpanded ? chevron_up : chevron_down}


### PR DESCRIPTION
## What does this pull request change?
Added "collapse" to the titles for some expandable buttons. These only had the title "Expand" which was misleading when already expanded.

## Why is this pull request needed?

## Issues related to this change

