### PR TITLE
fix(ListPlugin): 'selectFromScope' support relative addresses

### DIFF
--- a/example/app/data/DemoDataSource/plugins/list/templates/task1.entity.json
+++ b/example/app/data/DemoDataSource/plugins/list/templates/task1.entity.json
@@ -1,5 +1,5 @@
 {
-  "_id": "wash_task",
+  "_id": "wash_task_templates",
   "name": "Wash_the_car",
   "type": "./blueprints/Task",
   "description": "Car needs a thorough wash inside and outside.",

--- a/example/app/data/DemoDataSource/plugins/list/templates/uncontainedTaskList.entity.json
+++ b/example/app/data/DemoDataSource/plugins/list/templates/uncontainedTaskList.entity.json
@@ -1,11 +1,11 @@
 {
-  "_id": "uncontainedTaskList",
+  "_id": "uncontainedTaskList_templates",
   "name": "uncontainedTaskList",
   "type": "./blueprints/UncontainedTaskList",
   "task_list": [
     {
       "type": "CORE:Reference",
-      "address": "/$wash_task",
+      "address": "/$wash_task_templates",
       "referenceType": "link"
     }
   ]

--- a/packages/dm-core-plugins/src/list/ListPlugin.tsx
+++ b/packages/dm-core-plugins/src/list/ListPlugin.tsx
@@ -16,6 +16,7 @@ import {
   TEntityPickerReturn,
   TemplateMenu,
   TTemplate,
+  resolveRelativeAddressSimplified,
 } from '@development-framework/dm-core'
 import { toast } from 'react-toastify'
 import {
@@ -183,7 +184,10 @@ export const ListPlugin = (props: IUIPlugin & { config?: TListConfig }) => {
           showModal={showModal}
           setShowModal={setShowModal}
           typeFilter={type}
-          scope={config.selectFromScope}
+          scope={resolveRelativeAddressSimplified(
+            config.selectFromScope,
+            idReference
+          )}
           onChange={async (entities: TEntityPickerReturn[]) => {
             const newKeys: Record<string, boolean> = {}
             for (const { address, entity } of entities) {

--- a/packages/dm-core/src/components/TreeView.tsx
+++ b/packages/dm-core/src/components/TreeView.tsx
@@ -46,6 +46,14 @@ export type TNodeWrapperProps = {
 const TypeIcon = (props: { node: TreeNode; expanded: boolean }) => {
   const { node, expanded } = props
 
+  if (node.type === 'error')
+    return (
+      <FaExclamationTriangle
+        style={{ color: 'orange' }}
+        title='failed to load'
+      />
+    )
+
   const showAsReference =
     node.parent?.type !== EBlueprint.PACKAGE &&
     node?.type !== EBlueprint.PACKAGE &&
@@ -75,13 +83,6 @@ const TypeIcon = (props: { node: TreeNode; expanded: boolean }) => {
     }
     case 'dataSource':
       return <FaDatabase style={{ color: 'gray' }} title='data source' />
-    case 'error':
-      return (
-        <FaExclamationTriangle
-          style={{ color: 'orange' }}
-          title='failed to load'
-        />
-      )
     case EBlueprint.BLUEPRINT:
       return <FaRegFileAlt style={{ color: '#2966FF' }} title='blueprint' />
     case EBlueprint.PACKAGE:
@@ -224,8 +225,8 @@ export const TreeView = (props: {
   includeTypes?: string[] // Types to include in the tree (excludes the 'ignoredTypes' option)
 }) => {
   const { nodes, onSelect, NodeWrapper, ignoredTypes, includeTypes } = props
-
   if (includeTypes && includeTypes.length) {
+    includeTypes?.push('error') // Never hide error nodes
     return (
       <StyledUl>
         {nodes


### PR DESCRIPTION
## What does this pull request change?
- ListPlugin's "selectFromScope" can now be a relative address
- Fixes a bug where error nodes in Tree where shown as a folder or document
- Implement a new "resolveRelativeAddress" that is simpler to use (should remove old one later)
- Fix some test entities which had duplicated $id's

## Issues related to this change

closes #1053