### PR TITLE
fix: optional eds icon in viewselectoritem

### DIFF
--- a/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/signalApp.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/signalApp.recipe.json
@@ -35,11 +35,11 @@
             "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
             "label": "Study",
             "viewConfig": {
+              "eds_icon": "change_history",
               "type": "CORE:ReferenceViewConfig",
               "recipe": "Tabs",
               "scope": "study",
-              "showRefreshButton": true,
-              "eds_icon": "change_history"
+              "showRefreshButton": true
             }
           }
         ]

--- a/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/signals_simple/study.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/signals_simple/study.recipe.json
@@ -12,6 +12,7 @@
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
           "label": "Home",
+          "eds_icon": "home",
           "viewConfig": {
             "type": "CORE:ReferenceViewConfig",
             "recipe": "Edit"

--- a/example/app/data/DemoDataSource/recipes/plugins/view_selector/car_infosys/car.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/view_selector/car_infosys/car.recipe.json
@@ -12,6 +12,7 @@
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
           "label": "Home",
+          "eds_icon": "home",
           "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
             "recipe": {
@@ -23,8 +24,7 @@
                 "type": "PLUGINS:dm-core-plugins/form/FormInput",
                 "fields": ["name", "model", "Owner", "Technical"]
               }
-            },
-            "eds_icon": "home"
+            }
           }
         }
       ]

--- a/example/app/data/DemoDataSource/recipes/plugins/view_selector/car_infosys/carGarage.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/view_selector/car_infosys/carGarage.recipe.json
@@ -11,6 +11,7 @@
       "items": [
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
+          "eds_icon": "home",
           "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
             "recipe": {
@@ -23,24 +24,23 @@
                 "fields": ["name", "description"]
               }
             },
-            "scope": "self",
-            "eds_icon": "home"
+            "scope": "self"
           }
         },
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
+          "eds_icon": "car",
           "viewConfig": {
             "type": "CORE:ViewConfig",
-            "scope": "Audi",
-            "eds_icon": "car"
+            "scope": "Audi"
           }
         },
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
+          "eds_icon": "car",
           "viewConfig": {
             "type": "CORE:ViewConfig",
-            "scope": "Volvo",
-            "eds_icon": "car"
+            "scope": "Volvo"
           }
         }
       ]

--- a/example/app/data/DemoDataSource/recipes/plugins/view_selector/car_infosys/owner.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/view_selector/car_infosys/owner.recipe.json
@@ -12,6 +12,7 @@
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
           "label": "Owner details",
+          "eds_icon": "person",
           "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
             "recipe": {
@@ -23,8 +24,7 @@
                 "type": "PLUGINS:dm-core-plugins/form/FormInput",
                 "fields": ["name", "DateOwned"]
               }
-            },
-            "eds_icon": "person"
+            }
           }
         },
         {

--- a/example/app/data/DemoDataSource/recipes/plugins/view_selector/car_infosys/technical.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/view_selector/car_infosys/technical.recipe.json
@@ -12,6 +12,7 @@
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
           "label": "EU control",
+          "eds_icon": "check",
           "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
             "recipe": {
@@ -23,13 +24,13 @@
                 "type": "PLUGINS:dm-core-plugins/form/FormInput",
                 "fields": ["controlDate", "nextControl"]
               }
-            },
-            "eds_icon": "check"
+            }
           }
         },
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
           "label": "Dimensions",
+          "eds_icon": "car",
           "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
             "recipe": {
@@ -41,8 +42,7 @@
                 "type": "PLUGINS:dm-core-plugins/form/FormInput",
                 "fields": ["width", "length", "heigth"]
               }
-            },
-            "eds_icon": "car"
+            }
           }
         }
       ]

--- a/example/app/data/DemoDataSource/recipes/plugins/view_selector/roles_school_example/school.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/view_selector/roles_school_example/school.recipe.json
@@ -12,19 +12,19 @@
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
           "label": "Headmaster view",
+          "eds_icon": "visibility",
           "viewConfig": {
             "type": "CORE:ReferenceViewConfig",
-            "recipe": "AdminView",
-            "eds_icon": "visibility"
+            "recipe": "AdminView"
           }
         },
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
           "label": "Student view",
+          "eds_icon": "visibility",
           "viewConfig": {
             "type": "CORE:ReferenceViewConfig",
-            "recipe": "OperatorView",
-            "eds_icon": "visibility"
+            "recipe": "OperatorView"
           }
         }
       ]

--- a/example/app/data/DemoDataSource/recipes/plugins/view_selector/roles_school_example/schoolDistrict.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/view_selector/roles_school_example/schoolDistrict.recipe.json
@@ -33,10 +33,10 @@
           {
             "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
             "label": "Hogwarts Admin",
+            "eds_icon": "home",
             "viewConfig": {
               "type": "CORE:ReferenceViewConfig",
               "scope": "school",
-              "eds_icon": "home",
               "recipe": "AdminView"
             },
             "subItems": [
@@ -69,10 +69,10 @@
           {
             "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
             "label": "Hogwarts All",
+            "eds_icon": "home",
             "viewConfig": {
               "type": "CORE:ReferenceViewConfig",
               "scope": "school",
-              "eds_icon": "home",
               "recipe": "OperatorView"
             }
           }
@@ -90,10 +90,10 @@
           {
             "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
             "label": "Hogwarts All",
+            "eds_icon": "home",
             "viewConfig": {
               "type": "CORE:ReferenceViewConfig",
               "scope": "school",
-              "eds_icon": "home",
               "recipe": "OperatorView"
             }
           }

--- a/packages/dm-core-plugins/blueprints/view_selector/ViewSelectorItem.json
+++ b/packages/dm-core-plugins/blueprints/view_selector/ViewSelectorItem.json
@@ -20,6 +20,12 @@
       "optional": true
     },
     {
+      "name": "eds_icon",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true
+    },
+    {
       "name": "subItems",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",

--- a/packages/dm-core-plugins/src/view_selector/Sidebar.tsx
+++ b/packages/dm-core-plugins/src/view_selector/Sidebar.tsx
@@ -12,25 +12,26 @@ export const Sidebar = (props: {
 }): React.ReactElement => {
   const { selectedViewId, setSelectedViewId, viewSelectorItems, addView } =
     props
-
   return (
     <SideBar open style={{ height: 'auto' }}>
       <SideBar.Content>
         {viewSelectorItems.map((viewItem: TItemData) => {
           // subItem's will be rendered inside other items. Don't add them here
           if (viewItem.isSubItem) return null
-
           return (
             <div key={viewItem.viewId}>
               {viewItem.subItems ? (
                 <SideBar.Accordion
                   key={viewItem.viewId}
                   icon={
-                    viewItem.viewConfig?.eds_icon
-                      ? EdsIcons[
-                          viewItem.viewConfig.eds_icon as keyof typeof EdsIcons
-                        ]
-                      : EdsIcons.subdirectory_arrow_right
+                    viewItem.eds_icon
+                      ? EdsIcons[viewItem.eds_icon as keyof typeof EdsIcons]
+                      : viewItem.viewConfig?.eds_icon
+                        ? EdsIcons[
+                            viewItem.viewConfig
+                              ?.eds_icon as keyof typeof EdsIcons
+                          ]
+                        : EdsIcons.subdirectory_arrow_right
                   }
                   label={viewItem.label}
                   onClick={() => {
@@ -47,14 +48,6 @@ export const Sidebar = (props: {
                       return (
                         <SideBar.AccordionItem
                           key={index}
-                          icon={
-                            subItem.viewConfig?.eds_icon
-                              ? EdsIcons[
-                                  subItem.viewConfig
-                                    .eds_icon as keyof typeof EdsIcons
-                                ]
-                              : EdsIcons.subdirectory_arrow_right
-                          }
                           label={
                             subItem.label ??
                             subItem.viewConfig?.scope ??
@@ -76,11 +69,14 @@ export const Sidebar = (props: {
                 <SideBar.Link
                   key={viewItem.viewId}
                   icon={
-                    viewItem.viewConfig?.eds_icon
-                      ? EdsIcons[
-                          viewItem.viewConfig.eds_icon as keyof typeof EdsIcons
-                        ]
-                      : EdsIcons.subdirectory_arrow_right
+                    viewItem.eds_icon
+                      ? EdsIcons[viewItem.eds_icon as keyof typeof EdsIcons]
+                      : viewItem.viewConfig?.eds_icon
+                        ? EdsIcons[
+                            viewItem.viewConfig
+                              ?.eds_icon as keyof typeof EdsIcons
+                          ]
+                        : EdsIcons.subdirectory_arrow_right
                   }
                   label={viewItem.label}
                   role='tab'

--- a/packages/dm-core-plugins/src/view_selector/Tabs.tsx
+++ b/packages/dm-core-plugins/src/view_selector/Tabs.tsx
@@ -1,5 +1,5 @@
 import { Button, Tabs as EdsTabs, Tooltip } from '@equinor/eds-core-react'
-import { close } from '@equinor/eds-icons'
+import { close, subdirectory_arrow_right } from '@equinor/eds-icons'
 import * as React from 'react'
 import Icon from './Icon'
 import { TItemData } from './types'
@@ -40,10 +40,10 @@ export const Tabs = (props: {
                 variant='ghost'
                 style={{ fontSize: '16px' }}
               >
-                {config.viewConfig?.eds_icon && (
+                {(config.eds_icon ?? config.viewConfig?.eds_icon) && (
                   <Icon
-                    name={config.viewConfig.eds_icon}
-                    title={config.viewConfig.eds_icon}
+                    name={config.eds_icon ?? config.viewConfig?.eds_icon}
+                    title={config.eds_icon ?? config.viewConfig?.eds_icon}
                   />
                 )}
                 {config.label}

--- a/packages/dm-core-plugins/src/view_selector/types.tsx
+++ b/packages/dm-core-plugins/src/view_selector/types.tsx
@@ -8,6 +8,7 @@ export type TViewSelectorItem = {
   viewConfig?: TReferenceViewConfig | TInlineRecipeViewConfig | TViewConfig
   subItems?: TViewSelectorItem[]
   label?: string
+  eds_icon?: string
 }
 
 export type TItemData = TViewSelectorItem & {

--- a/packages/dm-core-plugins/src/view_selector/useViewSelector.tsx
+++ b/packages/dm-core-plugins/src/view_selector/useViewSelector.tsx
@@ -95,9 +95,10 @@ export function useViewSelector(
         newViews.push({
           viewConfig: viewItem.viewConfig,
           subItems: viewItem.subItems,
+          eds_icon: viewItem.eds_icon,
           label: viewItem.label ?? backupKey,
-          // Generate UUID to allow for multiple view of same scope
           viewId: viewId,
+          // Generate UUID to allow for multiple view of same scope
           rootEntityId: idReference,
           onSubmit: onSubmit,
           onChange: onChange,
@@ -110,6 +111,7 @@ export function useViewSelector(
           newViews.push({
             viewConfig: subItem.viewConfig,
             subItems: subItem.subItems,
+            eds_icon: subItem.eds_icon,
             label: subItem.label ?? subBackupKey,
             // Generate UUID to allow for multiple view of same scope
             viewId: subViewId,
@@ -127,6 +129,7 @@ export function useViewSelector(
       newViews.push({
         label: 'self',
         viewId: 'self',
+        eds_icon: 'home',
         viewConfig: {
           type: 'InlineRecipeViewConfig',
           scope: 'self',
@@ -135,7 +138,6 @@ export function useViewSelector(
             name: 'Yaml',
             plugin: '@development-framework/dm-core-plugins/yaml',
           },
-          eds_icon: 'home',
         },
         onSubmit: onSubmit,
         onChange: onChange,


### PR DESCRIPTION
## What does this pull request change?
View selector will display the eds icon in the viewselector item instead of the one in viewconfig

## Why is this pull request needed?
To have the possiblity to both control the displayed icon in the sidebar and to not change view when clicking the sidebar

## Issues related to this change
