### PR TITLE
Feat: better list padding + default pagination view

### DIFF
--- a/example/app/data/DemoDataSource/recipes/plugins/form/nested/car.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/nested/car.recipe.json
@@ -16,6 +16,7 @@
         "type": "PLUGINS:dm-core-plugins/list/ListPluginConfig",
         "headers": ["name", "type", "plateNumber"],
         "compact": true,
+        "defaultPaginationRowsPerPage": 7,
         "functionality": {
           "type": "PLUGINS:dm-core-plugins/list/FunctionalityConfig",
           "delete": true,

--- a/packages/dm-core-plugins/blueprints/list/ListPluginConfig.json
+++ b/packages/dm-core-plugins/blueprints/list/ListPluginConfig.json
@@ -97,6 +97,13 @@
       "description": "Override label for all items that are opened in a ViewSelector from List.",
       "attributeType": "string",
       "optional": true
+    },
+    {
+      "name": "defaultPaginationRowsPerPage",
+      "type": "CORE:BlueprintAttribute",
+      "description": "The number of rows per page to show by default. If there are less rows in the list than this number, then pagination selector will not be visible. ",
+      "attributeType": "number",
+      "optional": true
     }
   ]
 }

--- a/packages/dm-core-plugins/src/form/templates/ArrayComplexTemplate.tsx
+++ b/packages/dm-core-plugins/src/form/templates/ArrayComplexTemplate.tsx
@@ -80,7 +80,7 @@ export const ArrayComplexTemplate = (props: TArrayTemplate) => {
         </FormTemplate.Header.Actions>
       </FormTemplate.Header>
       {canExpand && isExpanded && (
-        <FormTemplate.Content>
+        <FormTemplate.Content padding='px-2 pt-2'>
           <ViewCreator
             idReference={`${idReference}.${namePath}`}
             onOpen={onOpen}

--- a/packages/dm-core-plugins/src/list/Components.tsx
+++ b/packages/dm-core-plugins/src/list/Components.tsx
@@ -6,20 +6,16 @@ import {
   Progress,
   Tooltip,
 } from '@equinor/eds-core-react'
-import {
-  chevron_down,
-  chevron_up,
-  delete_to_trash,
-  add,
-} from '@equinor/eds-icons'
+import { chevron_down, chevron_up, add } from '@equinor/eds-icons'
 export const AppendButton = (props: {
   onClick: (event: MouseEvent<HTMLButtonElement>) => void
+  compact?: boolean
 }) => (
   <Tooltip title='Add item'>
     <Button
       variant='outlined'
       onClick={props.onClick}
-      style={{ paddingInline: '0.5rem' }}
+      style={{ paddingInline: props.compact ? '0.5rem' : '0.7rem' }}
       aria-label='append-item'
     >
       <Icon data={add} size={18} title='Append' />

--- a/packages/dm-core-plugins/src/list/ListPlugin.tsx
+++ b/packages/dm-core-plugins/src/list/ListPlugin.tsx
@@ -47,6 +47,7 @@ type TListConfig = {
   resolveReferences: boolean
   templates?: TTemplate[]
   labelByIndex?: boolean
+  defaultPaginationRowsPerPage?: number
   label?: string
 }
 const defaultConfig: TListConfig = {
@@ -58,6 +59,7 @@ const defaultConfig: TListConfig = {
   selectFromScope: undefined,
   hideInvalidTypes: false,
   compact: false,
+  defaultPaginationRowsPerPage: 10,
   functionality: {
     add: true,
     sort: true,
@@ -91,8 +93,17 @@ export const ListPlugin = (props: IUIPlugin & { config?: TListConfig }) => {
     updateItem,
   } = useList<TGenericObject>(idReference, internalConfig.resolveReferences)
 
+  const defaultPaginationRowsPerPage =
+    internalConfig.defaultPaginationRowsPerPage ?? 10
+  const showPagination = useMemo(
+    () => items.length > defaultPaginationRowsPerPage,
+    [items]
+  )
+
   const [paginationPage, setPaginationPage] = useState(0)
-  const [paginationRowsPerPage, setPaginationRowsPerPage] = useState(5)
+  const [paginationRowsPerPage, setPaginationRowsPerPage] = useState(
+    defaultPaginationRowsPerPage
+  )
   const [showModal, setShowModal] = useState<boolean>(false)
   const [expanded, setExpanded] = useState<Record<string, boolean>>({})
   const [isTemplateMenuOpen, setTemplateMenuIsOpen] = useState<boolean>(false)
@@ -353,17 +364,23 @@ export const ListPlugin = (props: IUIPlugin & { config?: TListConfig }) => {
       <EdsProvider density={internalConfig.compact ? 'compact' : 'comfortable'}>
         <Stack
           direction='row'
-          justifyContent='space-between'
+          justifyContent={showPagination ? 'space-between' : 'flex-end'}
           spacing={1}
-          style={{ padding: '1rem 0 0.5rem 0' }}
+          style={
+            showPagination
+              ? { padding: '0.2rem 0 0.2rem 0.5rem' }
+              : { padding: '0.5rem 0 0.5rem 0' }
+          }
         >
-          <Pagination
-            count={Object.keys(items).length}
-            page={paginationPage}
-            setPage={setPaginationPage}
-            rowsPerPage={paginationRowsPerPage}
-            setRowsPerPage={setPaginationRowsPerPage}
-          />
+          {showPagination && (
+            <Pagination
+              count={Object.keys(items).length}
+              page={paginationPage}
+              setPage={setPaginationPage}
+              rowsPerPage={paginationRowsPerPage}
+              setRowsPerPage={setPaginationRowsPerPage}
+            />
+          )}
           <Stack
             direction='row'
             alignItems='center'

--- a/packages/dm-core-plugins/src/list/ListPlugin.tsx
+++ b/packages/dm-core-plugins/src/list/ListPlugin.tsx
@@ -59,7 +59,7 @@ const defaultConfig: TListConfig = {
   selectFromScope: undefined,
   hideInvalidTypes: false,
   compact: false,
-  defaultPaginationRowsPerPage: 10,
+  defaultPaginationRowsPerPage: 5,
   functionality: {
     add: true,
     sort: true,
@@ -93,16 +93,23 @@ export const ListPlugin = (props: IUIPlugin & { config?: TListConfig }) => {
     updateItem,
   } = useList<TGenericObject>(idReference, internalConfig.resolveReferences)
 
-  const defaultPaginationRowsPerPage =
-    internalConfig.defaultPaginationRowsPerPage ?? 10
-  const showPagination = useMemo(
-    () => items.length > defaultPaginationRowsPerPage,
-    [items]
-  )
+  const defaultPaginationRowsPerPage = useMemo(() => {
+    let numRows = internalConfig.defaultPaginationRowsPerPage ?? 5
+    numRows = Math.round(numRows)
+    numRows = Math.abs(numRows)
+    return numRows
+  }, [internalConfig.defaultPaginationRowsPerPage])
 
   const [paginationPage, setPaginationPage] = useState(0)
   const [paginationRowsPerPage, setPaginationRowsPerPage] = useState(
     defaultPaginationRowsPerPage
+  )
+
+  const showPagination = useMemo(
+    () =>
+      items.length >
+      Math.min(defaultPaginationRowsPerPage, paginationRowsPerPage),
+    [items, paginationRowsPerPage]
   )
   const [showModal, setShowModal] = useState<boolean>(false)
   const [expanded, setExpanded] = useState<Record<string, boolean>>({})
@@ -379,6 +386,7 @@ export const ListPlugin = (props: IUIPlugin & { config?: TListConfig }) => {
               setPage={setPaginationPage}
               rowsPerPage={paginationRowsPerPage}
               setRowsPerPage={setPaginationRowsPerPage}
+              defaultRowsPerPage={defaultPaginationRowsPerPage}
             />
           )}
           <Stack
@@ -397,6 +405,7 @@ export const ListPlugin = (props: IUIPlugin & { config?: TListConfig }) => {
                       setShowModal(true)
                     }
                   }}
+                  compact={internalConfig.compact}
                 />
               )}
             {internalConfig.functionality.add &&

--- a/packages/dm-core/src/components/Pagination/Pagination.tsx
+++ b/packages/dm-core/src/components/Pagination/Pagination.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import { Stack } from '../common'
 import { Button, Icon, NativeSelect, Typography } from '@equinor/eds-core-react'
 import { chevron_left, chevron_right } from '@equinor/eds-icons'
@@ -9,15 +9,32 @@ type PaginationProps = {
   setPage: React.Dispatch<React.SetStateAction<number>>
   rowsPerPage: number
   setRowsPerPage: React.Dispatch<React.SetStateAction<number>>
+  defaultRowsPerPage?: number
 }
 
 export function Pagination(props: PaginationProps) {
-  const { count = 0, page, setPage, rowsPerPage, setRowsPerPage } = props
+  const {
+    count = 0,
+    page,
+    setPage,
+    rowsPerPage,
+    setRowsPerPage,
+    defaultRowsPerPage,
+  } = props
 
   const calculatedPages = Math.ceil(count / rowsPerPage) // could be less than zero
   const availablePages = calculatedPages < 1 ? 1 : calculatedPages // if calculated pages is less than zero, return 1
   const visibleFromLabel = count === 0 ? 0 : page * rowsPerPage + 1
   const visibleToLabel = Math.min(count, (page + 1) * rowsPerPage)
+
+  const paginationSizes = useMemo(() => {
+    const sizes = [5, 10, 25, 50, 100, 500]
+    if (defaultRowsPerPage && !sizes.includes(defaultRowsPerPage)) {
+      sizes.push(defaultRowsPerPage)
+      sizes.sort((a, b) => a - b)
+    }
+    return sizes
+  }, [defaultRowsPerPage])
 
   return (
     <Stack
@@ -37,7 +54,7 @@ export function Pagination(props: PaginationProps) {
           onChange={(event) => setRowsPerPage(Number(event.target.value))}
           style={{ width: '70px' }}
         >
-          {[5, 10, 25, 50, 100, 500].map((amount) => (
+          {paginationSizes.map((amount) => (
             <option key={amount}>{amount}</option>
           ))}
         </NativeSelect>


### PR DESCRIPTION
## What does this pull request change?

Config to set default pagination. 
- is put into sorted list of paginationOptions
- if numItems < Min(defaultPaginationSize, selectedPaginationSize) then don't show pagination selector. 

Video of how it works: 
https://jam.dev/c/885b812e-70e2-4a17-b4a7-5a84042f13f5


## Why is this pull request needed?

## Issues related to this change

