### PR TITLE
feat: readonly primitives new ui looks better

### DIFF
--- a/e2e/tests/plugin-form-ReadOnlyPrimitives.spec.ts
+++ b/e2e/tests/plugin-form-ReadOnlyPrimitives.spec.ts
@@ -8,17 +8,21 @@ test('Read only primitives', async ({ page }) => {
   await page.getByRole('button', { name: 'read_only_primitives' }).click()
   await page.getByRole('button', { name: 'ReadOnlyPrimitives' }).click()
 
-  await expect(page.getByLabel('A required string')).not.toBeEditable()
+  await expect(page.getByLabel('readonly-A required string')).toBeVisible()
 
   await expect(
-    page.getByLabel('An optional string (Optional)')
-  ).not.toBeEditable()
+    page.getByLabel('readonly-An optional string (Optional)')
+  ).toBeVisible()
 
-  await expect(page.getByLabel('A required number')).not.toBeEditable()
+  await expect(page.getByLabel('readonly-A required number')).toBeVisible()
 
-  await expect(page.getByLabel('Numbers only (Optional)')).not.toBeEditable()
+  await expect(
+    page.getByLabel('readonly-Numbers only (Optional)')
+  ).toBeVisible()
 
-  await expect(page.getByLabel('Integer only (Optional)')).not.toBeEditable()
+  await expect(
+    page.getByLabel('readonly-Integer only (Optional)')
+  ).toBeVisible()
 
   await expect(
     page.getByLabel('An optional checkbox (Optional)')

--- a/packages/dm-core-plugins/src/form/components/ReadOnlyField.tsx
+++ b/packages/dm-core-plugins/src/form/components/ReadOnlyField.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+
+interface ReadOnlyFieldProps {
+  label?: string
+  value?: string | number
+  helperText?: string
+  unit?: string
+}
+
+const ReadOnlyField = ({
+  label,
+  value,
+  helperText,
+  unit,
+}: ReadOnlyFieldProps) => {
+  return (
+    <>
+      <p className='text-xs ms-2 text-[#6f6f6f] font-medium'>{label}</p>
+      <div className='bg-[#f7f7f7] p-2 rounded-sm h-9 flex items-center justify-between'>
+        <p aria-label={'readonly-' + label}>{value}</p>
+        <p className='text-xs text-[#6f6f6f] font-medium'>{unit}</p>
+      </div>
+      <p className='text-xs ms-2 mt-2 font-medium text-[#6f6f6f]'>
+        {helperText}
+      </p>
+    </>
+  )
+}
+
+export default ReadOnlyField

--- a/packages/dm-core-plugins/src/form/widgets/NumberWidget.tsx
+++ b/packages/dm-core-plugins/src/form/widgets/NumberWidget.tsx
@@ -1,22 +1,23 @@
 import React from 'react'
 import { NumberFieldWithoutArrows } from '../components/NumberFieldWithoutArrows'
 import { TWidget } from '../types'
-import { Typography } from '@equinor/eds-core-react'
+import ReadOnlyField from '../components/ReadOnlyField'
 
 const NumberWidget = (props: TWidget) => {
-  const { label, onChange, isDirty } = props
+  const { label, onChange, isDirty, value } = props
   const onChangeHandler = (event: React.ChangeEvent<HTMLInputElement>) =>
     onChange?.(Number(event.target.value))
+
+  if (props.readOnly) return <ReadOnlyField label={label} value={value} />
 
   return (
     <NumberFieldWithoutArrows
       id={props.id}
-      readOnly={props.readOnly}
       label={label}
-      defaultValue={props.value}
+      defaultValue={value}
       inputRef={props.inputRef}
       variant={props.variant}
-      helperText={props.helperText}
+      helperText={'Helpertext'}
       onChange={onChangeHandler}
       type={'number'}
       data-testid={`form-number-widget-${label}`}

--- a/packages/dm-core-plugins/src/form/widgets/TextWidget.tsx
+++ b/packages/dm-core-plugins/src/form/widgets/TextWidget.tsx
@@ -1,18 +1,20 @@
 import React from 'react'
-import { TextField, Typography } from '@equinor/eds-core-react'
+import { TextField } from '@equinor/eds-core-react'
 import { TWidget } from '../types'
+import ReadOnlyField from '../components/ReadOnlyField'
 
 const TextWidget = (props: TWidget) => {
-  const { label, onChange, isDirty } = props
+  const { label, onChange, isDirty, value } = props
   const onChangeHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
     onChange?.(event.target.value === '' ? null : event.target.value)
   }
+
+  if (props.readOnly) return <ReadOnlyField label={label} value={value} />
 
   return (
     <TextField
       id={props.id}
       label={label}
-      readOnly={props.readOnly}
       defaultValue={props.readOnly && props.value === '' ? '-' : props.value}
       inputRef={props.inputRef}
       variant={props.variant}

--- a/packages/dm-core-plugins/src/form/widgets/TextareaWidget.tsx
+++ b/packages/dm-core-plugins/src/form/widgets/TextareaWidget.tsx
@@ -2,9 +2,10 @@ import React from 'react'
 
 import { TextField, Typography } from '@equinor/eds-core-react'
 import { TWidget } from '../types'
+import ReadOnlyField from '../components/ReadOnlyField'
 
 const TextareaWidget = (props: TWidget) => {
-  const { label, onChange } = props
+  const { label, onChange, readOnly } = props
 
   const onChangeHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = event.target
@@ -12,10 +13,14 @@ const TextareaWidget = (props: TWidget) => {
     onChange?.(formattedValue)
   }
 
+  if (props.readOnly) return <ReadOnlyField />
+
   return (
     <TextField
       {...props}
       multiline={true}
+      readOnly={false}
+      disabled={props.readOnly}
       rows={5}
       onChange={onChangeHandler}
     />


### PR DESCRIPTION
## What does this pull request change?

Readonly now looks more like an inputField. 
Is a custom component. 
<img width="993" alt="image" src="https://github.com/equinor/dm-core-packages/assets/37016135/458fbc58-27be-4708-b119-01f19e6a3874">


## Why is this pull request needed?

## Issues related to this change

