### PR TITLE
fix: bad line break in p-tag. Missing image formats

### DIFF
--- a/packages/dm-core/src/components/MediaContent.tsx
+++ b/packages/dm-core/src/components/MediaContent.tsx
@@ -93,7 +93,7 @@ export const MediaContent = (props: MediaContentProps): ReactElement => {
           <h2 className='text-lg text-equinor-green font-medium'>
             No preview available
           </h2>
-          <p className='flex gap-1 mb-3 items-center'>
+          <p className='flex gap-1 mb-3 items-center block'>
             A preview for{' '}
             <code className='text-sm'>
               {meta.filetype.length > 0 ? meta.filetype : 'binary'}

--- a/packages/dm-core/src/utils/filetypes.ts
+++ b/packages/dm-core/src/utils/filetypes.ts
@@ -1,6 +1,12 @@
 export const imageFiletypes = [
   'gif',
   'jpeg',
+  'jpg',
+  'jfif',
+  'pjpeg',
+  'pjp',
+  'tif',
+  'tiff',
   'png',
   'apng',
   'avif',


### PR DESCRIPTION
- The paragraph was split into 3 parts, looking very weird.
- Some missing file formats (jpg!)