### PR TITLE
fix: logs viewer scrolling

### DIFF
--- a/packages/dm-core-plugins/src/job/JobLogsDialog.tsx
+++ b/packages/dm-core-plugins/src/job/JobLogsDialog.tsx
@@ -24,7 +24,7 @@ export const JobLogsDialog = (props: AboutDialogProps) => {
       open={isOpen}
       onClose={() => setIsOpen(false)}
       width={'60vw'}
-      style={{ maxHeight: '70vh' }}
+      style={{ maxHeight: '70vh', overflow: 'hidden' }}
     >
       <Dialog.CustomContent>
         <LogBlock

--- a/packages/dm-core-plugins/src/job/LogBlock.tsx
+++ b/packages/dm-core-plugins/src/job/LogBlock.tsx
@@ -8,7 +8,7 @@ export interface LogBlockProps {
   content: any
 }
 
-const FormattedLogContainer = styled.pre`
+const FormattedLogContainer = styled.div`
   font-size: 0.8rem;
   line-height: normal;
   position: relative;
@@ -18,7 +18,8 @@ const FormattedLogContainer = styled.pre`
   padding: 1rem;
   border-radius: 0.5rem;
   color: #dcdde0;
-  overflow: auto;
+  white-space: pre-wrap; 
+  overflow-x: hidden;
 
   & .hljs-string {
     color: #a5ff90;
@@ -38,6 +39,7 @@ const LogLine = styled.pre`
   &:hover {
     background-color: #316082;
   }
+  white-space: pre-wrap; 
 `
 
 export const LogBlock = (props: LogBlockProps) => {
@@ -62,7 +64,9 @@ export const LogBlock = (props: LogBlockProps) => {
         {content.constructor === Array ? (
           content.map((line) => <LogLine key={line}>{line}</LogLine>)
         ) : (
-          <pre>{JSON.stringify(content, null, 2)}</pre>
+          <pre className='whitespace-pre-wrap'>
+            {JSON.stringify(content, null, 2)}
+          </pre>
         )}
       </FormattedLogContainer>
     </>


### PR DESCRIPTION
## What does this pull request change?

1. Removed horisontal scrolling in logs, made it wrap instead. 
2. Removed "double" vertical scroll bars. So only has for the logs now, not the entire dialog as well.

How it was before: 
https://jam.dev/c/70eddea3-ded6-4e27-b95a-7911824df8b6

How it is now: 

https://jam.dev/c/a6a9fe01-4b84-446b-a559-039252ce1340


## Why is this pull request needed?

## Issues related to this change

