### PR TITLE
refactor: improve default time value, and open above if no space

### DIFF
--- a/packages/dm-core-plugins/src/form/fields/StringField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/StringField.tsx
@@ -26,7 +26,6 @@ export const StringField = (props: TField) => {
             enumType={attribute.enumType || undefined}
             isDirty={value !== null ? isDirty : false}
             onChange={(value: unknown) => {
-              console.log(value)
               return onChange(value ?? '')
             }}
             readOnly={readOnly}

--- a/packages/dm-core/src/hooks/useClickOutside.tsx
+++ b/packages/dm-core/src/hooks/useClickOutside.tsx
@@ -1,7 +1,7 @@
 import { MutableRefObject, useEffect } from 'react'
 
 export function useClickOutside(
-  elementRef: MutableRefObject<HTMLElement>,
+  elementRef: MutableRefObject<HTMLDivElement | null>,
   callback: () => any
 ): any {
   useEffect(() => {


### PR DESCRIPTION
## What does this pull request change?
- Sets the time to 12:00 when selecting a date, and there is no time set.
- Opens the panel above if there is no space beneath.

## Why is this pull request needed?

## Issues related to this change

