### PR TITLE
fix: default tab name on open

### DIFF
--- a/packages/dm-core-plugins/src/list/ListPlugin.tsx
+++ b/packages/dm-core-plugins/src/list/ListPlugin.tsx
@@ -108,7 +108,10 @@ export const ListPlugin = (props: IUIPlugin & { config?: TListConfig }) => {
       return
     }
 
-    const view = { ...internalConfig.openViewConfig, label: item?.data?.name }
+    const view = {
+      ...internalConfig.openViewConfig,
+      label: item?.data?.name ?? `${attribute?.name} #${item.index}`,
+    }
     onOpen(
       item.key,
       view,

--- a/packages/dm-core/src/components/Table/TableRow/TableRow.tsx
+++ b/packages/dm-core/src/components/Table/TableRow/TableRow.tsx
@@ -40,7 +40,12 @@ export function TableRow(props: TableRowProps) {
   function openItemAsTab() {
     props.onOpen(
       crypto.randomUUID(),
-      { label: item?.data?.name, type: 'ViewConfig' },
+      {
+        label:
+          item?.data?.name ??
+          `${idReference.split('.').slice(-1)} #${item.index}`,
+        type: 'ViewConfig',
+      },
       `${idReference}[${index}]`,
       false,
       (data: any) => handleItemUpdate(item, data)


### PR DESCRIPTION
## What does this pull request change?
Use index and attribute name when opening object without name in new tab

## Why is this pull request needed?
Name is often not a required attribute

## Issues related to this change
Close #860
