### PR TITLE
feat: name in new entity dialoig

### DIFF
--- a/e2e/tests/plugin-explorer.spec.ts
+++ b/e2e/tests/plugin-explorer.spec.ts
@@ -40,7 +40,7 @@ test('Create blueprint', async ({ page }) => {
   ).toBeVisible()
 })
 
-test('Create entity', async ({ page }) => {
+test('Create entity with name', async ({ page }) => {
   await page
     .getByRole('button', { name: 'package Playwright', exact: true })
     .click({ button: 'right' })
@@ -52,11 +52,12 @@ test('Create entity', async ({ page }) => {
   await dialog.getByRole('button', { name: 'plugins' }).click()
   await dialog.getByRole('button', { name: 'Playwright' }).click()
   await dialog.getByRole('button', { name: 'PlaywrightBlueprint' }).click()
+  await dialog.getByLabel('Name').fill('PlaywrightEntity')
   await dialog.getByRole('button', { name: 'Create' }).click()
   await expect(page.getByRole('alert')).toHaveText(['Entity is created'])
   await expect(dialog).not.toBeVisible()
   await expect(
-    page.getByRole('button', { name: 'file new_entity' })
+    page.getByRole('button', { name: 'file PlaywrightEntity' })
   ).toBeVisible()
 })
 

--- a/packages/dm-core/src/domain/Tree.ts
+++ b/packages/dm-core/src/domain/Tree.ts
@@ -252,7 +252,7 @@ export class TreeNode {
 
   // Creates a new entity in DMSS of the given type and saves it to this target,
   // returns the entity's UUID
-  async appendEntity(type: string, name: string): Promise<string> {
+  async appendEntity(type: string, name: string | undefined): Promise<string> {
     const response = await this.tree.dmssApi.instantiateEntity({
       // @ts-ignore
       entity: { name: name, type: type },


### PR DESCRIPTION
## What does this pull request change?
Adds name text input to new entity dialogue if blueprint has name attribute
<img width="495" alt="image" src="https://github.com/equinor/dm-core-packages/assets/43639886/de403ac0-da50-46c7-8f33-ed6fa661914a">
<img width="495" alt="image" src="https://github.com/equinor/dm-core-packages/assets/43639886/4dfe91eb-6f6f-404e-926a-069a14ec69e5">
<img width="558" alt="image" src="https://github.com/equinor/dm-core-packages/assets/43639886/6dfa9b64-6ea3-4c26-92c1-3bc95c334458">


- Fall back to "new_entity" as name if name field is empty when creating

## Why is this pull request needed?

## Issues related to this change
Closes #1063 