### PR TITLE
fix: replace name which is empty string with attribute + index

### DIFF
--- a/packages/dm-core-plugins/src/list/ListPlugin.tsx
+++ b/packages/dm-core-plugins/src/list/ListPlugin.tsx
@@ -118,7 +118,9 @@ export const ListPlugin = (props: IUIPlugin & { config?: TListConfig }) => {
 
     const view = {
       ...internalConfig.openViewConfig,
-      label: item?.data?.name ?? `${attribute?.name} #${item.index}`,
+      label: item?.data?.name
+        ? item?.data?.name
+        : `${attribute?.name} #${item.index}`,
     }
     onOpen(
       item.key,

--- a/packages/dm-core/src/components/Table/TableRow/TableRow.tsx
+++ b/packages/dm-core/src/components/Table/TableRow/TableRow.tsx
@@ -41,9 +41,9 @@ export function TableRow(props: TableRowProps) {
     props.onOpen(
       crypto.randomUUID(),
       {
-        label:
-          item?.data?.name ??
-          `${idReference.split('.').slice(-1)} #${item.index}`,
+        label: item?.data?.name
+          ? item?.data?.name
+          : `${idReference.split('.').slice(-1)} #${item.index}`,
         type: 'ViewConfig',
       },
       `${idReference}[${index}]`,


### PR DESCRIPTION
## What does this pull request change?
Where objects have name field as empty string, use attribute + index in the generated viewItem that is sendt to the viewSelector

## Why is this pull request needed?
viewSelector shows empty string as tab/sidebar label when name is empty string

## Issues related to this change

