### PR TITLE
fix: error when selecting templates for uncontained

### DIFF
--- a/packages/dm-core-plugins/src/list/ListPlugin.tsx
+++ b/packages/dm-core-plugins/src/list/ListPlugin.tsx
@@ -370,33 +370,31 @@ export const ListPlugin = (props: IUIPlugin & { config?: TListConfig }) => {
             spacing={1}
             justifyContent='space-between'
           >
-            {internalConfig.functionality.add &&
-              (!config.templates || config.templates.length < 2) && (
+            {internalConfig.functionality.add && (
+              <>
                 <AppendButton
                   onClick={() => {
-                    if (attribute && attribute.contained) {
-                      addItem(false)
-                    } else {
+                    if (attribute && !attribute.contained) {
                       setShowModal(true)
+                      return
                     }
+                    if (!(config.templates && config.templates.length))
+                      addItem(false)
+                    else if (config.templates.length === 1)
+                      addItem(false, undefined, config.templates[0].path)
+                    else setTemplateMenuIsOpen(true)
                   }}
                 />
-              )}
-            {internalConfig.functionality.add &&
-              config.templates &&
-              config.templates.length > 1 && (
-                <>
-                  <AppendButton onClick={() => setTemplateMenuIsOpen(true)} />
-                  <TemplateMenu
-                    templates={config.templates}
-                    onSelect={(template: TTemplate) =>
-                      addItem(false, undefined, template?.path)
-                    }
-                    onClose={() => setTemplateMenuIsOpen(false)}
-                    isOpen={isTemplateMenuOpen}
-                  />
-                </>
-              )}
+                <TemplateMenu
+                  templates={config.templates}
+                  onSelect={(template: TTemplate) =>
+                    addItem(false, undefined, template?.path)
+                  }
+                  onClose={() => setTemplateMenuIsOpen(false)}
+                  isOpen={isTemplateMenuOpen}
+                />
+              </>
+            )}
             <FormButton
               onClick={reloadData}
               disabled={!dirtyState}

--- a/packages/dm-core-plugins/src/list/ListPlugin.tsx
+++ b/packages/dm-core-plugins/src/list/ListPlugin.tsx
@@ -385,14 +385,16 @@ export const ListPlugin = (props: IUIPlugin & { config?: TListConfig }) => {
                     else setTemplateMenuIsOpen(true)
                   }}
                 />
-                <TemplateMenu
-                  templates={config.templates}
-                  onSelect={(template: TTemplate) =>
-                    addItem(false, undefined, template?.path)
-                  }
-                  onClose={() => setTemplateMenuIsOpen(false)}
-                  isOpen={isTemplateMenuOpen}
-                />
+                {config.templates?.length && (
+                  <TemplateMenu
+                    templates={config.templates}
+                    onSelect={(template: TTemplate) =>
+                      addItem(false, undefined, template?.path)
+                    }
+                    onClose={() => setTemplateMenuIsOpen(false)}
+                    isOpen={isTemplateMenuOpen}
+                  />
+                )}
               </>
             )}
             <FormButton

--- a/packages/dm-core/src/components/Table/Table.tsx
+++ b/packages/dm-core/src/components/Table/Table.tsx
@@ -152,30 +152,20 @@ export function Table(props: TableProps) {
             </EDSTable.Body>
           </EDSTable>
         </SortableContext>
-        {functionalityConfig.add &&
-          (!config.templates || config.templates.length < 2) && (
+        {functionalityConfig.add && (
+          <>
             <AddRowButton
               onClick={() => {
-                const defaultTemplate = config?.templates
-                  ? config.templates[0]
-                  : undefined
-                addItem(
-                  tableVariant === TableVariantNameEnum.View,
-                  undefined,
-                  defaultTemplate?.path
-                )
+                const saveOnAdd = tableVariant === TableVariantNameEnum.View
+                if (!(config.templates && config.templates.length))
+                  addItem(saveOnAdd)
+                else if (config.templates.length === 1)
+                  addItem(saveOnAdd, undefined, config.templates[0].path)
+                else setTemplateMenuIsOpen(true)
               }}
               ariaLabel={'Add new row'}
             />
-          )}
-        {functionalityConfig.add &&
-          config.templates &&
-          config.templates.length > 1 && (
-            <>
-              <AddRowButton
-                ariaLabel={'Add new row'}
-                onClick={() => setTemplateMenuIsOpen(true)}
-              />
+            {config.templates?.length && (
               <TemplateMenu
                 templates={config.templates}
                 onSelect={(template: TTemplate) =>
@@ -188,8 +178,9 @@ export function Table(props: TableProps) {
                 onClose={() => setTemplateMenuIsOpen(false)}
                 isOpen={isTemplateMenuOpen}
               />
-            </>
-          )}
+            )}
+          </>
+        )}
       </Stack>
       <Stack direction='row' spacing={1} justifyContent='space-between'>
         <Pagination


### PR DESCRIPTION
## What does this pull request change?


FIX templates for list
- Makes it so uncontained list does not try to use templates, which caused errors. 
- Also makes contained use template[0] if there is only one template provided. 

REFACTOR templates for table

- code here was a bit messy, so refactored it to same pattern as used for lsit


## Why is this pull request needed?



## Issues related to this change

