### PR TITLE
Fix: tooltip placement checkbox

### DIFF
--- a/packages/dm-core-plugins/src/form/widgets/CheckboxWidget.tsx
+++ b/packages/dm-core-plugins/src/form/widgets/CheckboxWidget.tsx
@@ -4,20 +4,22 @@ import { TWidget } from '../types'
 const CheckboxWidget = (props: TWidget) => {
   const { value, readOnly, tooltip } = props
   return (
-    <Tooltip title={tooltip ?? ''}>
-      <div style={{ display: 'flex', alignItems: 'center' }}>
-        <Checkbox
-          {...props}
-          disabled={readOnly}
-          checked={value !== undefined ? value : false}
-          type='checkbox'
-          data-testid='form-checkbox'
-        />
-        {props.variant === 'error' && (
-          <p style={{ color: 'red', marginLeft: '5px' }}>*{props.helperText}</p>
-        )}
-      </div>
-    </Tooltip>
+    <div style={{ display: 'flex', alignItems: 'center' }}>
+      <Tooltip title={tooltip ?? ''}>
+        <span>
+          <Checkbox
+            {...props}
+            disabled={readOnly}
+            checked={value !== undefined ? value : false}
+            type='checkbox'
+            data-testid='form-checkbox'
+          />
+        </span>
+      </Tooltip>
+      {props.variant === 'error' && (
+        <p style={{ color: 'red', marginLeft: '5px' }}>*{props.helperText}</p>
+      )}
+    </div>
   )
 }
 


### PR DESCRIPTION
## What does this pull request change?

Earlier tooltip was to the right of the whole box. 

<img width="441" alt="image" src="https://github.com/equinor/dm-core-packages/assets/37016135/6657d1a8-a0de-4e38-8bbe-f227a4db58eb">


## Why is this pull request needed?

## Issues related to this change

