### PR TITLE
fix: cast 0 to number

### DIFF
--- a/packages/dm-core-plugins/src/form/fields/NumberField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/NumberField.tsx
@@ -32,7 +32,7 @@ export const NumberField = (props: TField) => {
             {...props}
             readOnly={readOnly}
             onChange={(event: unknown) => {
-              onChange(event ? Number(event) : undefined)
+              onChange(event !== '' ? Number(event) : null)
             }}
             value={value ?? ''}
             id={namePath}


### PR DESCRIPTION
## What does this pull request change?
Pass `null` to number field controller, instead of undefined
Make sure "0" is cast to Number instead of passing null to field controller

## Why is this pull request needed?
Bug that makes it impossible to set 0 in number field

## Issues related to this change
Closes #1072 
