### PR TITLE
fix: zero is a valid value

### DIFF
--- a/packages/dm-core/src/components/Table/TableRow/TableCell/TableCell.tsx
+++ b/packages/dm-core/src/components/Table/TableRow/TableCell/TableCell.tsx
@@ -111,7 +111,7 @@ export function TableCell(props: TableCellProps) {
           }
         />
       ) : (
-        value || '-'
+        value
       )}
     </Styled.TableCell>
   )


### PR DESCRIPTION
## What does this pull request change?

Not show - when the element in table is zero. Instead show 0. 
<img width="639" alt="image" src="https://github.com/equinor/dm-core-packages/assets/37016135/668cd288-a40e-49ae-b243-b74225239d04">


## Why is this pull request needed?

## Issues related to this change

