### PR TITLE
fix: minor ui changes to icons in table

### DIFF
--- a/packages/dm-core/src/components/Table/Table.tsx
+++ b/packages/dm-core/src/components/Table/Table.tsx
@@ -49,11 +49,17 @@ export function Table(props: TableProps) {
     useState<TTableSortDirection>('ascending')
   const [isTemplateMenuOpen, setTemplateMenuIsOpen] = useState<boolean>(false)
 
-  const { currentItems, itemsPerPage, currentPage, setItemsPerPage, setPage } =
-    usePagination(
-      TableVariantNameEnum.Edit || !sortColumn ? items : sortedItems,
-      10
-    )
+  const {
+    currentItems,
+    itemsPerPage,
+    currentPage,
+    setItemsPerPage,
+    setPage,
+    setLastPage,
+  } = usePagination(
+    TableVariantNameEnum.Edit || !sortColumn ? items : sortedItems,
+    10
+  )
   const functionalityConfig =
     config.variant.length === 1
       ? config.variant[0].functionality
@@ -151,24 +157,27 @@ export function Table(props: TableProps) {
             <AddRowButton
               onClick={() => {
                 const saveOnAdd = tableVariant === TableVariantNameEnum.View
-                if (!(config.templates && config.templates.length))
+                if (!(config.templates && config.templates.length)) {
                   addItem(saveOnAdd)
-                else if (config.templates.length === 1)
+                  setLastPage()
+                } else if (config.templates.length === 1) {
                   addItem(saveOnAdd, undefined, config.templates[0].path)
-                else setTemplateMenuIsOpen(true)
+                  setLastPage()
+                } else setTemplateMenuIsOpen(true)
               }}
               ariaLabel={'Add new row'}
             />
             {config.templates?.length && (
               <TemplateMenu
                 templates={config.templates}
-                onSelect={(template: TTemplate) =>
+                onSelect={(template: TTemplate) => {
                   addItem(
                     tableVariant === TableVariantNameEnum.View,
                     undefined,
                     template?.path
                   )
-                }
+                  setLastPage()
+                }}
                 onClose={() => setTemplateMenuIsOpen(false)}
                 isOpen={isTemplateMenuOpen}
               />

--- a/packages/dm-core/src/components/Table/TableHead/TableHead.tsx
+++ b/packages/dm-core/src/components/Table/TableHead/TableHead.tsx
@@ -32,7 +32,7 @@ export function TableHead(props: TableHeadProps) {
             return tableVariant === TableVariantNameEnum.View ? (
               <Table.Cell
                 key={column.data}
-                width={column.data === '^expandable' ? '80' : '48'}
+                width={'48'}
                 aria-label={
                   column.data === '^expandable'
                     ? 'Open as expandable'

--- a/packages/dm-core/src/components/Table/TableRow/TableCell/TableCell.tsx
+++ b/packages/dm-core/src/components/Table/TableRow/TableCell/TableCell.tsx
@@ -41,7 +41,6 @@ export function TableCell(props: TableCellProps) {
               isExpanded ? 'Close expandable row' : 'Open expandable row'
             }
             variant='ghost_icon'
-            color='secondary'
             onClick={() => setIsExpanded(!isExpanded)}
           >
             <Icon data={isExpanded ? chevron_up : chevron_down} />
@@ -60,7 +59,7 @@ export function TableCell(props: TableCellProps) {
             aria-label='Open in new tab'
             onClick={openItemAsTab}
           >
-            <Icon data={external_link} aria-hidden />
+            <Icon data={external_link} aria-hidden size={18} />
           </Button>
         </Tooltip>
       </Styled.TableCell>


### PR DESCRIPTION
## What does this pull request change?

1. Jumps to last page when adding a new element. 
2. Ui Changes: 
Open icon slightly smaller. 
Chevron to the left side is now primary color (for consistency). 
Cell with chevron is not so big anymore. 

How it is now: 
<img width="506" alt="image" src="https://github.com/equinor/dm-core-packages/assets/37016135/2417c20f-5a73-473f-880e-5682f40e925e">



How is was before: 
<img width="671" alt="image" src="https://github.com/equinor/dm-core-packages/assets/37016135/c045d599-92db-4714-a66a-8243e70abfd4">


## Why is this pull request needed?

## Issues related to this change

