### PR TITLE
fix: compact list

### DIFF
--- a/e2e/tests/plugin-form-Nested.spec.ts
+++ b/e2e/tests/plugin-form-Nested.spec.ts
@@ -149,7 +149,7 @@ test('Locations', async () => {
 
 test('New car', async () => {
   const carsDiv = page.getByTestId('cars')
-  await carsDiv.getByRole('button', { name: 'Append Add Item' }).click()
+  await carsDiv.getByLabel('append-item').click()
   await carsDiv.getByRole('button', { name: 'Save' }).click()
   await carsDiv.getByRole('button', { name: 'Expand item' }).last().click()
   await carsDiv.getByTestId('form-text-widget-Name').fill('McLaren')
@@ -173,7 +173,7 @@ test('New customer', async () => {
   await customersDiv.getByRole('button', { name: 'Open' }).click()
   const lastTabPanel = page.getByRole('tabpanel').last()
   await expect(lastTabPanel).toBeVisible()
-  await lastTabPanel.getByRole('button', { name: 'Add Item' }).click()
+  await lastTabPanel.getByLabel('append-item').click()
   await lastTabPanel.getByRole('button', { name: 'Save' }).click()
   await lastTabPanel.getByRole('button', { name: 'Expand item' }).last().click()
   await lastTabPanel.getByTestId('form-text-widget-Name').fill('Lewis')

--- a/e2e/tests/plugin-list-task_list.spec.ts
+++ b/e2e/tests/plugin-list-task_list.spec.ts
@@ -26,7 +26,7 @@ async function reloadPage(page: Page) {
 }
 
 test('Add a new task', async ({ page }) => {
-  await page.getByRole('button', { name: 'Add item' }).click()
+  await page.getByLabel('append-item').click()
   await page.getByRole('button', { name: 'Save' }).click()
   await expect(page.getByRole('button', { name: 'Save' })).toBeDisabled()
   await page
@@ -235,9 +235,9 @@ test('Edit a task', async ({ page }) => {
 })
 
 test('Pagination', async ({ page }) => {
-  await page.getByRole('button', { name: 'Add item' }).click()
-  await page.getByRole('button', { name: 'Add item' }).click()
-  await page.getByRole('button', { name: 'Add item' }).click()
+  await page.getByLabel('append-item').click()
+  await page.getByLabel('append-item').click()
+  await page.getByLabel('append-item').click()
   await expect(page.getByText('1 - 5 of 6')).toBeVisible()
   await page.getByRole('button', { name: 'Save' }).click()
   await expect(page.getByRole('button', { name: 'Save' })).toBeDisabled()

--- a/example/app/data/DemoDataSource/recipes/plugins/form/nested/car.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/nested/car.recipe.json
@@ -15,6 +15,7 @@
       "config": {
         "type": "PLUGINS:dm-core-plugins/list/ListPluginConfig",
         "headers": ["name", "type", "plateNumber"],
+        "compact": true,
         "functionality": {
           "type": "PLUGINS:dm-core-plugins/list/FunctionalityConfig",
           "delete": true,

--- a/packages/dm-core-plugins/blueprints/list/ListPluginConfig.json
+++ b/packages/dm-core-plugins/blueprints/list/ListPluginConfig.json
@@ -16,6 +16,14 @@
       "default": false
     },
     {
+      "name": "compact",
+      "type": "CORE:BlueprintAttribute",
+      "description": "If table should be more compact, with less padding and smaller icons. ",
+      "attributeType": "boolean",
+      "optional": true,
+      "default": false
+    },
+    {
       "name": "saveExpanded",
       "type": "CORE:BlueprintAttribute",
       "description": "Use save button to save expanded items.",

--- a/packages/dm-core-plugins/src/list/Components.tsx
+++ b/packages/dm-core-plugins/src/list/Components.tsx
@@ -15,9 +15,16 @@ import {
 export const AppendButton = (props: {
   onClick: (event: MouseEvent<HTMLButtonElement>) => void
 }) => (
-  <Button variant='outlined' onClick={props.onClick}>
-    <Icon data={add} title='Append' /> Add Item
-  </Button>
+  <Tooltip title='Add item'>
+    <Button
+      variant='outlined'
+      onClick={props.onClick}
+      style={{ paddingInline: '0.5rem' }}
+      aria-label='append-item'
+    >
+      <Icon data={add} size={18} title='Append' />
+    </Button>
+  </Tooltip>
 )
 
 export const FormButton = (props: {

--- a/packages/dm-core-plugins/src/list/ListPlugin.tsx
+++ b/packages/dm-core-plugins/src/list/ListPlugin.tsx
@@ -18,7 +18,13 @@ import {
   TTemplate,
 } from '@development-framework/dm-core'
 import { toast } from 'react-toastify'
-import { Button, Icon, Tooltip, Typography } from '@equinor/eds-core-react'
+import {
+  Button,
+  EdsProvider,
+  Icon,
+  Tooltip,
+  Typography,
+} from '@equinor/eds-core-react'
 import { external_link, undo, chevron_right, link } from '@equinor/eds-icons'
 import { AppendButton, ListChevronButton, FormButton } from './Components'
 
@@ -30,6 +36,7 @@ type TListConfig = {
   saveExpanded: boolean
   selectFromScope?: string
   hideInvalidTypes?: boolean
+  compact?: boolean
   functionality: {
     add: boolean
     sort: boolean
@@ -48,6 +55,7 @@ const defaultConfig: TListConfig = {
   saveExpanded: false,
   selectFromScope: undefined,
   hideInvalidTypes: false,
+  compact: false,
   functionality: {
     add: true,
     sort: true,
@@ -100,6 +108,15 @@ export const ListPlugin = (props: IUIPlugin & { config?: TListConfig }) => {
     updateItem(item, data, false)
   }
 
+  const ensureNotObject = (attribute: any) => {
+    if (typeof attribute === 'object') {
+      throw new Error(
+        `Objects can not be displayed in table header. Attribute '${attribute}' is not a primitive type.`
+      )
+    }
+    return attribute
+  }
+
   const handleExpand = (item: TItem<any>) => {
     const isExpanded = expanded[item.key] || false
     setExpanded({ ...expanded, [item.key]: !isExpanded })
@@ -138,7 +155,7 @@ export const ListPlugin = (props: IUIPlugin & { config?: TListConfig }) => {
   const { documentPath, dataSource } = splitAddress(idReference)
 
   return (
-    <Stack style={{ minWidth: 'fit-content' }}>
+    <Stack style={{ width: '100%' }}>
       {attribute && !attribute.contained && (
         <EntityPickerDialog
           showModal={showModal}
@@ -167,69 +184,89 @@ export const ListPlugin = (props: IUIPlugin & { config?: TListConfig }) => {
               role='row'
               justifyContent='space-between'
               alignItems='center'
+              className={`border-b border-[#ccc]`}
               style={{
-                borderBottom: '1px solid #ccc',
+                paddingBlock: internalConfig.compact ? '' : '2px',
+                paddingInline: '4px',
+                width: '100%',
               }}
             >
-              <Stack direction='row' alignItems='center'>
+              <Stack
+                direction='row'
+                alignItems='center'
+                style={{
+                  width: '100%',
+                  overflow: 'hidden',
+                }}
+              >
                 {internalConfig.functionality.expand && (
-                  <Tooltip title={expanded[item.key] ? 'Minimize' : 'Expand'}>
-                    <Button
-                      variant='ghost_icon'
-                      color='secondary'
-                      disabled={!item.isSaved}
-                      data-testid={`expandListItem-${index}`}
-                      onClick={() => handleExpand(item)}
-                    >
-                      <Icon
-                        data={chevron_right}
-                        size={24}
-                        title={
-                          expanded[item.key] ? 'Minimize item' : 'Expand item'
-                        }
-                        className='transition-all'
-                        style={{
-                          transform: expanded[item.key]
-                            ? 'rotate(90deg)'
-                            : 'rotate(0deg)',
-                        }}
-                      />
-                    </Button>
-                  </Tooltip>
+                  <EdsProvider
+                    density={internalConfig.compact ? 'compact' : 'comfortable'}
+                  >
+                    <Tooltip title={expanded[item.key] ? 'Minimize' : 'Expand'}>
+                      <div className='w-fit'>
+                        <Button
+                          variant='ghost_icon'
+                          color='secondary'
+                          disabled={!item.isSaved}
+                          data-testid={`expandListItem-${index}`}
+                          onClick={() => handleExpand(item)}
+                        >
+                          <Icon
+                            data={chevron_right}
+                            size={internalConfig.compact ? 18 : 24}
+                            title={
+                              expanded[item.key]
+                                ? 'Minimize item'
+                                : 'Expand item'
+                            }
+                            className='transition-all'
+                            style={{
+                              padding: '0px',
+                              transform: expanded[item.key]
+                                ? 'rotate(90deg)'
+                                : 'rotate(0deg)',
+                            }}
+                          />
+                        </Button>
+                      </div>
+                    </Tooltip>
+                  </EdsProvider>
                 )}
                 {attribute && !attribute.contained && <Icon data={link} />}
-                {internalConfig.headers.map(
-                  (attribute: string, index: number) => {
-                    if (item.data && item.data?.[attribute]) {
-                      if (typeof item.data[attribute] === 'object')
-                        throw new Error(
-                          `Objects can not be displayed in table header. Attribute '${attribute}' is not a primitive type.`
-                        )
-                      return (
-                        <Typography
-                          key={attribute}
-                          variant='body_short'
-                          bold={index === 0}
-                          style={{
-                            marginLeft: index !== 0 ? '10px' : '0',
-                          }}
-                          className={
-                            internalConfig.functionality.expand
-                              ? 'cursor-pointer'
-                              : ''
-                          }
-                          onClick={() =>
-                            internalConfig.functionality.expand &&
-                            item.isSaved &&
-                            handleExpand(item)
-                          }
-                        >
-                          {item?.data[attribute]}
-                        </Typography>
-                      )
-                    }
+                <div
+                  onClick={() =>
+                    internalConfig.functionality.expand &&
+                    item.isSaved &&
+                    handleExpand(item)
                   }
-                )}
+                  className={`px-2 overflow-hidden text-ellipsis whitespace-nowrap
+                    ${
+                      internalConfig.functionality.expand
+                        ? 'cursor-pointer'
+                        : ''
+                    }`}
+                >
+                  {internalConfig.headers.map(
+                    (attribute: string, index: number) => {
+                      if (item.data && item.data?.[attribute]) {
+                        return (
+                          <Typography
+                            key={attribute}
+                            variant='body_short'
+                            bold={index === 0}
+                            style={{
+                              marginLeft: index !== 0 ? '10px' : '0',
+                              display: 'inline',
+                            }}
+                          >
+                            {ensureNotObject(item?.data[attribute])}
+                          </Typography>
+                        )
+                      }
+                    }
+                  )}
+                </div>
               </Stack>
               <Stack direction='row' alignItems='center'>
                 {internalConfig.functionality.open && (
@@ -281,39 +318,41 @@ export const ListPlugin = (props: IUIPlugin & { config?: TListConfig }) => {
             </Stack>
             <Stack>
               {expanded[item.key] && (
-                <ViewCreator
-                  onSubmit={
-                    config.saveExpanded
-                      ? undefined
-                      : (data: TGenericObject) => handleItemUpdate(item, data)
-                  }
-                  onChange={
-                    config.saveExpanded
-                      ? (data: TGenericObject) => handleItemUpdate(item, data)
-                      : undefined
-                  }
-                  idReference={
-                    attribute && !attribute.contained
-                      ? resolveRelativeAddress(
-                          item?.reference?.address || '',
-                          documentPath,
-                          dataSource
-                        )
-                      : `${idReference}[${item.index}]`
-                  }
-                  viewConfig={internalConfig.expandViewConfig}
-                />
+                <div className='m-2 border-b border-[#ccc] pb-4'>
+                  <ViewCreator
+                    onSubmit={
+                      config.saveExpanded
+                        ? undefined
+                        : (data: TGenericObject) => handleItemUpdate(item, data)
+                    }
+                    onChange={
+                      config.saveExpanded
+                        ? (data: TGenericObject) => handleItemUpdate(item, data)
+                        : undefined
+                    }
+                    idReference={
+                      attribute && !attribute.contained
+                        ? resolveRelativeAddress(
+                            item?.reference?.address || '',
+                            documentPath,
+                            dataSource
+                          )
+                        : `${idReference}[${item.index}]`
+                    }
+                    viewConfig={internalConfig.expandViewConfig}
+                  />
+                </div>
               )}
             </Stack>
           </Stack>
         ))}
-      <Stack
-        direction='row'
-        justifyContent='space-between'
-        spacing={1}
-        style={{ padding: '1rem 0' }}
-      >
-        {items.length > paginationRowsPerPage && (
+      <EdsProvider density={internalConfig.compact ? 'compact' : 'comfortable'}>
+        <Stack
+          direction='row'
+          justifyContent='space-between'
+          spacing={1}
+          style={{ padding: '1rem 0 0.5rem 0' }}
+        >
           <Pagination
             count={Object.keys(items).length}
             page={paginationPage}
@@ -321,56 +360,61 @@ export const ListPlugin = (props: IUIPlugin & { config?: TListConfig }) => {
             rowsPerPage={paginationRowsPerPage}
             setRowsPerPage={setPaginationRowsPerPage}
           />
-        )}
-        <Stack direction='row' spacing={1}>
-          {internalConfig.functionality.add &&
-            (!config.templates || config.templates.length < 2) && (
-              <AppendButton
-                onClick={() => {
-                  if (attribute && attribute.contained) {
-                    addItem(false)
-                  } else {
-                    setShowModal(true)
-                  }
-                }}
-              />
-            )}
-          {internalConfig.functionality.add &&
-            config.templates &&
-            config.templates.length > 1 && (
-              <>
-                <AppendButton onClick={() => setTemplateMenuIsOpen(true)} />
-                <TemplateMenu
-                  templates={config.templates}
-                  onSelect={(template: TTemplate) =>
-                    addItem(false, undefined, template?.path)
-                  }
-                  onClose={() => setTemplateMenuIsOpen(false)}
-                  isOpen={isTemplateMenuOpen}
+          <Stack
+            direction='row'
+            alignItems='center'
+            spacing={1}
+            justifyContent='space-between'
+          >
+            {internalConfig.functionality.add &&
+              (!config.templates || config.templates.length < 2) && (
+                <AppendButton
+                  onClick={() => {
+                    if (attribute && attribute.contained) {
+                      addItem(false)
+                    } else {
+                      setShowModal(true)
+                    }
+                  }}
                 />
-              </>
-            )}
-          <FormButton
-            onClick={reloadData}
-            disabled={!dirtyState}
-            tooltip={'Revert changes'}
-            variant={'outlined'}
-            isLoading={isLoading}
-            dataTestid='RevertList'
-          >
-            <Icon data={undo} size={16} />
-          </FormButton>
-          <FormButton
-            onClick={() => save(items)}
-            disabled={!dirtyState}
-            isLoading={isLoading}
-            tooltip={'Save'}
-            dataTestid='SaveList'
-          >
-            Save
-          </FormButton>
+              )}
+            {internalConfig.functionality.add &&
+              config.templates &&
+              config.templates.length > 1 && (
+                <>
+                  <AppendButton onClick={() => setTemplateMenuIsOpen(true)} />
+                  <TemplateMenu
+                    templates={config.templates}
+                    onSelect={(template: TTemplate) =>
+                      addItem(false, undefined, template?.path)
+                    }
+                    onClose={() => setTemplateMenuIsOpen(false)}
+                    isOpen={isTemplateMenuOpen}
+                  />
+                </>
+              )}
+            <FormButton
+              onClick={reloadData}
+              disabled={!dirtyState}
+              tooltip={'Revert changes'}
+              variant={'outlined'}
+              isLoading={isLoading}
+              dataTestid='RevertList'
+            >
+              <Icon data={undo} size={16} />
+            </FormButton>
+            <FormButton
+              onClick={() => save(items)}
+              disabled={!dirtyState}
+              isLoading={isLoading}
+              tooltip={'Save'}
+              dataTestid='SaveList'
+            >
+              Save
+            </FormButton>
+          </Stack>
         </Stack>
-      </Stack>
+      </EdsProvider>
     </Stack>
   )
 }


### PR DESCRIPTION
Made a flag to control list compactness. 
Either list is compact or "normal" 


Also made the overflow make sense, with overflow ellipsis if the list attributes span too far, and no overflow. 

<img width="735" alt="image" src="https://github.com/equinor/dm-core-packages/assets/37016135/4969eb68-92a9-4503-854b-8ecce87a8dd5">


Compared to non-compact: 
<img width="811" alt="image" src="https://github.com/equinor/dm-core-packages/assets/37016135/b333527f-3924-4528-9dbf-f83a8acee100">
