### PR TITLE
fix: default able to expand if no open passed

### DIFF
--- a/packages/dm-core-plugins/src/form/templates/ObjectModelContainedTemplate.tsx
+++ b/packages/dm-core-plugins/src/form/templates/ObjectModelContainedTemplate.tsx
@@ -27,7 +27,8 @@ export const ObjectModelContainedTemplate = (
   const isCreated = value && Object.keys(value).length > 0
   const canExpand =
     isCreated &&
-    (uiAttribute?.functionality?.expand ?? config.functionality.expand)
+    (!onOpen ||
+      (uiAttribute?.functionality?.expand ?? config.functionality.expand))
   const canOpen =
     isCreated &&
     onOpen &&

--- a/packages/dm-core-plugins/src/form/templates/ObjectModelUncontainedTemplate.tsx
+++ b/packages/dm-core-plugins/src/form/templates/ObjectModelUncontainedTemplate.tsx
@@ -39,7 +39,8 @@ export const ObjectModelUncontainedTemplate = (
   const referenceExists = address !== undefined
   const canExpand =
     referenceExists &&
-    (uiAttribute?.functionality?.expand ?? config.functionality.expand)
+    (!onOpen ||
+      (uiAttribute?.functionality?.expand ?? config.functionality.expand))
   const canOpen =
     referenceExists &&
     onOpen &&

--- a/packages/dm-core-plugins/src/form/templates/ObjectStorageUncontainedTemplate.tsx
+++ b/packages/dm-core-plugins/src/form/templates/ObjectStorageUncontainedTemplate.tsx
@@ -30,7 +30,8 @@ export const ObjectStorageUncontainedTemplate = (props: TObjectTemplate) => {
   const referenceExists = address !== undefined
   const canExpand =
     referenceExists &&
-    (uiAttribute?.functionality?.expand ?? config.functionality.expand)
+    (!onOpen ||
+      (uiAttribute?.functionality?.expand ?? config.functionality.expand))
   const canOpen =
     referenceExists &&
     onOpen &&


### PR DESCRIPTION
## What does this pull request change?

* Default to expand if no `onOpen` function is available

## Why is this pull request needed?

## Issues related to this change

