### PR TITLE
fix: use form state to update entity

### DIFF
--- a/example/app/data/DemoDataSource/plugins/form/tests/blueprints/primitivearray.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/form/tests/blueprints/primitivearray.blueprint.json
@@ -1,0 +1,17 @@
+{
+  "name": "MyBlueprint",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "attributes": [
+    {
+      "name": "type",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "array",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "dimensions": "*"
+    }
+  ]
+}

--- a/example/app/data/DemoDataSource/plugins/form/tests/primitivearray.entity.json
+++ b/example/app/data/DemoDataSource/plugins/form/tests/primitivearray.entity.json
@@ -1,0 +1,4 @@
+{
+  "type": "./blueprints/MyBlueprint",
+  "array": []
+}

--- a/example/app/data/DemoDataSource/recipes/plugins/form/tests/primitivearray.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/tests/primitivearray.recipe.json
@@ -1,0 +1,22 @@
+{
+  "type": "CORE:RecipeLink",
+  "_blueprintPath_": "/plugins/form/tests/blueprints/MyBlueprint",
+  "initialUiRecipe": {
+    "name": "Edit",
+    "type": "CORE:UiRecipe",
+    "description": "Default edit",
+    "showRefreshButton": true,
+    "plugin": "@development-framework/dm-core-plugins/form",
+    "config": {
+      "type": "PLUGINS:dm-core-plugins/form/FormInput",
+      "attributes": [
+        {
+          "type": "PLUGINS:dm-core-plugins/form/fields/ArrayField",
+          "name": "array",
+          "template": "ArrayPrimitiveListTemplate"
+        }
+      ],
+      "fields": ["array"]
+    }
+  }
+}

--- a/packages/dm-core-plugins/src/form/components/PrimitiveArray.tsx
+++ b/packages/dm-core-plugins/src/form/components/PrimitiveArray.tsx
@@ -7,6 +7,7 @@ import {
   DeleteSoftButton,
   TAttribute,
 } from '@development-framework/dm-core'
+import { useFormContext } from 'react-hook-form'
 
 interface PrimitiveArrayProps {
   uiAttribute: TUiAttributeObject | undefined
@@ -35,9 +36,10 @@ const PrimitiveArray = ({
   onChange,
 }: PrimitiveArrayProps) => {
   const [hovering, setHovering] = useState<number>(-1)
+  const { getValues } = useFormContext()
 
   const updateValues = (index: number, newValue: TPrimitive): void => {
-    const newValues = [...data]
+    const newValues = getValues(namePath) || []
     switch (attribute.attributeType) {
       case 'boolean':
         newValues[index] = newValue
@@ -53,7 +55,7 @@ const PrimitiveArray = ({
     }
   }
   const removeItem = (index: number) => {
-    const newValues = [...data]
+    const newValues = getValues(namePath) || []
     newValues.splice(index, 1)
     onChange(newValues)
   }


### PR DESCRIPTION
## What does this pull request change?
Use react hook from context to manipulate form state when deleting item in primitive array

## Why is this pull request needed?
Bug where primitive array is not updated correctly when deleting while in dirty state

## Issues related to this change
Closes #1073 
