### PR TITLE
fix: wrong name of start and end date replaced in date range picker

### DIFF
--- a/packages/dm-core-plugins/src/job/DateRangePicker.tsx
+++ b/packages/dm-core-plugins/src/job/DateRangePicker.tsx
@@ -19,14 +19,14 @@ const DateRangePicker = (props: {
         id='cron-job-start-date'
         variant='datetime'
         value={value.startDate}
-        onChange={(date) => setDateRange({ ...value, start: date })}
+        onChange={(date) => setDateRange({ ...value, startDate: date })}
         label='Valid from'
       />
       <Datepicker
         id='cron-job-end-date'
         variant='datetime'
         value={value.endDate}
-        onChange={(date) => setDateRange({ ...value, end: date })}
+        onChange={(date) => setDateRange({ ...value, endDate: date })}
         label='Valid to'
       />
     </div>


### PR DESCRIPTION
## What does this pull request change?

## Why is this pull request needed?

## Issues related to this change

