### PR TITLE
refactor: even-odd coloring on table rows

### DIFF
--- a/packages/dm-core/src/components/Table/TableRow/TableRow.tsx
+++ b/packages/dm-core/src/components/Table/TableRow/TableRow.tsx
@@ -83,7 +83,10 @@ export function TableRow(props: TableRowProps) {
       <EdsProvider density='compact'>
         <Table.Row
           key={item.key}
-          style={dragProps.style}
+          style={{
+            ...dragProps.style,
+            backgroundColor: index % 2 === 0 ? '#f7f7f7' : '',
+          }}
           ref={dragProps.setNodeRef}
         >
           {editMode && (


### PR DESCRIPTION
## What does this pull request change?
Makes the table rows colored slightly differently based on their index. Hover style disappeared though, and I can't see the declaration of `...dragProps` 🤔 @awesthouse where are those defined?

## Why is this pull request needed?

## Issues related to this change

