### PR TITLE
fix: use field name in payload

### DIFF
--- a/packages/dm-core-plugins/src/data-grid/DataGridPlugin.tsx
+++ b/packages/dm-core-plugins/src/data-grid/DataGridPlugin.tsx
@@ -40,7 +40,7 @@ export function DataGridPlugin(props: IUIPlugin) {
   async function saveDocument() {
     setLoading(true)
     try {
-      const payload = { ...document, data }
+      const payload = { ...document, [fieldName]: data }
       await dmssAPI.documentUpdate({
         idAddress: idReference,
         data: JSON.stringify(payload),


### PR DESCRIPTION
## What does this pull request change?
Uses correct fieldName in payload, not hard-coded field "data"

## Why is this pull request needed?
Trying to post to data field, when it might not exist

