### PR TITLE
fix: replace temporary template resolver with common

### DIFF
--- a/packages/dm-core/src/hooks/useList/useList.tsx
+++ b/packages/dm-core/src/hooks/useList/useList.tsx
@@ -4,9 +4,9 @@ import { EBlueprint } from '../../Enums'
 import { useDMSS } from '../../context/DMSSContext'
 import { ErrorResponse } from '../../services'
 import { TAttribute, TGenericObject, TLinkReference } from '../../types'
+import { resolveRelativeAddressSimplified } from '../../utils/addressUtilities'
 import { IUseListReturnType, TItem } from './types'
 import * as utils from './utils'
-import { getTemplate } from './utils'
 
 export type { TItem }
 
@@ -101,7 +101,12 @@ export function useList<T extends object>(
       setDirtyState(true)
       let newEntity: TGenericObject
       if (template) {
-        newEntity = await getTemplate(dmssAPI, idReference, template)
+        newEntity = (
+          await dmssAPI.documentGet({
+            address: resolveRelativeAddressSimplified(template, idReference),
+            depth: 99,
+          })
+        ).data
       } else {
         const instantiateResponse = await dmssAPI.instantiateEntity({
           entity: {

--- a/packages/dm-core/src/hooks/useList/utils.ts
+++ b/packages/dm-core/src/hooks/useList/utils.ts
@@ -1,8 +1,3 @@
-import { AxiosResponse } from 'axios'
-import { DmssAPI } from '../../services'
-import { TGenericObject, TLinkReference } from '../../types'
-import { TItem } from './types'
-
 export function arrayMove(arr: any[], fromIndex: number, toIndex: number) {
   const arrayCopy = [...arr]
   const element = arrayCopy[fromIndex]
@@ -24,49 +19,4 @@ export function createNewItemObject(
     reference: null,
     isSaved,
   }
-}
-
-export function createItemsFromDocument(
-  response: AxiosResponse,
-  contained: boolean | undefined,
-  resolvedReferences: any[]
-): TItem<any>[] {
-  if (contained && !Array.isArray(response.data)) {
-    throw new Error(
-      `Not an array! Got document ${JSON.stringify(response.data)} `
-    )
-  }
-  const items = Object.values(response.data).map((data, index) => ({
-    key: crypto.randomUUID() as string,
-    index: index,
-    data: contained ? data : resolvedReferences || data,
-    reference: contained ? null : (data as TLinkReference),
-    isSaved: true,
-  }))
-  return items
-}
-
-function getParentId(idReference: string): string {
-  const lastDotIndex = idReference.lastIndexOf('.')
-  return idReference.substring(0, lastDotIndex)
-}
-
-// TODO: This is now very basic. It's expected that "template" is a direct attribute on the parent. No path/id-traversal is allowed.
-export async function getTemplate(
-  dmssAPI: DmssAPI,
-  idReference: string,
-  template: string
-): Promise<TGenericObject> {
-  const parentId = getParentId(idReference)
-
-  // This is a temporary thing to allow for "correct syntax" in recipes, without actually parsing it...
-  // The plan is to swap the meaning of "^" and "~(parent)", and allow for more complex traversing
-  if (template.substring(0, 2) === '~.') {
-    template = template.substring(2)
-  }
-  const templateEntity: AxiosResponse = await dmssAPI.documentGet({
-    address: `${parentId}.${template}`,
-    depth: 2,
-  })
-  return templateEntity.data as TGenericObject
 }


### PR DESCRIPTION
## What does this pull request change?
- replace temporary template resolver with common "relativeAddressResolver"

## Why is this pull request needed?
- The old resolver did not support all types of relative addresses