### PR TITLE
feat: added close button to userinfo and about dialogs

### DIFF
--- a/packages/dm-core-plugins/src/header/components/AboutDialog.tsx
+++ b/packages/dm-core-plugins/src/header/components/AboutDialog.tsx
@@ -1,6 +1,7 @@
 import { Dialog, TApplication } from '@development-framework/dm-core'
-import { Button } from '@equinor/eds-core-react'
+import { Button, Icon } from '@equinor/eds-core-react'
 import React from 'react'
+import { close } from '@equinor/eds-icons'
 
 type AboutDialogProps = {
   isOpen: boolean
@@ -20,6 +21,14 @@ export const AboutDialog = (props: AboutDialogProps) => {
     >
       <Dialog.Header>
         <Dialog.Title>About {applicationEntity.label}</Dialog.Title>
+        <Button
+          variant='ghost'
+          onClick={() => {
+            setIsOpen(false)
+          }}
+        >
+          <Icon data={close} size={16} title='Close' />
+        </Button>
       </Dialog.Header>
       <Dialog.CustomContent>
         {applicationEntity.description}

--- a/packages/dm-core-plugins/src/header/components/UserInfoDialog.tsx
+++ b/packages/dm-core-plugins/src/header/components/UserInfoDialog.tsx
@@ -5,12 +5,13 @@ import {
   TRole,
   useDMSS,
 } from '@development-framework/dm-core'
-import { Button, Radio, Typography } from '@equinor/eds-core-react'
+import { Button, Icon, Radio, Typography } from '@equinor/eds-core-react'
 import { AxiosResponse } from 'axios'
 import React, { useContext, useState } from 'react'
 import { AuthContext } from 'react-oauth2-code-pkce'
 import { toast } from 'react-toastify'
 import styled from 'styled-components'
+import { close } from '@equinor/eds-icons'
 
 const UnstyledList = styled.ul`
   margin: 0;
@@ -63,6 +64,14 @@ export const UserInfoDialog = (props: UserInfoDialogProps) => {
     >
       <Dialog.Header>
         <Dialog.Title>User info</Dialog.Title>
+        <Button
+          variant='ghost'
+          onClick={() => {
+            setIsOpen(false)
+          }}
+        >
+          <Icon data={close} size={16} title='Close' />
+        </Button>
       </Dialog.Header>
       <Dialog.CustomContent>
         <Row>


### PR DESCRIPTION
## What does this pull request change?
Added a close button in the upper right corner for UserInforDialog and AboutDialog.

![Screenshot 2023-12-21 at 13 48 33](https://github.com/equinor/dm-core-packages/assets/38418577/ebda58ad-6144-45b5-94f6-7cce8ae0ac1b)


## Why is this pull request needed?
More user friendly to have an explicit close button, besides clicking outside of the dialog box.

## Issues related to this change

