### PR TITLE
fix: select entity label as view label

### DIFF
--- a/packages/dm-core-plugins/src/list/ListPlugin.tsx
+++ b/packages/dm-core-plugins/src/list/ListPlugin.tsx
@@ -150,11 +150,11 @@ export const ListPlugin = (props: IUIPlugin & { config?: TListConfig }) => {
       )
       return
     }
-    const label = config.label
-      ? config.label
-      : item?.data?.name
-        ? item?.data?.name
-        : `${attribute?.name}`
+    const label =
+      config.label ||
+      item.data?.label ||
+      item.data?.name ||
+      `${attribute?.name}`
     const view = {
       ...internalConfig.openViewConfig,
       label: config.labelByIndex ? `${label} #${item.index + 1}` : label,

--- a/packages/dm-core/src/components/Table/TableRow/TableRow.tsx
+++ b/packages/dm-core/src/components/Table/TableRow/TableRow.tsx
@@ -54,11 +54,11 @@ export function TableRow(props: TableRowProps) {
       )
       return
     }
-    const label = config.label
-      ? config.label
-      : item?.data?.name
-        ? item?.data?.name
-        : `${idReference.split('.').slice(-1)}`
+    const label =
+      config.label ||
+      item.data?.label ||
+      item.data?.name ||
+      `${idReference.split('.').slice(-1)}`
     props.onOpen(
       item.key,
       {


### PR DESCRIPTION
## What does this pull request change?
Prioritieses entitty label above enity name when generating label for viewSelectorItem

## Why is this pull request needed?
Requested feature

## Issues related to this change
Closes #1064 
