### PR TITLE
refactor: actually reverse data instead of using css

### DIFF
--- a/example/app/data/DemoDataSource/recipes/plugins/data_grid/default/default.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/data_grid/default/default.recipe.json
@@ -47,6 +47,46 @@
         },
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
+          "label": "Vertical (Set dimensions)",
+          "viewConfig": {
+            "type": "CORE:InlineRecipeViewConfig",
+            "recipe": {
+              "name": "Vertical  (Set dimensions)",
+              "type": "CORE:UiRecipe",
+              "plugin": "@development-framework/dm-core-plugins/data_grid",
+              "config": {
+                "type": "PLUGINS:dm-core-plugins/data_grid/DataGridPluginConfig",
+                "fieldNames": ["dimensional"],
+                "title": "Vertical (Set dimensions)",
+                "description": "Vertical printing with set dimensions",
+                "printDirection": "vertical"
+              }
+            },
+            "scope": "self"
+          }
+        },
+        {
+          "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
+          "label": "Vertical (Unknown dimensions)",
+          "viewConfig": {
+            "type": "CORE:InlineRecipeViewConfig",
+            "recipe": {
+              "name": "Vertical  (Unknown dimensions)",
+              "type": "CORE:UiRecipe",
+              "plugin": "@development-framework/dm-core-plugins/data_grid",
+              "config": {
+                "type": "PLUGINS:dm-core-plugins/data_grid/DataGridPluginConfig",
+                "fieldNames": ["data"],
+                "title": "Vertical (Unknown dimensions)",
+                "description": "Vertical printing with unknown dimensions",
+                "printDirection": "vertical"
+              }
+            },
+            "scope": "self"
+          }
+        },
+        {
+          "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
           "label": "Custom labels",
           "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",

--- a/example/app/data/DemoDataSource/recipes/plugins/data_grid/multiple_primitives/multiplePrimitives.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/data_grid/multiple_primitives/multiplePrimitives.recipe.json
@@ -40,7 +40,7 @@
               "plugin": "@development-framework/dm-core-plugins/data_grid",
               "config": {
                 "type": "PLUGINS:dm-core-plugins/data_grid/DataGridPluginConfig",
-                "rowLabels": ["Manufacturer", "Name", "Type", "VIN"],
+                "columnLabels": ["Manufacturer", "Name", "Type", "VIN"],
                 "fieldNames": ["manufacturer", "car_name", "model", "vin"],
                 "title": "Vertically printed datagrid",
                 "printDirection": "vertical"

--- a/packages/dm-core-plugins/src/data-grid/DataGrid.tsx
+++ b/packages/dm-core-plugins/src/data-grid/DataGrid.tsx
@@ -122,7 +122,7 @@ export function DataGrid(props: DataGridProps) {
         {config.description && <Typography>{config.description}</Typography>}
       </Stack>
       <EdsProvider density='compact'>
-        <Styled.DataGrid flip={config.printDirection === 'vertical'}>
+        <Styled.DataGrid>
           {config.showColumns && (
             <Styled.Head>
               <Styled.Row>
@@ -137,9 +137,7 @@ export function DataGrid(props: DataGridProps) {
                     label={column}
                     selected={selectedColumn}
                     setSelected={setSelectedColumn}
-                    type={
-                      config.printDirection === 'horizontal' ? 'column' : 'row'
-                    }
+                    type='column'
                   />
                 ))}
               </Styled.Row>
@@ -159,11 +157,7 @@ export function DataGrid(props: DataGridProps) {
                       editable={functionality.rowsAreEditable}
                       selected={selectedRow}
                       setSelected={setSelectedRow}
-                      type={
-                        config.printDirection === 'horizontal'
-                          ? 'row'
-                          : 'column'
-                      }
+                      type='row'
                     />
                   )}
                   {functionality.isMultiDimensional ? (
@@ -204,14 +198,12 @@ export function DataGrid(props: DataGridProps) {
       <Styled.ActionRow>
         <DataGridActions
           addRow={addRow}
-          addColumn={addColumn}
           columnLabels={columnLabels}
           data={data}
           deleteRow={deleteRow}
           functionality={functionality}
           moveRow={moveRow}
           name={props.name || dataGridId}
-          printDirection={config.printDirection}
           rowLabels={rowLabels}
           selectedRow={selectedRow}
         />

--- a/packages/dm-core-plugins/src/data-grid/DataGridActions/DataGridActions.tsx
+++ b/packages/dm-core-plugins/src/data-grid/DataGridActions/DataGridActions.tsx
@@ -23,28 +23,19 @@ import { TFunctionalityChecks } from '../types'
 
 type DataGridActionsProps = {
   addRow: () => void
-  addColumn: () => void
   columnLabels: string[]
   data: any[]
   deleteRow: () => void
   functionality: TFunctionalityChecks
   moveRow: (direction: 'up' | 'down') => void
   name: string
-  printDirection: 'horizontal' | 'vertical'
   rowLabels: string[]
   selectedRow: number | undefined
 }
 
 export function DataGridActions(props: DataGridActionsProps) {
-  const {
-    columnLabels,
-    data,
-    functionality,
-    moveRow,
-    printDirection,
-    rowLabels,
-    selectedRow,
-  } = props
+  const { columnLabels, data, functionality, moveRow, rowLabels, selectedRow } =
+    props
   const [includeColumnLabels, setIsIncludeColumnLabels] =
     useState<boolean>(false)
   const [includeRowLabels, setIsIncludeRowLabels] = useState<boolean>(false)
@@ -54,35 +45,20 @@ export function DataGridActions(props: DataGridActionsProps) {
   const [menuButtonAnchor, setMenuButtonAnchor] =
     useState<HTMLButtonElement | null>(null)
 
-  function reverseData(dataArray: string[][]) {
-    const reversedData: any[] = []
-    for (let index = 0; index < columnLabels.length; index++) {
-      const values = dataArray.map((item) => item[index])
-      reversedData.push(values)
-    }
-    return reversedData
-  }
-
   function mapData(separator: string) {
     let dataCopy = window.structuredClone(data)
-    if (printDirection === 'vertical') {
-      dataCopy = reverseData(dataCopy)
-    }
-    const currentColumnLabels =
-      printDirection === 'vertical' ? [...rowLabels] : [...columnLabels]
-    const currentRowLabels =
-      printDirection === 'vertical' ? [...columnLabels] : [...rowLabels]
+    const columnLabelsCopy = [...columnLabels]
     if (includeRowLabels) {
-      dataCopy.map((item, index) => item.unshift(currentRowLabels[index]))
+      dataCopy.map((item, index) => item.unshift(rowLabels[index]))
     }
     if (functionality.isMultiDimensional) {
       dataCopy = dataCopy?.map((line: any[]) => line.join(separator))
     }
     if (includeColumnLabels) {
       if (includeRowLabels) {
-        currentColumnLabels.unshift('')
+        columnLabelsCopy.unshift('')
       }
-      dataCopy.unshift(currentColumnLabels?.join(separator))
+      dataCopy.unshift(columnLabelsCopy?.join(separator))
     }
     return dataCopy.join('\n')
   }
@@ -115,11 +91,7 @@ export function DataGridActions(props: DataGridActionsProps) {
       {functionality.addButtonIsEnabled && (
         <Styled.ActionRowButton
           aria-label='Add data row'
-          onClick={() =>
-            functionality.addButtonFunctionality === 'addRow'
-              ? props.addRow()
-              : props.addColumn()
-          }
+          onClick={() => props.addRow()}
         >
           <Icon size={16} data={add} />
         </Styled.ActionRowButton>

--- a/packages/dm-core-plugins/src/data-grid/HeaderCell/HeaderCell.tsx
+++ b/packages/dm-core-plugins/src/data-grid/HeaderCell/HeaderCell.tsx
@@ -74,13 +74,13 @@ export function HeaderCell(props: HeaderCellProps) {
             <Menu.Item onClick={() => props.delete(index)}>
               <Icon size={16} data={delete_to_trash} /> Delete {type}
             </Menu.Item>
-            <Menu.Item onClick={() => add(index - 1)}>
+            <Menu.Item onClick={() => add(index)}>
               <Icon size={16} data={addIcon} /> Add 1 {type}{' '}
               {type === 'column' ? 'left' : 'above'}
             </Menu.Item>
-            <Menu.Item onClick={() => add(index)}>
+            <Menu.Item onClick={() => add(index + 1)}>
               <Icon size={16} data={addIcon} /> Add 1 {type}{' '}
-              {type === 'column' ? 'left' : 'below'}
+              {type === 'column' ? 'right' : 'below'}
             </Menu.Item>
           </>
         )}

--- a/packages/dm-core-plugins/src/data-grid/styles.ts
+++ b/packages/dm-core-plugins/src/data-grid/styles.ts
@@ -1,7 +1,7 @@
 import { tokens } from '@equinor/eds-tokens'
 import styled, { css } from 'styled-components'
 
-export const DataGrid = styled.table<{ flip?: boolean }>`
+export const DataGrid = styled.table`
   width: 100%;
   max-width: 100%;
   vertical-align: top;
@@ -19,37 +19,6 @@ export const DataGrid = styled.table<{ flip?: boolean }>`
       }
     }
   }
-
-  ${({ flip }) =>
-    flip &&
-    css`
-    display: flex;
-    overflow: hidden;
-    thead {
-      display: flex;
-      flex-shrink: 0;
-      min-width: min-content;
-      th {
-        border-bottom: 0;
-        position: relative;
-      }
-    }
-    tbody {
-      display: flex;
-      position: relative;
-      overflow-x: auto;
-      overflow-y: hidden;
-    }
-    tr {
-      display: flex;
-      flex-direction: column;
-      min-width: min-content;
-      flex-shrink: 0;
-    }
-    th, td {
-      display: block;
-    }
-  `}
 `
 
 export const Row = styled.tr`

--- a/packages/dm-core-plugins/src/data-grid/types.ts
+++ b/packages/dm-core-plugins/src/data-grid/types.ts
@@ -45,7 +45,6 @@ export type DataGridProps = {
 }
 
 export type TFunctionalityChecks = {
-  addButtonFunctionality: string
   addButtonIsEnabled: boolean
   columnDimensions: string
   columnsAreEditable: boolean

--- a/packages/dm-core-plugins/src/data-grid/utils.ts
+++ b/packages/dm-core-plugins/src/data-grid/utils.ts
@@ -60,6 +60,15 @@ export function arrayMove(arr: any[], fromIndex: number, toIndex: number) {
 export const getFillValue = (type: string) =>
   type === 'boolean' ? false : type === 'number' ? 0 : ''
 
+export function reverseData(dataArray: string[][], columnsLength: number) {
+  const reversedData: any[] = []
+  for (let index = 0; index < columnsLength; index++) {
+    const values = dataArray.map((item) => item[index])
+    reversedData.push(values)
+  }
+  return reversedData
+}
+
 export function getFunctionalityVariables(
   config: DataGridConfig,
   dimensions: string | undefined
@@ -75,8 +84,6 @@ export function getFunctionalityVariables(
   const [columnDimensions, rowDimensions] = dimensions?.split(',') || ['*', '*']
   const isMultiPrimitive = fieldNames.length > 1
   const isMultiDimensional: boolean = dimensions?.includes(',') || false
-  const addButtonFunctionality =
-    printDirection === 'horizontal' ? 'addRow' : 'addColumn'
   const isSortEnabled =
     !isMultiPrimitive &&
     config.adjustableRows &&
@@ -101,7 +108,6 @@ export function getFunctionalityVariables(
   return {
     rowsAreEditable,
     columnsAreEditable,
-    addButtonFunctionality,
     addButtonIsEnabled,
     isMultiDimensional,
     columnDimensions,


### PR DESCRIPTION
## What does this pull request change?
- Actually reverse data in plugin before passing it to DataGrid component, reverse back before saving
- columnLabels will always be columnLabels, rowLabels will always be rowLabels
- No need to reverse data before exporting data
- Added two more examples for testing printDirection in single-primitive datagrids
- Simplifies a lot of the functionality based on printDirection

## Why is this pull request needed?
- Used to flip table only using css, meaning that HTML-markup and what was viewed was different - not great for accessibility (reading direction, tabbing happened top->down, not left->right as it should)
- columnLabels and rowLabels switching places and meaning based on printDirection was confusing to user - now it's constant. We only flip the data, not the table itself. 

## Issues related to this change
#998 
