### PR TITLE
fix: adding tooltip

### DIFF
--- a/e2e/tests/plugin-form-dimensional_scalar.spec.ts
+++ b/e2e/tests/plugin-form-dimensional_scalar.spec.ts
@@ -70,9 +70,7 @@ test('Dimensional scalar', async ({ page }) => {
     await page.getByRole('button', { name: 'close', exact: true }).click()
     await expect(page.getByRole('alert')).not.toBeVisible()
     await page.getByRole('button', { name: 'waveForm' }).click()
-    await expect(
-      page.getByTestId('significantWaveHeight').getByRole('paragraph')
-    ).toContainText('significantWaveHeight (config)')
+    await expect(page.getByText('significantWaveHeight (config)')).toBeVisible()
     await expect(
       page.getByText('Should not show as config overrides')
     ).not.toBeVisible()
@@ -102,7 +100,7 @@ test('Dimensional scalar', async ({ page }) => {
       page.getByTestId('maximumWaveHeight').getByRole('spinbutton')
     ).toHaveValue('88888')
     await expect(
-      page.getByTestId('maximumWaveHeight').getByRole('paragraph')
+      page.getByTestId('maximumWaveHeight').getByRole('paragraph').first()
     ).toContainText('New Maximum')
     await expect(
       page.getByTestId('maximumWaveHeight').locator('span')

--- a/example/app/data/DemoDataSource/recipes/plugins/form/nested/carRentalCompany.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/nested/carRentalCompany.recipe.json
@@ -51,6 +51,11 @@
             }
           },
           {
+            "name": "name",
+            "type": "PLUGINS:dm-core-plugins/form/fields/StringField",
+            "tooltip": "This is the name of the company"
+          },
+          {
             "name": "accountant",
             "type": "PLUGINS:dm-core-plugins/form/fields/ObjectField",
             "uiRecipe": "defaultYaml",

--- a/example/app/data/DemoDataSource/recipes/plugins/form/uncontained/company.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/uncontained/company.recipe.json
@@ -73,13 +73,15 @@
             "type": "PLUGINS:dm-core-plugins/form/fields/StringField",
             "widget": "TextareaWidget",
             "hideOptionalLabel": true,
-            "readOnly": true
+            "readOnly": true,
+            "tooltip": "tooltip"
           },
           {
             "name": "averageSalary",
             "type": "PLUGINS:dm-core-plugins/form/fields/NumberField",
             "hideOptionalLabel": true,
-            "label": "Salary (avg)"
+            "label": "Salary (avg)",
+            "tooltip": "tooltip"
           }
         ],
         "fields": [

--- a/packages/dm-core-plugins/blueprints/form/fields/Field.json
+++ b/packages/dm-core-plugins/blueprints/form/fields/Field.json
@@ -1,19 +1,8 @@
 {
   "name": "Field",
   "type": "dmss://system/SIMOS/Blueprint",
+  "extends": ["CORE:NamedEntity"],
   "attributes": [
-    {
-      "name": "name",
-      "type": "dmss://system/SIMOS/BlueprintAttribute",
-      "optional": false,
-      "attributeType": "string"
-    },
-    {
-      "name": "type",
-      "type": "dmss://system/SIMOS/BlueprintAttribute",
-      "optional": false,
-      "attributeType": "string"
-    },
     {
       "name": "showInline",
       "type": "dmss://system/SIMOS/BlueprintAttribute",

--- a/packages/dm-core-plugins/src/form/components/PrimitiveArray.tsx
+++ b/packages/dm-core-plugins/src/form/components/PrimitiveArray.tsx
@@ -94,6 +94,7 @@ const PrimitiveArray = ({
                     name: '',
                     type: '',
                     ...uiAttribute,
+                    tooltip: '',
                     config: {
                       hideLabel: true,
                       ...uiAttribute?.config,

--- a/packages/dm-core-plugins/src/form/fields/NumberField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/NumberField.tsx
@@ -45,6 +45,7 @@ export const NumberField = (props: TField) => {
                 : ''
             }
             inputRef={ref}
+            tooltip={uiAttribute?.tooltip}
             helperText={error?.message || error?.type}
             variant={invalid ? 'error' : undefined}
             isDirty={value !== null ? isDirty : false}

--- a/packages/dm-core-plugins/src/form/fields/StringField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/StringField.tsx
@@ -40,6 +40,7 @@ export const StringField = (props: TField) => {
                 : ''
             }
             inputRef={ref}
+            tooltip={uiAttribute?.tooltip}
             helperText={error?.message || error?.type}
             variant={invalid ? 'error' : undefined}
             config={{

--- a/packages/dm-core-plugins/src/form/widgets/common/StyledInputFields.tsx
+++ b/packages/dm-core-plugins/src/form/widgets/common/StyledInputFields.tsx
@@ -1,5 +1,6 @@
 import { colors } from '@development-framework/dm-core'
-import { TextField } from '@equinor/eds-core-react'
+import { Icon, TextField, Tooltip } from '@equinor/eds-core-react'
+import { info_circle } from '@equinor/eds-icons'
 import React from 'react'
 import styled from 'styled-components'
 
@@ -25,6 +26,7 @@ const StyledInputField = styled(TextField)`
 const StyledEDSField = (
   props: React.ComponentProps<typeof StyledInputField> & {
     isDirty?: boolean
+    tooltip?: string
   }
 ) => {
   let background = props.config?.backgroundColor ?? colors.equinorLightGray
@@ -41,6 +43,16 @@ const StyledEDSField = (
         // @ts-ignore
         '--eds-input-background': background,
       }}
+      rightAdornments={
+        <span className='flex space-x-2'>
+          <p>{props?.unit}</p>
+          {props.tooltip && (
+            <Tooltip title={props.tooltip ?? ''}>
+              <Icon data={info_circle} size={16} />
+            </Tooltip>
+          )}
+        </span>
+      }
     ></StyledInputField>
   )
 }
@@ -48,11 +60,11 @@ const StyledEDSField = (
 export const StyledTextField = (
   props: React.ComponentProps<typeof StyledEDSField>
 ) => {
-  const { value, ...propsWithoutValue } = props
+  const { value, ...restProps } = props
 
   return (
     <StyledEDSField
-      {...propsWithoutValue}
+      {...restProps}
       defaultValue={
         props.readOnly && props.value === ''
           ? '-'


### PR DESCRIPTION
## What does this pull request change?

Adding tooltip to "Field" so that one can have tooltips on normal input fields as well. 


<img width="683" alt="image" src="https://github.com/equinor/dm-core-packages/assets/37016135/37bf630e-feea-4b77-9077-2490f6e2c6f3">
<img width="321" alt="image" src="https://github.com/equinor/dm-core-packages/assets/37016135/095354aa-697d-4dc1-ad31-bdbda941498d">


## Why is this pull request needed?

## Issues related to this change

