### PR TITLE
feat: complex attribute, bug fix, and new icon for model uncontained

### DIFF
--- a/e2e/tests/plugin-default_recipe.spec.ts
+++ b/e2e/tests/plugin-default_recipe.spec.ts
@@ -28,10 +28,7 @@ test('TableList default DMSS UI Recipe', async ({ page }) => {
   })
 
   await test.step('Open item in tab', async () => {
-    await page
-      .getByRole('group', { name: 'Cars' })
-      .getByLabel('Open in tab')
-      .click()
+    await page.getByLabel('Open in tab').click()
     await page
       .getByRole('row', { name: 'Volvo' })
       .getByRole('button', { name: 'Expand item', exact: true })

--- a/packages/dm-core-plugins/src/form/components/ExpandChevron.tsx
+++ b/packages/dm-core-plugins/src/form/components/ExpandChevron.tsx
@@ -8,7 +8,6 @@ const ExpandChevron = ({
 }: {
   isExpanded: boolean
   setIsExpanded: (expanded: boolean) => void
-  isActive?: boolean
 }) => {
   return (
     <TooltipButton

--- a/packages/dm-core-plugins/src/form/components/ExpandChevron.tsx
+++ b/packages/dm-core-plugins/src/form/components/ExpandChevron.tsx
@@ -5,7 +5,11 @@ import { chevron_down, chevron_right } from '@equinor/eds-icons'
 const ExpandChevron = ({
   isExpanded,
   setIsExpanded,
-}: { isExpanded: boolean; setIsExpanded: (expanded: boolean) => void }) => {
+}: {
+  isExpanded: boolean
+  setIsExpanded: (expanded: boolean) => void
+  isActive?: boolean
+}) => {
   return (
     <TooltipButton
       title={isExpanded ? 'Collapse' : 'Expand'}

--- a/packages/dm-core-plugins/src/form/templates/ArrayComplexTemplate.tsx
+++ b/packages/dm-core-plugins/src/form/templates/ArrayComplexTemplate.tsx
@@ -12,6 +12,7 @@ import {
   getExpandViewConfig,
   getOpenViewConfig,
 } from './shared/utils'
+import { list } from '@equinor/eds-icons'
 
 export const ArrayComplexTemplate = (props: TArrayTemplate) => {
   const { namePath, attribute, uiAttribute } = props
@@ -49,7 +50,14 @@ export const ArrayComplexTemplate = (props: TArrayTemplate) => {
           }
           setIsExpanded={setIsExpanded}
           attribute={attribute}
+          icon={list}
         />
+        {canOpen && (
+          <OpenObjectButton
+            viewId={namePath}
+            viewConfig={getOpenViewConfig(uiAttribute, namePath)}
+          />
+        )}
         <FormTemplate.Header.Actions>
           {attribute.optional &&
             !config.readOnly &&
@@ -69,12 +77,6 @@ export const ArrayComplexTemplate = (props: TArrayTemplate) => {
                 onAdd={() => setInitialValue([])}
               />
             ))}
-          {canOpen && (
-            <OpenObjectButton
-              viewId={namePath}
-              viewConfig={getOpenViewConfig(uiAttribute, namePath)}
-            />
-          )}
         </FormTemplate.Header.Actions>
       </FormTemplate.Header>
       {canExpand && isExpanded && (

--- a/packages/dm-core-plugins/src/form/templates/ObjectModelContainedTemplate.tsx
+++ b/packages/dm-core-plugins/src/form/templates/ObjectModelContainedTemplate.tsx
@@ -91,7 +91,9 @@ export const ObjectModelContainedTemplate = (
             idReference={`${idReference}.${namePath}`}
             onOpen={onOpen}
             viewConfig={getExpandViewConfig(uiAttribute)}
-            onChange={(data: any) => setValue(namePath, data)}
+            onChange={(data: Record<string, unknown>) =>
+              setValue(namePath, data)
+            }
           />
         </FormTemplate.Content>
       )}

--- a/packages/dm-core-plugins/src/form/templates/ObjectModelUncontainedTemplate.tsx
+++ b/packages/dm-core-plugins/src/form/templates/ObjectModelUncontainedTemplate.tsx
@@ -16,6 +16,7 @@ import {
   getCanOpenOrExpand,
   getOpenViewConfig,
 } from './shared/utils'
+import { link } from '@equinor/eds-icons'
 
 export const ObjectModelUncontainedTemplate = (
   props: TObjectTemplate
@@ -54,6 +55,7 @@ export const ObjectModelUncontainedTemplate = (
           onOpen={() =>
             onOpen?.(namePath, getOpenViewConfig(uiAttribute), address)
           }
+          icon={link}
         />
         <FormTemplate.Header.Actions>
           {canOpen && (

--- a/packages/dm-core-plugins/src/form/templates/ObjectStorageUncontainedTemplate.tsx
+++ b/packages/dm-core-plugins/src/form/templates/ObjectStorageUncontainedTemplate.tsx
@@ -78,7 +78,9 @@ export const ObjectStorageUncontainedTemplate = (props: TObjectTemplate) => {
             idReference={address}
             onOpen={onOpen}
             viewConfig={getExpandViewConfig(uiAttribute)}
-            onChange={(data: any) => setValue(namePath, data)}
+            onChange={(data: Record<string, unknown>) =>
+              setValue(namePath, data)
+            }
           />
         </FormTemplate.Content>
       )}

--- a/packages/dm-core-plugins/src/form/templates/shared/FormTemplate.tsx
+++ b/packages/dm-core-plugins/src/form/templates/shared/FormTemplate.tsx
@@ -1,8 +1,8 @@
-import React, { PropsWithChildren } from 'react'
+import React, { PropsWithChildren, useState } from 'react'
 import { Icon, Typography } from '@equinor/eds-core-react'
 import { IconData, file, file_description } from '@equinor/eds-icons'
 import ExpandChevron from '../../components/ExpandChevron'
-import { TAttribute } from '@development-framework/dm-core'
+import { TAttribute, useSearch } from '@development-framework/dm-core'
 import { getDisplayLabel } from '../../utils/getDisplayLabel'
 
 const FormTemplate = ({ children }: PropsWithChildren) => {
@@ -51,21 +51,51 @@ const FormTemplateHeaderTitle = ({
   onOpen?: () => void
   icon?: IconData
 }) => {
+  const [isHovering, setIsHovering] = useState(false)
+
   return (
     <div
-      className={`flex flex-start items-center ${!canExpand ? 'ps-2' : 'ps-1'}`}
+      className={`flex flex-start items-center w-full h-full ${
+        !canExpand ? 'ps-2' : 'ps-1'
+      }`}
     >
       {canExpand && (
-        <ExpandChevron
-          isExpanded={isExpanded ?? false}
-          setIsExpanded={(exp) => setIsExpanded?.(exp)}
-        />
+        <span
+          className={`flex w-fit rounded-full items-center ${
+            canExpand && isHovering ? 'bg-[#deedee] ' : ''
+          }`}
+        >
+          <ExpandChevron
+            isExpanded={isExpanded ?? false}
+            setIsExpanded={(exp) => setIsExpanded?.(exp)}
+          />
+        </span>
       )}
       <div
-        className={`flex items-center space-x-1 ${
+        className={`flex items-center space-x-1 w-full h-full ${
           objectIsNotEmpty ? '' : 'opacity-40'
         }
+        ${
+          objectIsNotEmpty && (canOpen || canExpand)
+            ? 'cursor-pointer hover:opacity-80'
+            : ''
+        }
     `}
+        onMouseEnter={() => setIsHovering(true)}
+        onMouseLeave={() => setIsHovering(false)}
+        onClick={(event) => {
+          if (!objectIsNotEmpty) return
+          if (event.ctrlKey || event.metaKey) {
+            event.preventDefault()
+            canOpen && onOpen?.()
+            return
+          }
+          if (canExpand) {
+            setIsExpanded?.(!isExpanded)
+            return
+          }
+          canOpen && onOpen?.()
+        }}
       >
         <Icon
           data={icon ?? (objectIsNotEmpty ? file_description : file)}
@@ -74,20 +104,15 @@ const FormTemplateHeaderTitle = ({
         <Typography
           bold={true}
           className={`
-          ${objectIsNotEmpty && (canOpen || canExpand) ? 'cursor-pointer' : ''}
-          ${canOpen ? 'hover:underline' : ''}`}
-          onClick={() => {
-            if (!objectIsNotEmpty) return
-            if (canOpen) {
-              onOpen?.()
-              return
-            }
-            canExpand && setIsExpanded?.(!isExpanded)
-          }}
+          ${
+            objectIsNotEmpty && isHovering && canOpen && !canExpand
+              ? 'underline'
+              : ''
+          }`}
         >
           {getDisplayLabel(attribute)}
         </Typography>
-        {attribute.optional && <p className='ps-1 text-xs'>Optional</p>}
+        {attribute.optional && <p className='ps-1 mt-0.5 text-xs'>Optional</p>}
       </div>
     </div>
   )

--- a/packages/dm-core-plugins/src/form/templates/shared/utils.ts
+++ b/packages/dm-core-plugins/src/form/templates/shared/utils.ts
@@ -11,13 +11,14 @@ export const getExpandViewConfig = (uiAttribute?: TUiAttributeObject) => {
 
 export const getOpenViewConfig = (
   uiAttribute?: TUiAttributeObject,
+  /** namePath requried for model contained, but should not be set for model Uncontained **/
   namePath?: string
 ) => {
   return (
     uiAttribute?.openViewConfig ?? {
       type: 'ReferenceViewConfig',
-      scope: namePath,
       recipe: uiAttribute?.uiRecipe,
+      scope: namePath,
     }
   )
 }


### PR DESCRIPTION
## What does this pull request change?

1. New icon for model uncontained. Link
<img width="621" alt="image" src="https://github.com/equinor/dm-core-packages/assets/37016135/8d667dd8-9332-4df8-a0e9-b021a845828d">



2. Better ui for all objects in form. 
- whole thing is clickable. 
- shows with underline if opens in tab, shows with chevron if expand
- ctrl + click / comand + click to open instead of expand

<img width="543" alt="image" src="https://github.com/equinor/dm-core-packages/assets/37016135/86d8ed99-70c9-428e-acb9-add2286b7d4b">



3. Also made new ui design include complex arrays. 


<img width="632" alt="image" src="https://github.com/equinor/dm-core-packages/assets/37016135/1064777d-f8c4-4deb-98ea-dc6726461f3e">


5. A bug fix with the onOpen sometimes finding wrong reference 

## Why is this pull request needed?

## Issues related to this change

