### PR TITLE
fix: empty schedule overwriting default cron string

### DIFF
--- a/packages/dm-core-plugins/src/job/CrateFromRecipe.tsx
+++ b/packages/dm-core-plugins/src/job/CrateFromRecipe.tsx
@@ -127,7 +127,7 @@ export const CrateFromRecipe = (
     if (!jobDocument) return
     if (asCronJob || jobDocument.type === EBlueprint.RECURRING_JOB)
       // @ts-ignore
-      setSchedule(jobDocument?.schedule)
+      setSchedule(jobDocument?.schedule.cron ? jobDocument?.schedule : schedule)
     if (jobDocument.type === EBlueprint.RECURRING_JOB) setAsCronJob(true)
   }, [isLoading, jobEntityError, jobDocument])
 


### PR DESCRIPTION
## What does this pull request change?
Avoid overwriting default schedule from new job with empty schedule

## Why is this pull request needed?
Before the recurring job has been created, its schedule is empty by default. The cron configuring component sets a default cron string, which is then overwritten in state by the empty schedule

## Issues related to this change

