### PR TITLE
fix: Creating new config object on every render breaks memo

### DIFF
--- a/example/src/plugins/table/TestUseListPlugin.tsx
+++ b/example/src/plugins/table/TestUseListPlugin.tsx
@@ -3,6 +3,7 @@ import {
   IUIPlugin,
   Loading,
   Pagination,
+  TEntityPickerReturn,
   TGenericObject,
   TItem,
   TValidEntity,
@@ -64,7 +65,7 @@ const TestUseListPlugin = (props: IUIPlugin) => {
         showModal={showAddReferenceModal}
         setShowModal={setShowAddReferenceModal}
         typeFilter={attribute?.attributeType}
-        onChange={(v) => {
+        onChange={(v: TEntityPickerReturn) => {
           addReference(v.address, v.entity)
         }}
       />

--- a/packages/dm-core/src/components/EntityView.tsx
+++ b/packages/dm-core/src/components/EntityView.tsx
@@ -3,7 +3,7 @@ import React, { useState, Suspense, memo } from 'react'
 import styled from 'styled-components'
 import { ErrorBoundary, ErrorGroup } from '../utils/ErrorBoundary'
 import { useRecipe } from '../hooks'
-import { IUIPlugin } from '../types'
+import { IUIPlugin, TUiRecipe } from '../types'
 import { Loading } from './Loading'
 import { Typography } from '@equinor/eds-core-react'
 import RefreshButton from './RefreshButton'
@@ -20,33 +20,17 @@ type IEntityView = IUIPlugin & {
   dimensions?: string
 }
 
-function UiPlugin({
-  getPlugin,
-  pluginName,
-  idReference,
-  type,
-  onSubmit,
-  onOpen,
-  config,
-  onChange,
-}: IUIPlugin & {
-  getPlugin: (name: string) => (p: IUIPlugin) => React.ReactElement
-  pluginName: string
-}) {
-  const UiPlugin = getPlugin(pluginName)
-  return (
-    <UiPlugin
-      idReference={idReference}
-      type={type}
-      onSubmit={onSubmit}
-      onOpen={onOpen}
-      config={config || {}}
-      onChange={onChange}
-    />
-  )
-}
+const MemoizedUiPlugin = memo(function UiPlugin(
+  props: IUIPlugin & {
+    getPlugin: (name: string) => (p: IUIPlugin) => React.ReactElement
+    recipe: TUiRecipe
+  }
+) {
+  const UiPlugin = props.getPlugin(props.recipe.plugin)
+  return <UiPlugin {...props} config={props.recipe.config ?? {}} />
+})
 
-const MemoizedUiPlugin = memo(UiPlugin)
+// const MemoizedUiPlugin = memo(UiPlugin)
 
 export const EntityView = (props: IEntityView): React.ReactElement => {
   const {
@@ -127,13 +111,12 @@ export const EntityView = (props: IEntityView): React.ReactElement => {
             )}
             <MemoizedUiPlugin
               getPlugin={getUiPlugin}
-              pluginName={recipe.plugin}
+              recipe={recipe}
               idReference={idReference}
               type={type}
               onSubmit={onSubmit}
               onOpen={onOpen}
               onChange={onChange}
-              config={recipe.config || {}}
               key={reloadCounter}
             />
           </div>


### PR DESCRIPTION
## What does this pull request change?
- Since `Object.is({}, {}) is false.`, the memo wrapped UiPlugins did not work.
- Solved by passing the whole "recipe" object to memoized function, before creating a default {}

## Why is this pull request needed?
- Rerender on hover breaks some child components that can not rerender at any point (plotly etc.)

## Issues related to this change
closes #https://github.com/equinor/dm-app-simpos/issues/65