### PR TITLE
feat: can hide delete now

### DIFF
--- a/example/app/data/DemoDataSource/recipes/plugins/form/nested/carRentalCompany.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/nested/carRentalCompany.recipe.json
@@ -42,6 +42,7 @@
             "name": "trainee",
             "type": "PLUGINS:dm-core-plugins/form/fields/ObjectField",
             "uiRecipe": "defaultForm",
+            "hideDelete": true,
             "functionality": {
               "type": "PLUGINS:dm-core-plugins/form/FormFunctionalityConfig",
               "open": false,

--- a/packages/dm-core-plugins/blueprints/form/fields/ObjectField.json
+++ b/packages/dm-core-plugins/blueprints/form/fields/ObjectField.json
@@ -50,6 +50,14 @@
       "optional": true,
       "default": false,
       "attributeType": "boolean"
+    },
+    {
+      "name": "hideDelete",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "Only applicable if entity is optional. If this is true, then it hides delete button in form.",
+      "optional": true,
+      "default": false,
+      "attributeType": "boolean"
     }
   ]
 }

--- a/packages/dm-core-plugins/src/form/templates/ObjectModelContainedTemplate.tsx
+++ b/packages/dm-core-plugins/src/form/templates/ObjectModelContainedTemplate.tsx
@@ -78,13 +78,16 @@ export const ObjectModelContainedTemplate = (
               )}
             </>
           )}
-          {attribute.optional && objectIsNotEmpty && !config.readOnly && (
-            <RemoveObject
-              popupTitle={`Confirm Removal`}
-              popupMessage={`Are sure you want to remove reference to '${namePath}'`}
-              namePath={namePath}
-            />
-          )}
+          {attribute.optional &&
+            objectIsNotEmpty &&
+            !config.readOnly &&
+            !uiAttribute?.hideDelete && (
+              <RemoveObject
+                popupTitle={`Confirm Removal`}
+                popupMessage={`Are sure you want to remove reference to '${namePath}'`}
+                namePath={namePath}
+              />
+            )}
         </FormTemplate.Header.Actions>
       </FormTemplate.Header>
       {canExpand && isExpanded && (

--- a/packages/dm-core-plugins/src/form/templates/ObjectModelUncontainedTemplate.tsx
+++ b/packages/dm-core-plugins/src/form/templates/ObjectModelUncontainedTemplate.tsx
@@ -45,7 +45,6 @@ export const ObjectModelUncontainedTemplate = (
     uiAttribute,
     onOpen
   )
-  console.log(uiAttribute)
   return (
     <FormTemplate>
       <FormTemplate.Header>

--- a/packages/dm-core-plugins/src/form/types.tsx
+++ b/packages/dm-core-plugins/src/form/types.tsx
@@ -42,12 +42,7 @@ type TUiAttributeBase = {
   showInline?: boolean
   config?: Record<any, any>
   readOnly?: boolean
-  expandViewConfig?: TViewConfig
-  openViewConfig?: TViewConfig
-  functionality?: {
-    expand: boolean
-    open: boolean
-  }
+
   hideOptionalLabel?: boolean
   label?: string
 }
@@ -66,6 +61,13 @@ export type TUiAttributeObject = TUiAttributeBase & {
   uiRecipe?: string
   showExpanded?: boolean
   searchByType?: boolean
+  expandViewConfig?: TViewConfig
+  openViewConfig?: TViewConfig
+  functionality?: {
+    expand: boolean
+    open: boolean
+  }
+  hideDelete?: boolean
 }
 
 export type TPrimitive = string | number | boolean


### PR DESCRIPTION
## What does this pull request change?


1. form config "hideDelete" makes entity un-deletable even if it is optional 
2. Currently only for storage Contained

<img width="690" alt="image" src="https://github.com/equinor/dm-core-packages/assets/37016135/7da7d7ed-df38-4577-be1d-509acbc0359e">

## Why is this pull request needed?

## Issues related to this change

