### PR TITLE
feat: support create primitive arrays based on dimensions in form

### DIFF
--- a/example/app/data/DemoDataSource/plugins/form/primitive_arrays/blueprints/PrimitiveArrays.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/form/primitive_arrays/blueprints/PrimitiveArrays.blueprint.json
@@ -1,0 +1,101 @@
+{
+  "name": "PrimitiveArrays",
+  "type": "CORE:Blueprint",
+  "attributes": [
+    {
+      "name": "type",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "requiredList",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "number",
+      "label": "Dimensions: * (required)",
+      "dimensions": "*"
+    },
+    {
+      "name": "optionalList",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "number",
+      "label": "Dimensions: * (optional)",
+      "optional": true,
+      "dimensions": "*"
+    },
+    {
+      "name": "requiredSetList",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "number",
+      "label": "Dimensions: 5 (required)",
+      "dimensions": "5"
+    },
+    {
+      "name": "optionalSetList",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "number",
+      "label": "Dimensions: 5 (optional)",
+      "dimensions": "5",
+      "optional": true
+    },
+    {
+      "name": "requiredGrid",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "number",
+      "label": "Dimensions: *,* (required)",
+      "dimensions": "*,*"
+    },
+    {
+      "name": "optionalGrid",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "number",
+      "label": "Dimensions: *,* (optional)",
+      "dimensions": "*,*",
+      "optional": true
+    },
+    {
+      "name": "requiredSetGrid",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "number",
+      "label": "Dimensions 4,5 (required)",
+      "dimensions": "4,5"
+    },
+    {
+      "name": "optionalSetGrid",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "number",
+      "label": "Dimensions 4,5 (optional)",
+      "dimensions": "4,5",
+      "optional": true
+    },
+    {
+      "name": "requiredSetColumnsGrid",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "number",
+      "label": "Dimensions 5,* (required)",
+      "dimensions": "5,*"
+    },
+    {
+      "name": "optionalSetColumnsGrid",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "number",
+      "label": "Dimensions 5,* (optional)",
+      "dimensions": "5,*",
+      "optional": true
+    },
+    {
+      "name": "requiredSetRowsGrid",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "number",
+      "label": "Dimensions *,3 (required)",
+      "dimensions": "*,3"
+    },
+    {
+      "name": "optionalSetRowsGrid",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "number",
+      "label": "Dimensions *,3 (optional)",
+      "dimensions": "*,3",
+      "optional": true
+    }
+  ]
+}

--- a/example/app/data/DemoDataSource/plugins/form/primitive_arrays/primitiveArrays.entity.json
+++ b/example/app/data/DemoDataSource/plugins/form/primitive_arrays/primitiveArrays.entity.json
@@ -1,0 +1,20 @@
+{
+  "_id": "PrimitiveArrays",
+  "type": "./blueprints/PrimitiveArrays",
+  "requiredList": [40, 20, 60],
+  "requiredSetList": [50, 40, 30, 20, 10],
+  "requiredGrid": [[30, 60, 90], [40, 20, 50]],
+  "requiredSetGrid": [
+    [10, 20, 30, 40],
+    [15, 25, 35, 45],
+    [90, 80, 70, 60],
+    [95, 85, 75, 65],
+    [15, 25, 35, 45]
+  ],
+  "requiredSetColumnsGrid": [
+    [20, 10, 30, 20, 50],
+    [30, 20, 25, 15, 10],
+    [45, 64, 90, 40, 30]
+  ],
+  "requiredSetRowsGrid": [[400, 20, 180], [200, 10, 90], [110, 50, 70]]
+}

--- a/example/app/data/DemoDataSource/recipes/plugins/form/primitive_array/PrimitiveArray.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/primitive_array/PrimitiveArray.recipe.json
@@ -1,0 +1,14 @@
+{
+  "type": "CORE:RecipeLink",
+  "_blueprintPath_": "/plugins/form/primitive_arrays/blueprints/PrimitiveArrays",
+  "initialUiRecipe": {
+    "name": "Edit",
+    "type": "CORE:UiRecipe",
+    "description": "Default edit",
+    "showRefreshButton": true,
+    "plugin": "@development-framework/dm-core-plugins/form",
+    "config": {
+      "type": "PLUGINS:dm-core-plugins/form/FormInput"
+    }
+  }
+}

--- a/packages/dm-core-plugins/src/form/fields/ArrayField.test.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ArrayField.test.tsx
@@ -39,7 +39,7 @@ describe('List of strings', () => {
     }
     mockBlueprintGet([blueprint])
     const utils = render(
-      <Form idReference="ds/$1" type="MyBlueprint" formData={data} config={{
+      <Form idReference="ds/$1" type="MyBlueprint" formData={data || { array: []}} config={{
         attributes: [
           {
             type: "dm-core-plugins/form/fields/ArrayField",

--- a/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
+++ b/packages/dm-core-plugins/src/form/fields/ArrayField.tsx
@@ -49,7 +49,7 @@ export default function ArrayField(props: TArrayTemplate) {
             <Template
               namePath={namePath}
               onChange={onChange}
-              value={value ?? []}
+              value={value}
               uiAttribute={uiAttribute}
               attribute={attribute}
             />


### PR DESCRIPTION
## What does this pull request change?
- Support creating empty primitive arrays based on dimensions in PrimitiveArray field.
- Added new form to test all use-cases for dimensions and optional/required of primitive arrays in form

## Why is this pull request needed?
Haven't added support yet for creating arrays and 2D arrays in PrimitiveArrays and empty arrays with the correct dimensions and length are needed for the DataGrid component so that user can just input values. We also restrict add and delete functionality of rows and columns based on dimensions so the dimensional arrays have to be correct on creation.

## Issues related to this change
#1147 
