### PR TITLE
fix: show number 0 values as actual 0s

### DIFF
--- a/packages/dm-core/src/components/Table/TableRow/TableCell/TableCell.tsx
+++ b/packages/dm-core/src/components/Table/TableRow/TableCell/TableCell.tsx
@@ -111,7 +111,7 @@ export function TableCell(props: TableCellProps) {
           }
         />
       ) : (
-        value || '-'
+        value || (column.dataType === 'number' ? 0 : '-')
       )}
     </Styled.TableCell>
   )

--- a/packages/dm-core/src/components/Table/types.ts
+++ b/packages/dm-core/src/components/Table/types.ts
@@ -33,7 +33,7 @@ export type TTableFunctionalityConfig = {
 
 export type TTableColumnConfig = {
   data: string
-  dataType?: 'string' | 'boolean'
+  dataType?: 'string' | 'boolean' | 'number'
   editable?: boolean
   label?: string
   presentAs?: 'checkbox' | 'text'


### PR DESCRIPTION
## What does this pull request change?
When value is 0 in tablecell show the actual zero instead of false value placeholder

## Why is this pull request needed?
0 is equivalent to false, so the check doesn't work for numbers where we want to show 0 values as actual 0s

## Issues related to this change

