### PR TITLE
feat: compactable form buttons

### DIFF
--- a/example/app/data/DemoDataSource/recipes/plugins/form/nested/carRentalCompany.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/nested/carRentalCompany.recipe.json
@@ -79,6 +79,7 @@
             }
           }
         ],
+        "compactButtons": true,
         "showExpanded": true,
         "fields": [
           "owner",

--- a/packages/dm-core-plugins/blueprints/form/FormInput.json
+++ b/packages/dm-core-plugins/blueprints/form/FormInput.json
@@ -42,6 +42,14 @@
       "default": true
     },
     {
+      "name": "compactButtons",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "If true, the submit and redo buttons in the form will be compact. ",
+      "attributeType": "boolean",
+      "optional": true,
+      "default": false
+    },
+    {
       "name": "functionality",
       "type": "CORE:BlueprintAttribute",
       "description": "List functionality config",

--- a/packages/dm-core-plugins/src/form/components/Form.tsx
+++ b/packages/dm-core-plugins/src/form/components/Form.tsx
@@ -168,7 +168,11 @@ export const Form = (props: TFormProps) => {
                 <EdsProvider
                   density={config?.compactButtons ? 'compact' : 'comfortable'}
                 >
-                  <div className='flex space-x-2 justify-start mt-4'>
+                  <div
+                    className={`flex space-x-2 justify-start ${
+                      config?.compactButtons ? 'mt-2' : 'mt-4'
+                    }`}
+                  >
                     <Button
                       onClick={handleCustomReset}
                       type='button'

--- a/packages/dm-core-plugins/src/form/components/Form.tsx
+++ b/packages/dm-core-plugins/src/form/components/Form.tsx
@@ -12,7 +12,7 @@ import {
   useBlueprint,
   useDMSS,
 } from '@development-framework/dm-core'
-import { Button, Icon } from '@equinor/eds-core-react'
+import { Button, EdsProvider, Icon } from '@equinor/eds-core-react'
 import { FormProvider, useForm } from 'react-hook-form'
 import styled from 'styled-components'
 import { RegistryProvider } from '../context/RegistryContext'
@@ -20,7 +20,6 @@ import { TFormConfig, TFormProps, TUiAttributeObject } from '../types'
 import { AttributeList } from './AttributeList'
 import { isPrimitiveType } from '../utils/isPrimitiveType'
 import { getCanOpenOrExpand } from '../templates/shared/utils'
-import { FormButton } from '../../list/Components'
 import { undo } from '@equinor/eds-icons'
 
 const Wrapper = styled.div`
@@ -166,25 +165,29 @@ export const Form = (props: TFormProps) => {
             <Wrapper>
               <AttributeList namePath={namePath} blueprint={blueprint} />
               {showSubmitButton && !config?.readOnly && (
-                <div className='flex space-x-2 justify-start mt-4'>
-                  <Button
-                    onClick={handleCustomReset}
-                    type='button'
-                    disabled={disabled}
-                    tooltip={'Revert changes'}
-                    variant={'outlined'}
-                    data-testid='form-reset'
-                  >
-                    <Icon data={undo} size={16} />
-                  </Button>
-                  <Button
-                    type='submit'
-                    data-testid='form-submit'
-                    onClick={handleSubmit}
-                  >
-                    Submit
-                  </Button>
-                </div>
+                <EdsProvider
+                  density={config?.compactButtons ? 'compact' : 'comfortable'}
+                >
+                  <div className='flex space-x-2 justify-start mt-4'>
+                    <Button
+                      onClick={handleCustomReset}
+                      type='button'
+                      disabled={disabled}
+                      tooltip={'Revert changes'}
+                      variant={'outlined'}
+                      data-testid='form-reset'
+                    >
+                      <Icon data={undo} size={16} />
+                    </Button>
+                    <Button
+                      type='submit'
+                      data-testid='form-submit'
+                      onClick={handleSubmit}
+                    >
+                      Submit
+                    </Button>
+                  </div>
+                </EdsProvider>
               )}
             </Wrapper>
           </RegistryProvider>

--- a/packages/dm-core-plugins/src/form/types.tsx
+++ b/packages/dm-core-plugins/src/form/types.tsx
@@ -84,6 +84,7 @@ export type TFormConfig = {
   fields: string[]
   readOnly?: boolean
   showExpanded?: boolean
+  compactButtons?: boolean
   functionality: {
     expand?: boolean
     open?: boolean


### PR DESCRIPTION
## What does this pull request change?

Add the options for compact submit buttons, for use when there are many mini-forms. 
Is a flag in formConfig. 
compactButtons : boolean

<img width="1450" alt="image" src="https://github.com/equinor/dm-core-packages/assets/37016135/98460085-a933-4585-86bf-136f44d35883">



## Why is this pull request needed?

## Issues related to this change

