### PR TITLE
fix: update uncontained object test with expand

### DIFF
--- a/e2e/tests/plugin-form-UncontainedObject.spec.ts
+++ b/e2e/tests/plugin-form-UncontainedObject.spec.ts
@@ -28,12 +28,26 @@ test('uncontainedObject', async ({ page }) => {
     await expect(dialog).not.toBeVisible()
   }
 
-  await test.step('Assert CEO and accountant', async () => {
+  await test.step('Assert CEO', async () => {
     await page.getByTestId('ceo').getByRole('button', { name: 'Open' }).click()
     await expect(page.getByRole('code').getByText('Miranda')).toBeVisible()
     await expect(page.getByRole('code').getByText('1337')).toBeVisible()
     await page.getByRole('button', { name: 'Close ceo' }).click()
+  })
 
+  await test.step('Assert Accountant', async () => {
+    await page
+      .getByTestId('accountant')
+      .getByRole('button', { name: 'Collapse' })
+      .click()
+    await expect(
+      page.getByTestId('accountant').getByRole('code').getByText('Miranda')
+    ).not.toBeVisible()
+    await expect(page.getByRole('code').getByText('1337')).not.toBeVisible()
+    await page
+      .getByTestId('accountant')
+      .getByRole('button', { name: 'Expand' })
+      .click()
     await expect(
       page.getByTestId('accountant').getByRole('code').getByText('Miranda')
     ).toBeVisible()


### PR DESCRIPTION
## What does this pull request change?
Updated the test for uncontainedObject after added expand feature (#928).

## Why is this pull request needed?

## Issues related to this change

