### PR TITLE
fix: item must be saved before can expand

### DIFF
--- a/packages/dm-core-plugins/src/list/ListPlugin.tsx
+++ b/packages/dm-core-plugins/src/list/ListPlugin.tsx
@@ -220,6 +220,7 @@ export const ListPlugin = (props: IUIPlugin & { config?: TListConfig }) => {
                           }
                           onClick={() =>
                             internalConfig.functionality.expand &&
+                            item.isSaved &&
                             handleExpand(item)
                           }
                         >


### PR DESCRIPTION
## What does this pull request change?

* fix: the item need to be saved it can be expanded

## Why is this pull request needed?

## Issues related to this change

