### PR TITLE
fix: remove close button

### DIFF
--- a/packages/dm-core-plugins/src/job/JobLogsDialog.tsx
+++ b/packages/dm-core-plugins/src/job/JobLogsDialog.tsx
@@ -33,11 +33,6 @@ export const JobLogsDialog = (props: AboutDialogProps) => {
         />
         {result && <LogBlock title='Result' content={result} />}
       </Dialog.CustomContent>
-      <Dialog.Actions
-        style={{ display: 'flex', flexDirection: 'row', justifyContent: 'end' }}
-      >
-        <Button onClick={() => setIsOpen(false)}>Close</Button>
-      </Dialog.Actions>
     </Dialog>
   )
 }


### PR DESCRIPTION
## What does this pull request change?

removes close button from job logs dialog, since it is redundant, you simply close by clicking away

## Why is this pull request needed?

## Issues related to this change

