### PR TITLE
fix: select subitem when parent has no viewconfig

### DIFF
--- a/packages/dm-core-plugins/src/view_selector/Sidebar.tsx
+++ b/packages/dm-core-plugins/src/view_selector/Sidebar.tsx
@@ -62,7 +62,7 @@ export const Sidebar = (props: {
                           }
                           role='tab'
                           onClick={() => {
-                            if (viewItem.viewConfig) {
+                            if (subItem.viewConfig) {
                               setSelectedViewId(subViewId)
                             }
                           }}


### PR DESCRIPTION
## What does this pull request change?

## Why is this pull request needed?

## Issues related to this change
Closes #729 
