### PR TITLE
fix: reset role state when closing without saving

### DIFF
--- a/packages/dm-core-plugins/src/header/components/UserInfoDialog.tsx
+++ b/packages/dm-core-plugins/src/header/components/UserInfoDialog.tsx
@@ -59,7 +59,10 @@ export const UserInfoDialog = (props: UserInfoDialogProps) => {
     <Dialog
       isDismissable
       open={isOpen}
-      onClose={() => setIsOpen(false)}
+      onClose={() => {
+        setSelectedRole(role)
+        setIsOpen(false)
+      }}
       width={'720px'}
     >
       <Dialog.Header>
@@ -67,6 +70,7 @@ export const UserInfoDialog = (props: UserInfoDialogProps) => {
         <Button
           variant='ghost'
           onClick={() => {
+            setSelectedRole(role)
             setIsOpen(false)
           }}
         >


### PR DESCRIPTION
## What does this pull request change?
Reset to original user role when closing the dialog box without saving.

## Why is this pull request needed?
When you select a new role but closes the dialog without saving, the new value was still selected when it should have been reset to the original state.

The fix applies for both ways of closing the dialog box. Either by using the "X" or by clicking outside of the box.

## Issues related to this change

