### PR TITLE
fix: update existing viewitem on add

### DIFF
--- a/packages/dm-core-plugins/src/view_selector/useViewSelector.tsx
+++ b/packages/dm-core-plugins/src/view_selector/useViewSelector.tsx
@@ -52,19 +52,27 @@ export function useViewSelector(
     onSubmitAdded?: (data: any) => void,
     onChangeAdded?: (data: any) => void
   ) => {
-    if (!viewSelectorItems.find((view: TItemData) => view.viewId === viewId)) {
+    const existingViewIndex = viewSelectorItems.findIndex(
+      (view: TItemData) => view.viewId === viewId
+    )
+    const newView: TItemData = {
+      viewId: viewId,
+      viewConfig: viewConfig,
+      label: viewConfig.label ?? viewId,
+      rootEntityId: rootId || idReference,
+      onSubmit: onSubmitAdded,
+      onChange: onChangeAdded,
+      closeable: true,
+      isSubItem: isSubItem,
+    }
+    if (existingViewIndex === -1) {
       // View does not exist, add it
-      const newView: TItemData = {
-        viewId: viewId,
-        viewConfig: viewConfig,
-        label: viewConfig.label ?? viewId,
-        rootEntityId: rootId || idReference,
-        onSubmit: onSubmitAdded,
-        onChange: onChangeAdded,
-        closeable: true,
-        isSubItem: isSubItem,
-      }
       setViewSelectorItems([...viewSelectorItems, newView])
+    } else {
+      newView.viewId = viewSelectorItems[existingViewIndex].viewId
+      const replaced = [...viewSelectorItems]
+      replaced.splice(existingViewIndex, 1, newView)
+      setViewSelectorItems(replaced)
     }
     setSelectedViewId(viewId)
   }

--- a/packages/dm-core/src/components/Table/TableRow/TableRow.tsx
+++ b/packages/dm-core/src/components/Table/TableRow/TableRow.tsx
@@ -62,7 +62,7 @@ export function TableRow(props: TableRowProps) {
     props.onOpen(
       item.key,
       {
-        label: config.labelByIndex ? `${label} #${item.index + 1}` : label,
+        label: config.labelByIndex ? `${label} #${index + 1}` : label,
         type: 'ViewConfig',
       },
       `${idReference}[${index}]`,


### PR DESCRIPTION
## What does this pull request change?
Updates the tab (viewItem) with the latest state onOpen (e.g. with new index when position has changed after delete)

## Why is this pull request needed?
Opening tab after delete does not update the index

## Issues related to this change
Closes #1065 
