### PR TITLE
ci: only publish on deploy

### DIFF
--- a/.github/workflows/on-main-push.yaml
+++ b/.github/workflows/on-main-push.yaml
@@ -27,7 +27,7 @@ jobs:
 
   publish-packages:
     needs: release-please
-    if: ${{ needs.release-please.outputs.releases_created }}
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## What does this pull request change?

* they have started to use string for releases_created, see https://github.com/google-github-actions/release-please-action/issues/912
 
## Why is this pull request needed?

## Issues related to this change

