### PR TITLE
fix: table opens too many tabs

### DIFF
--- a/packages/dm-core/src/components/Table/TableRow/TableRow.tsx
+++ b/packages/dm-core/src/components/Table/TableRow/TableRow.tsx
@@ -60,7 +60,7 @@ export function TableRow(props: TableRowProps) {
         ? item?.data?.name
         : `${idReference.split('.').slice(-1)}`
     props.onOpen(
-      crypto.randomUUID(),
+      item.key,
       {
         label: config.labelByIndex ? `${label} #${item.index + 1}` : label,
         type: 'ViewConfig',


### PR DESCRIPTION
## What does this pull request change?
Use a deterministic key to open tabs
<img width="575" alt="image" src="https://github.com/equinor/dm-core-packages/assets/43639886/5fd5d3db-fbbe-435f-b7b2-2afe6c7bf1a8">

## Why is this pull request needed?
Table duplicates tabs because a different viewId is used for each open event

## Issues related to this change
Closes #1055 
