### PR TITLE
fix: disable submit when form state is invalid

### DIFF
--- a/packages/dm-core-plugins/src/form/components/Form.tsx
+++ b/packages/dm-core-plugins/src/form/components/Form.tsx
@@ -76,7 +76,6 @@ export const Form = (props: TFormProps) => {
   const namePath: string = ''
 
   const replaceNull = (obj: TGenericObject) => {
-    console.log(obj)
     for (const key of Object.keys(obj)) {
       if (obj[key] === null) {
         obj[key] = undefined

--- a/packages/dm-core-plugins/src/form/components/Form.tsx
+++ b/packages/dm-core-plugins/src/form/components/Form.tsx
@@ -187,6 +187,9 @@ export const Form = (props: TFormProps) => {
                       type='submit'
                       data-testid='form-submit'
                       onClick={handleSubmit}
+                      disabled={
+                        !methods.formState.isDirty && methods.formState.isValid
+                      }
                     >
                       Submit
                     </Button>

--- a/packages/dm-core-plugins/src/form/components/Form.tsx
+++ b/packages/dm-core-plugins/src/form/components/Form.tsx
@@ -21,6 +21,7 @@ import { AttributeList } from './AttributeList'
 import { isPrimitiveType } from '../utils/isPrimitiveType'
 import { getCanOpenOrExpand } from '../templates/shared/utils'
 import { undo } from '@equinor/eds-icons'
+import { isEmpty } from 'lodash'
 
 const Wrapper = styled.div`
   max-width: 650px;
@@ -187,9 +188,7 @@ export const Form = (props: TFormProps) => {
                       type='submit'
                       data-testid='form-submit'
                       onClick={handleSubmit}
-                      disabled={
-                        !methods.formState.isDirty && methods.formState.isValid
-                      }
+                      disabled={disabled && isEmpty(methods.formState.errors)}
                     >
                       Submit
                     </Button>

--- a/packages/dm-core-plugins/src/form/components/Form.tsx
+++ b/packages/dm-core-plugins/src/form/components/Form.tsx
@@ -21,7 +21,6 @@ import { AttributeList } from './AttributeList'
 import { isPrimitiveType } from '../utils/isPrimitiveType'
 import { getCanOpenOrExpand } from '../templates/shared/utils'
 import { undo } from '@equinor/eds-icons'
-import { isEmpty } from 'lodash'
 
 const Wrapper = styled.div`
   max-width: 650px;

--- a/packages/dm-core-plugins/src/form/components/Form.tsx
+++ b/packages/dm-core-plugins/src/form/components/Form.tsx
@@ -70,9 +70,11 @@ export const Form = (props: TFormProps) => {
       ...props.config?.functionality,
     },
   }
-
   // Every react hook form controller needs to have a unique name
-  const namePath: string = ''
+  const namePath: string =
+    idReference.split('.').length > 1
+      ? `${idReference.split('.').slice(-1)}`
+      : ''
 
   const replaceNull = (obj: TGenericObject) => {
     for (const key of Object.keys(obj)) {
@@ -162,49 +164,55 @@ export const Form = (props: TFormProps) => {
 
   const showSubmitButton = props.showSubmitButton ?? true
   const disabled = isLoading || !methods.formState.isDirty
+  const content = () => {
+    return (
+      <RegistryProvider
+        onOpen={onOpen}
+        idReference={idReference}
+        config={{ ...defaultConfig, ...props.config }}
+      >
+        <Wrapper>
+          <AttributeList namePath={namePath} blueprint={blueprint} />
+          {showSubmitButton && !config?.readOnly && (
+            <EdsProvider
+              density={config?.compactButtons ? 'compact' : 'comfortable'}
+            >
+              <div
+                className={`flex space-x-2 justify-start ${
+                  config?.compactButtons ? 'mt-2' : 'mt-4'
+                }`}
+              >
+                <Button
+                  onClick={handleCustomReset}
+                  type='button'
+                  disabled={disabled}
+                  tooltip={'Revert changes'}
+                  variant={'outlined'}
+                  data-testid='form-reset'
+                >
+                  <Icon data={undo} size={16} />
+                </Button>
+                <Button
+                  type='submit'
+                  data-testid='form-submit'
+                  onClick={handleSubmit}
+                >
+                  Submit
+                </Button>
+              </div>
+            </EdsProvider>
+          )}
+        </Wrapper>
+      </RegistryProvider>
+    )
+  }
+
   return (
     <>
-      {showComponent && (
-        <FormProvider {...methods}>
-          <RegistryProvider
-            onOpen={onOpen}
-            idReference={idReference}
-            config={{ ...defaultConfig, ...props.config }}
-          >
-            <Wrapper>
-              <AttributeList namePath={namePath} blueprint={blueprint} />
-              {showSubmitButton && !config?.readOnly && (
-                <EdsProvider
-                  density={config?.compactButtons ? 'compact' : 'comfortable'}
-                >
-                  <div
-                    className={`flex space-x-2 justify-start ${
-                      config?.compactButtons ? 'mt-2' : 'mt-4'
-                    }`}
-                  >
-                    <Button
-                      onClick={handleCustomReset}
-                      type='button'
-                      disabled={disabled}
-                      tooltip={'Revert changes'}
-                      variant={'outlined'}
-                      data-testid='form-reset'
-                    >
-                      <Icon data={undo} size={16} />
-                    </Button>
-                    <Button
-                      type='submit'
-                      data-testid='form-submit'
-                      onClick={handleSubmit}
-                    >
-                      Submit
-                    </Button>
-                  </div>
-                </EdsProvider>
-              )}
-            </Wrapper>
-          </RegistryProvider>
-        </FormProvider>
+      {showComponent && showSubmitButton ? (
+        <FormProvider {...methods}>{content()}</FormProvider>
+      ) : (
+        <>{content()}</>
       )}
     </>
   )

--- a/packages/dm-core-plugins/src/form/components/Form.tsx
+++ b/packages/dm-core-plugins/src/form/components/Form.tsx
@@ -188,7 +188,6 @@ export const Form = (props: TFormProps) => {
                       type='submit'
                       data-testid='form-submit'
                       onClick={handleSubmit}
-                      disabled={disabled && isEmpty(methods.formState.errors)}
                     >
                       Submit
                     </Button>

--- a/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
@@ -9,9 +9,9 @@ import arrayTemplates from '../templates'
 
 export default function ArrayField(props: TArrayTemplate) {
   const { uiAttribute, namePath, attribute } = props
+  const { getValues, setValue, control } = useFormContext()
 
   if (isPrimitiveType(attribute.attributeType) && uiAttribute?.widget) {
-    const { getValues, setValue } = useFormContext()
     const value = getValues(namePath)
     const Widget = getWidget(uiAttribute.widget)
     return (
@@ -35,6 +35,7 @@ export default function ArrayField(props: TArrayTemplate) {
     return (
       <Controller
         name={namePath}
+        control={control}
         render={({ field: { value, onChange } }) => {
           // TODO: make this into same as getWidget(uiAttribute?.template)
           const templates = { ...arrayTemplates }

--- a/packages/dm-core-plugins/src/form/fields/BooleanField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/BooleanField.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Controller } from 'react-hook-form'
+import { Controller, useFormContext } from 'react-hook-form'
 import { getWidget } from '../context/WidgetContext'
 import { TField, TUiAttributeString } from '../types'
 import { useRegistryContext } from '../context/RegistryContext'
@@ -10,11 +10,16 @@ export const BooleanField = (props: TField) => {
 
   const Widget = getWidget(uiAttribute?.widget ?? 'CheckboxWidget')
   const { config } = useRegistryContext()
+  const { control } = useFormContext()
   const readOnly = uiAttribute?.readOnly || config.readOnly
   return (
     <Controller
       name={namePath}
+      control={control}
       defaultValue={attribute.default === 'True'} // we need to convert default values coming from the API since they are always strings
+      rules={{
+        required: attribute.optional ? false : 'Required',
+      }}
       render={({
         field: { ref, value, ...props },
         fieldState: { invalid, error },

--- a/packages/dm-core-plugins/src/form/fields/NumberField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/NumberField.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Controller } from 'react-hook-form'
+import { Controller, useFormContext } from 'react-hook-form'
 import { getWidget } from '../context/WidgetContext'
 import { TField, TUiAttributeString } from '../types'
 import { useRegistryContext } from '../context/RegistryContext'
@@ -11,10 +11,12 @@ export const NumberField = (props: TField) => {
 
   const Widget = getWidget(uiAttribute?.widget ?? 'NumberWidget')
   const { config } = useRegistryContext()
+  const { control } = useFormContext()
   const readOnly = uiAttribute?.readOnly || config.readOnly
   return (
     <Controller
       name={namePath}
+      control={control}
       rules={{
         required: attribute.optional ? false : 'Required',
         pattern: {
@@ -32,7 +34,7 @@ export const NumberField = (props: TField) => {
             {...props}
             readOnly={readOnly}
             onChange={(event: unknown) => {
-              onChange(event ? Number(event) : null)
+              onChange(event !== null ? Number(event) : null)
             }}
             value={value ?? ''}
             id={namePath}

--- a/packages/dm-core-plugins/src/form/fields/NumberField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/NumberField.tsx
@@ -33,9 +33,7 @@ export const NumberField = (props: TField) => {
           <Widget
             {...props}
             readOnly={readOnly}
-            onChange={(event: unknown) => {
-              onChange(event !== null ? Number(event) : null)
-            }}
+            onChange={onChange}
             value={value ?? ''}
             id={namePath}
             label={

--- a/packages/dm-core-plugins/src/form/fields/NumberField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/NumberField.tsx
@@ -31,7 +31,9 @@ export const NumberField = (props: TField) => {
           <Widget
             {...props}
             readOnly={readOnly}
-            onChange={onChange}
+            onChange={(event: unknown) => {
+              onChange(event ? Number(event) : null)
+            }}
             value={value ?? ''}
             id={namePath}
             label={

--- a/packages/dm-core-plugins/src/form/fields/NumberField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/NumberField.tsx
@@ -31,9 +31,7 @@ export const NumberField = (props: TField) => {
           <Widget
             {...props}
             readOnly={readOnly}
-            onChange={(event: unknown) => {
-              onChange(event ? Number(event) : undefined)
-            }}
+            onChange={onChange}
             value={value ?? ''}
             id={namePath}
             label={

--- a/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ObjectField.tsx
@@ -10,7 +10,7 @@ import { ObjectModelUncontainedTemplate } from '../templates/ObjectModelUncontai
 
 export const ObjectField = (props: TField): React.ReactElement => {
   const { namePath, uiAttribute, attribute } = props
-  const { getValues } = useFormContext()
+  const { getValues, control } = useFormContext()
   const values = getValues(namePath)
   const isStorageUncontained =
     values !== undefined &&
@@ -21,6 +21,7 @@ export const ObjectField = (props: TField): React.ReactElement => {
     return (
       <Controller
         name={namePath}
+        control={control}
         rules={{
           required: attribute.optional ? false : 'Required',
         }}

--- a/packages/dm-core-plugins/src/form/fields/StringField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/StringField.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Controller } from 'react-hook-form'
+import { Controller, useFormContext } from 'react-hook-form'
 import { getWidget } from '../context/WidgetContext'
 import { TField } from '../types'
 import { useRegistryContext } from '../context/RegistryContext'
@@ -9,10 +9,12 @@ export const StringField = (props: TField) => {
   const { namePath, uiAttribute, attribute, backgroundColor } = props
   const Widget = getWidget(uiAttribute?.widget ?? 'TextWidget')
   const { config } = useRegistryContext()
+  const { control } = useFormContext()
   const readOnly = uiAttribute?.readOnly || config.readOnly
   return (
     <Controller
       name={namePath}
+      control={control}
       rules={{
         required: attribute.optional ? false : 'Required',
       }}

--- a/packages/dm-core-plugins/src/form/widgets/CheckboxWidget.tsx
+++ b/packages/dm-core-plugins/src/form/widgets/CheckboxWidget.tsx
@@ -6,13 +6,18 @@ import { TWidget } from '../types'
 const CheckboxWidget = (props: TWidget) => {
   const { value, readOnly } = props
   return (
-    <Checkbox
-      {...props}
-      disabled={readOnly}
-      checked={value !== undefined ? value : false}
-      type='checkbox'
-      data-testid='form-checkbox'
-    />
+    <div style={{ display: 'flex', alignItems: 'center' }}>
+      <Checkbox
+        {...props}
+        disabled={readOnly}
+        checked={value !== undefined ? value : false}
+        type='checkbox'
+        data-testid='form-checkbox'
+      />
+      {props.variant === 'error' && (
+        <p style={{ color: 'red' }}>*{props.helperText}</p>
+      )}
+    </div>
   )
 }
 

--- a/packages/dm-core-plugins/src/form/widgets/NumberWidget.tsx
+++ b/packages/dm-core-plugins/src/form/widgets/NumberWidget.tsx
@@ -5,7 +5,7 @@ import { StyledNumberField } from './common/StyledInputFields'
 const NumberWidget = (props: TWidget) => {
   const { onChange } = props
   const onChangeHandler = (event: React.ChangeEvent<HTMLInputElement>) =>
-    onChange?.(Number(event.target.value))
+    onChange?.(event.target.value !== '' ? Number(event.target.value) : null)
   return (
     <StyledNumberField
       {...props}


### PR DESCRIPTION
## What does this pull request change?
- avoid passing `undefined` to react-hook-form controller as this is invalid

## Why is this pull request needed?

## Issues related to this change
#1072 
