### PR TITLE
fix: ui that tooltip was placed wrong

### DIFF
--- a/packages/dm-core-plugins/src/form/templates/ArrayPrimitiveListTemplate.tsx
+++ b/packages/dm-core-plugins/src/form/templates/ArrayPrimitiveListTemplate.tsx
@@ -34,9 +34,9 @@ export const ArrayPrimitiveListTemplate = (
             objectIsNotEmpty={true}
             icon={list}
             uiAttribute={uiAttribute}
-          />
+          />{' '}
+          <FormTemplate.Header.Actions uiAttribute={uiAttribute} />
         </FormTemplate.Header>
-        <FormTemplate.Header.Actions uiAttribute={uiAttribute} />
         {isExpanded && (
           <FormTemplate.Content padding=''>
             <PrimitiveArray


### PR DESCRIPTION
## What does this pull request change?
The tooltip i was placed below the header row

Now it looks like this. 
<img width="294" alt="image" src="https://github.com/equinor/dm-core-packages/assets/37016135/f8f5c2d7-60a7-47a7-ba34-65a5adb62e3d">


## Why is this pull request needed?

## Issues related to this change

