### PR TITLE
fix: optional showmeta for mediaviewer

### DIFF
--- a/e2e/tests/plugin-form-Media_viewer.spec.ts
+++ b/e2e/tests/plugin-form-Media_viewer.spec.ts
@@ -10,7 +10,7 @@ test('Media viewer', async ({ page }) => {
   const dialog = page.getByRole('dialog')
 
   await test.step('video', async () => {
-    await page.getByRole('button', { name: 'video' }).click()
+    await page.getByRole('button', { name: 'mediaViewerMOV' }).click()
     await expect(page.locator('video')).toBeVisible()
     await page.getByRole('button', { name: 'view meta info' }).click()
 
@@ -26,7 +26,7 @@ test('Media viewer', async ({ page }) => {
     await download.createReadStream()
   })
   await test.step('gif', async () => {
-    await page.getByRole('button', { name: 'fast' }).click()
+    await page.getByRole('button', { name: 'mediaViewerGIF' }).click()
     await expect(page.locator('img')).toHaveJSProperty('complete', true)
     await expect(page.locator('img')).not.toHaveJSProperty('naturalWidth', 0)
     await expect(page.getByRole('img', { name: 'fast' })).toBeVisible()
@@ -44,7 +44,7 @@ test('Media viewer', async ({ page }) => {
   })
 
   await test.step('image', async () => {
-    await page.getByRole('button', { name: 'beauty' }).click()
+    await page.getByRole('button', { name: 'mediaViewerIMG' }).click()
     await expect(page.locator('img')).toHaveJSProperty('complete', true)
     await expect(page.locator('img')).not.toHaveJSProperty('naturalWidth', 0)
     await expect(page.getByRole('img', { name: 'beauty' })).toBeVisible()

--- a/example/app/data/DemoDataSource/plugins/media_viewer/mediaViewerGIF.entity.json
+++ b/example/app/data/DemoDataSource/plugins/media_viewer/mediaViewerGIF.entity.json
@@ -1,9 +1,9 @@
 {
-  "name": "mediaViewerMOV",
+  "name": "mediaViewerGIF",
   "type": "./MediaViewer",
   "file": {
     "type": "dmss://system/SIMOS/Reference",
-    "address": "./assets/video",
+    "address": "./assets/fast",
     "referenceType": "link"
   }
 }

--- a/example/app/data/DemoDataSource/plugins/media_viewer/mediaViewerIMG.entity.json
+++ b/example/app/data/DemoDataSource/plugins/media_viewer/mediaViewerIMG.entity.json
@@ -1,9 +1,9 @@
 {
-  "name": "mediaViewerMOV",
+  "name": "mediaViewerIMG",
   "type": "./MediaViewer",
   "file": {
     "type": "dmss://system/SIMOS/Reference",
-    "address": "./assets/video",
+    "address": "./assets/beauty",
     "referenceType": "link"
   }
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/mediaViewer/mediaViewer.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/mediaViewer/mediaViewer.recipe.json
@@ -16,7 +16,6 @@
         "config": {
           "type": "PLUGINS:dm-core-plugins/media_viewer/MediaViewerConfig",
           "width": 1000,
-          "height": 100,
           "showMeta": true,
           "caption": "some header",
           "description": "some description"

--- a/packages/dm-core-plugins/blueprints/media_viewer/MediaViewerConfig.json
+++ b/packages/dm-core-plugins/blueprints/media_viewer/MediaViewerConfig.json
@@ -23,7 +23,8 @@
       "name": "showMeta",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "boolean",
-      "default": true
+      "default": false,
+      "optional": true
     },
     {
       "name": "caption",

--- a/packages/dm-core/src/components/MediaContent.tsx
+++ b/packages/dm-core/src/components/MediaContent.tsx
@@ -113,18 +113,17 @@ export const MediaContent = (props: MediaContentProps): ReactElement => {
   return (
     <>
       <MediaWrapper $height={config.height} $width={config.width}>
-        {!['pdf'].includes(meta.filetype) &&
-          (config.showMeta !== undefined ? config.showMeta : true) && (
-            <MetaPopoverButton
-              onClick={() => setShowMeta(!showMeta)}
-              variant='ghost_icon'
-              aria-haspopup
-              aria-expanded={showMeta}
-              ref={referenceElement}
-            >
-              <Icon data={info_circle} title='view meta info' />
-            </MetaPopoverButton>
-          )}
+        {!['pdf'].includes(meta.filetype) && (
+          <MetaPopoverButton
+            onClick={() => setShowMeta(!showMeta)}
+            variant='ghost_icon'
+            aria-haspopup
+            aria-expanded={showMeta}
+            ref={referenceElement}
+          >
+            <Icon data={info_circle} title='view meta info' />
+          </MetaPopoverButton>
+        )}
         {renderMediaElement(meta.filetype)}
       </MediaWrapper>
       <Popover
@@ -141,22 +140,24 @@ export const MediaContent = (props: MediaContentProps): ReactElement => {
             <label className='font-bold text-sm'>Description</label>
             <p>{config.description}</p>
           </div>
-          <div className='grid grid-cols-2 font-normal text-xs'>
-            <label className='font-bold'>File name:</label>
-            <span> {meta.title}</span>
-            <label className='font-bold'>Author:</label>
-            <span> {meta.author}</span>
-            <label className='font-bold'>Filetype:</label>
-            <span> {meta.filetype}</span>
-            <label className='font-bold'>Filesize:</label>
-            <span> {formatBytes(meta.fileSize)}</span>
-            <label className='font-bold'>Upload date:</label>
-            <span>
-              {DateTime.fromISO(meta.date.replace(' ', 'T')).toFormat(
-                'dd/MM/yyyy HH:mm'
-              )}
-            </span>
-          </div>
+          {config.showMeta && (
+            <div className='grid grid-cols-2 font-normal text-xs'>
+              <label className='font-bold'>File name:</label>
+              <span> {meta.title}</span>
+              <label className='font-bold'>Author:</label>
+              <span> {meta.author}</span>
+              <label className='font-bold'>Filetype:</label>
+              <span> {meta.filetype}</span>
+              <label className='font-bold'>Filesize:</label>
+              <span> {formatBytes(meta.fileSize)}</span>
+              <label className='font-bold'>Date:</label>
+              <span>
+                {DateTime.fromISO(meta.date.replace(' ', 'T')).toFormat(
+                  'dd/MM/yyyy HH:mm'
+                )}
+              </span>
+            </div>
+          )}
         </Popover.Content>
         <Popover.Actions>
           <div className='flex justify-start w-full'>


### PR DESCRIPTION
## What does this pull request change?
Make showMeta optional and default to false

<img width="515" alt="image" src="https://github.com/equinor/dm-core-packages/assets/43639886/9db1b814-c7d9-46aa-9550-26605c4e37ce">


## Why is this pull request needed?

## Issues related to this change
Closes #1095 
