### PR TITLE
feat: entity picker upgrades

### DIFF
--- a/packages/dm-core/src/components/Pickers/EntityPickerDialog.tsx
+++ b/packages/dm-core/src/components/Pickers/EntityPickerDialog.tsx
@@ -10,7 +10,7 @@ import { toast } from 'react-toastify'
 import { ApplicationContext } from '../../context/ApplicationContext'
 import { Tree, TreeNode } from '../../domain/Tree'
 import { TValidEntity } from '../../types'
-import { TREE_DIALOG_WIDTH } from '../../utils/variables'
+import { TREE_DIALOG_HEIGHT, TREE_DIALOG_WIDTH } from '../../utils/variables'
 import { Dialog } from '../Dialog'
 import { TNodeWrapperProps, TreeView } from '../TreeView'
 import styled from 'styled-components'
@@ -165,6 +165,7 @@ export const EntityPickerDialog = (
         setShowModal(false)
       }}
       width={TREE_DIALOG_WIDTH}
+      height={TREE_DIALOG_HEIGHT}
     >
       <Dialog.Header>
         <Dialog.Title>
@@ -173,14 +174,14 @@ export const EntityPickerDialog = (
           }`}
         </Dialog.Title>
       </Dialog.Header>
-      <Dialog.CustomContent>
-        {loading ? (
-          <div style={{ display: 'flex', justifyContent: 'center' }}>
-            <Progress.Circular />
-          </div>
-        ) : (
-          <div>
-            <div style={{ height: '40vh', overflow: 'auto' }}>
+      <Dialog.CustomContent style={{ overflow: 'hidden' }}>
+        <div className='flex flex-col h-full'>
+          {loading ? (
+            <div style={{ display: 'flex', justifyContent: 'center' }}>
+              <Progress.Circular />
+            </div>
+          ) : (
+            <div className='overflow-auto h-full'>
               <TreeView
                 // If configured to hide "invalidTypes", only show the "typeFilter", along with data sources and packages to allow for browsing
                 includeTypes={
@@ -209,13 +210,13 @@ export const EntityPickerDialog = (
                 }
               />
             </div>
-          </div>
-        )}
+          )}
+          <div className='bg-[#e0dcdc] h-px inline mt-5'></div>
+        </div>
       </Dialog.CustomContent>
-      <Dialog.Actions style={{ justifyContent: 'space-around' }}>
+      <Dialog.Actions style={{ justifyContent: 'right' }}>
         <Button
           variant='outlined'
-          color='danger'
           onClick={() => {
             setSelectedNodes([])
             setShowModal(false)
@@ -239,7 +240,7 @@ export const EntityPickerDialog = (
             setShowModal(false)
           }}
         >
-          Ok
+          Select
         </Button>
       </Dialog.Actions>
     </Dialog>

--- a/packages/dm-core/src/utils/variables.tsx
+++ b/packages/dm-core/src/utils/variables.tsx
@@ -1,4 +1,4 @@
 export const PATH_INPUT_FIELD_WIDTH: string = '450px'
 export const INPUT_FIELD_WIDTH: string = '285px'
-export const TREE_DIALOG_HEIGHT: string = '50vh'
-export const TREE_DIALOG_WIDTH: string = '25vw'
+export const TREE_DIALOG_HEIGHT: string = '75vh'
+export const TREE_DIALOG_WIDTH: string = '50vw'


### PR DESCRIPTION
## What does this pull request change?

1. Entity picker dialog is now bigger
2. Entity picker buttons are right adjusted. 
3. Entity picker overflow makes more sense with a sroll, and a hline that separates buttons from content. 

<img width="1693" alt="image" src="https://github.com/equinor/dm-core-packages/assets/37016135/3a8793dc-ef24-403b-8be8-fa1eef060fa4">



## Why is this pull request needed?

## Issues related to this change

