### PR TITLE
fix: allow list header to grow with flexbox

### DIFF
--- a/example/app/data/DemoDataSource/plugins/form/nested/myCarRentalCompany.entity.json
+++ b/example/app/data/DemoDataSource/plugins/form/nested/myCarRentalCompany.entity.json
@@ -15,12 +15,12 @@
     {
       "name": "Volvo",
       "type": "./blueprints/Car",
-      "plateNumber": "1337"
+      "plateNumber": "133713371337"
     },
     {
       "name": "Ferrari",
       "type": "./blueprints/Car",
-      "plateNumber": "F1337"
+      "plateNumber": "F1337F1337F1337"
     }
   ],
   "customers": [

--- a/example/app/data/DemoDataSource/recipes/plugins/form/nested/car.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/nested/car.recipe.json
@@ -5,5 +5,22 @@
     "name": "form",
     "type": "CORE:UiRecipe",
     "plugin": "@development-framework/dm-core-plugins/form"
-  }
+  },
+  "uiRecipes": [
+    {
+      "name": "List",
+      "type": "CORE:UiRecipe",
+      "plugin": "@development-framework/dm-core-plugins/list",
+      "dimensions": "*",
+      "config": {
+        "type": "PLUGINS:dm-core-plugins/list/ListPluginConfig",
+        "headers": ["name", "type", "plateNumber"],
+        "functionality": {
+          "type": "PLUGINS:dm-core-plugins/list/FunctionalityConfig",
+          "delete": true,
+          "expand": true
+        }
+      }
+    }
+  ]
 }

--- a/packages/dm-core-plugins/src/list/ListPlugin.tsx
+++ b/packages/dm-core-plugins/src/list/ListPlugin.tsx
@@ -138,7 +138,7 @@ export const ListPlugin = (props: IUIPlugin & { config?: TListConfig }) => {
   const { documentPath, dataSource } = splitAddress(idReference)
 
   return (
-    <Stack>
+    <Stack style={{ minWidth: 'fit-content' }}>
       {attribute && !attribute.contained && (
         <EntityPickerDialog
           showModal={showModal}
@@ -161,19 +161,17 @@ export const ListPlugin = (props: IUIPlugin & { config?: TListConfig }) => {
       )}
       {paginatedRows &&
         paginatedRows.map((item: TItem<TGenericObject>, index: number) => (
-          <React.Fragment key={item?.key}>
+          <Stack key={item?.key} style={{ width: '100%' }}>
             <Stack
               direction='row'
               role='row'
-              spacing={1}
               justifyContent='space-between'
               alignItems='center'
               style={{
-                padding: '0.25rem 0.5rem',
                 borderBottom: '1px solid #ccc',
               }}
             >
-              <Stack direction='row' spacing={0.5} alignItems='center'>
+              <Stack direction='row' alignItems='center'>
                 {internalConfig.functionality.expand && (
                   <Tooltip title={expanded[item.key] ? 'Minimize' : 'Expand'}>
                     <Button
@@ -212,6 +210,9 @@ export const ListPlugin = (props: IUIPlugin & { config?: TListConfig }) => {
                           key={attribute}
                           variant='body_short'
                           bold={index === 0}
+                          style={{
+                            marginLeft: index !== 0 ? '10px' : '0',
+                          }}
                           className={
                             internalConfig.functionality.expand
                               ? 'cursor-pointer'
@@ -304,7 +305,7 @@ export const ListPlugin = (props: IUIPlugin & { config?: TListConfig }) => {
                 />
               )}
             </Stack>
-          </React.Fragment>
+          </Stack>
         ))}
       <Stack
         direction='row'


### PR DESCRIPTION
## What does this pull request change?
- Allow ListPlugin to shrink down at the minimum as wide as its content
- Use flexbox on list items (rows)

## Why is this pull request needed?

## Issues related to this change
Closes #991 


<img width="652" alt="image" src="https://github.com/equinor/dm-core-packages/assets/43639886/d843f601-1c4b-4ae2-af81-4df3eceb18e6">
<img width="673" alt="image" src="https://github.com/equinor/dm-core-packages/assets/43639886/da55c1fd-5b93-4a23-b761-3e37b5b5fd9e">
<img width="1255" alt="image" src="https://github.com/equinor/dm-core-packages/assets/43639886/925b29f6-32e6-40e1-ab1c-18cb83a98408">
