### PR TITLE
fix: job label and close datepicker on click outside

### DIFF
--- a/packages/dm-core-plugins/src/job/CrateFromRecipe.tsx
+++ b/packages/dm-core-plugins/src/job/CrateFromRecipe.tsx
@@ -13,7 +13,7 @@ import {
   useJob,
 } from '@development-framework/dm-core'
 import React, { useContext, useEffect, useMemo, useState } from 'react'
-import { Button, Chip, LinearProgress } from '@equinor/eds-core-react'
+import { Button, Chip, Label, LinearProgress } from '@equinor/eds-core-react'
 import { JobControlButton } from './JobControlButton'
 import styled from 'styled-components'
 import { AxiosError } from 'axios'
@@ -158,6 +158,7 @@ export const CrateFromRecipe = (
           }
         />
       )}
+      {config.label && <Label label={config.label} />}
       <JobButtonWrapper>
         <JobControlButton
           jobStatus={status}

--- a/packages/dm-core/src/components/Pickers/Datepicker/Datepicker.tsx
+++ b/packages/dm-core/src/components/Pickers/Datepicker/Datepicker.tsx
@@ -56,6 +56,23 @@ export const Datepicker = (props: DatepickerProps): ReactElement => {
     onChange(datetime?.toISO() ?? '')
   }, [datetime])
 
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        datepickerRef.current &&
+        !datepickerRef.current.contains(event.target as Node)
+      ) {
+        setOpen(false)
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [datepickerRef])
+
   function handleDateInput(dateInput: string): void {
     if (dateInput) {
       const { day, month, year, max } = extractDateComponents(dateInput)


### PR DESCRIPTION
## What does this pull request change?
- DatePicker now closes when you click outside it
- If the jobConfig has a label, use it when rendering