### PR TITLE
feat: json formatter sort keys once

### DIFF
--- a/_schema/blueprint.schema.json
+++ b/_schema/blueprint.schema.json
@@ -1,9 +1,6 @@
 {
   "type": "object",
   "description": "Schema for writing correct blueprints",
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Blueprint schema",
-  "additionalItems": false,
   "$defs": {
     "type": {
       "type": "string",
@@ -17,6 +14,8 @@
       ]
     }
   },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalItems": false,
   "properties": {
     "name": {
       "type": "string"
@@ -44,20 +43,21 @@
           "attributeType": {
             "type": "string"
           },
-          "optional": {
-            "type": "boolean"
+          "default": true,
+          "dimensions": {
+            "type": "string"
           },
           "label": {
             "type": "string"
           },
-          "dimensions": {
-            "type": "string"
-          },
-          "default": true
+          "optional": {
+            "type": "boolean"
+          }
         },
         "required": ["type", "attributeType"]
       }
     }
   },
-  "required": ["name", "type"]
+  "required": ["name", "type"],
+  "title": "Blueprint schema"
 }

--- a/_schema/recipe.schema.json
+++ b/_schema/recipe.schema.json
@@ -1,9 +1,6 @@
 {
   "type": "object",
   "description": "Schema for writing correct blueprints",
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Blueprint schema",
-  "additionalItems": false,
   "$defs": {
     "type": {
       "type": "string",
@@ -14,6 +11,8 @@
       "enum": ["CORE:UiRecipe", "dmss://system/SIMOS/UiRecipe"]
     }
   },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalItems": false,
   "properties": {
     "type": {
       "$ref": "#/$defs/type"
@@ -30,11 +29,11 @@
         "type": {
           "$ref": "#/$defs/uiRecipes"
         },
-        "plugin": {
-          "type": "string"
-        },
         "config": {
           "$ref": "recipeConfig.schema.json"
+        },
+        "plugin": {
+          "type": "string"
         }
       },
       "required": ["type", "plugin", "config"]
@@ -61,5 +60,6 @@
       }
     }
   },
-  "required": ["type", "_blueprintPath_"]
+  "required": ["type", "_blueprintPath_"],
+  "title": "Blueprint schema"
 }

--- a/_schema/recipeConfig.schema.json
+++ b/_schema/recipeConfig.schema.json
@@ -1,17 +1,7 @@
 {
   "type": "object",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "View Config recipe schema",
   "additionalItems": false,
-  "properties": {
-    "type": {
-      "type": "string",
-      "enum": [
-        "PLUGINS:dm-core-plugins/form/FormInput",
-        "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig"
-      ]
-    }
-  },
   "allOf": [
     {
       "if": {
@@ -48,10 +38,10 @@
       },
       "then": {
         "properties": {
-          "childTabsOnRender": {
+          "asSidebar": {
             "type": "boolean"
           },
-          "asSidebar": {
+          "childTabsOnRender": {
             "type": "boolean"
           },
           "items": {
@@ -63,6 +53,9 @@
                   "type": "string"
                 },
                 "label": {
+                  "type": "string"
+                },
+                "scope": {
                   "type": "string"
                 },
                 "viewConfig": {
@@ -89,9 +82,6 @@
                       }
                     }
                   }
-                },
-                "scope": {
-                  "type": "string"
                 }
               }
             }
@@ -100,5 +90,15 @@
         "required": ["items"]
       }
     }
-  ]
+  ],
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "PLUGINS:dm-core-plugins/form/FormInput",
+        "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig"
+      ]
+    }
+  },
+  "title": "View Config recipe schema"
 }

--- a/example/app/data/DemoDataSource/apps/EmployeeApp/blueprints/Employee.blueprint.json
+++ b/example/app/data/DemoDataSource/apps/EmployeeApp/blueprints/Employee.blueprint.json
@@ -22,8 +22,8 @@
       "name": "profilePicture",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "CORE:File",
-      "optional": true,
-      "contained": false
+      "contained": false,
+      "optional": true
     }
   ]
 }

--- a/example/app/data/DemoDataSource/apps/EmployeeApp/employeeApp.entity.json
+++ b/example/app/data/DemoDataSource/apps/EmployeeApp/employeeApp.entity.json
@@ -3,7 +3,6 @@
   "name": "employeeApp",
   "type": "./blueprints/EmployeeApp",
   "description": "This is an app for viewing employees.",
-  "label": "",
   "dataSources": ["DemoDataSource", "system", "WorkflowDS"],
   "employees": [
     {
@@ -24,5 +23,6 @@
         "referenceType": "link"
       }
     }
-  ]
+  ],
+  "label": ""
 }

--- a/example/app/data/DemoDataSource/apps/ExampleApplication/exampleApplication.entity.json
+++ b/example/app/data/DemoDataSource/apps/ExampleApplication/exampleApplication.entity.json
@@ -2,26 +2,26 @@
   "_id": "example-application-id",
   "name": "exampleApplication",
   "type": "./ExampleApplication",
-  "label": "Example Application",
   "dataSources": ["DemoDataSource", "system", "WorkflowDS"],
+  "label": "Example Application",
   "roles": [
     {
-      "type": "CORE:Role",
       "name": "dmss-admin",
-      "label": "Administrator",
-      "authServerRoleName": "dmss-admin"
+      "type": "CORE:Role",
+      "authServerRoleName": "dmss-admin",
+      "label": "Administrator"
     },
     {
-      "type": "CORE:Role",
       "name": "operator",
-      "label": "Operator",
-      "authServerRoleName": "operator"
+      "type": "CORE:Role",
+      "authServerRoleName": "operator",
+      "label": "Operator"
     },
     {
-      "type": "CORE:Role",
       "name": "developer",
-      "label": "SIMPOS Developer",
-      "authServerRoleName": "developer"
+      "type": "CORE:Role",
+      "authServerRoleName": "developer",
+      "label": "SIMPOS Developer"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/apps/MySignalApp/instances/CaseUISelector.recipe.json
+++ b/example/app/data/DemoDataSource/apps/MySignalApp/instances/CaseUISelector.recipe.json
@@ -4,7 +4,6 @@
   "initialUiRecipe": {
     "name": "UiRecipesSelector",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
     "config": {
       "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
       "items": [
@@ -27,7 +26,8 @@
           }
         }
       ]
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
   },
   "uiRecipes": [
     {
@@ -38,11 +38,11 @@
     {
       "name": "Tabs",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
       "config": {
         "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
         "childTabsOnRender": true
-      }
+      },
+      "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
     },
     {
       "name": "Edit",

--- a/example/app/data/DemoDataSource/apps/MySignalApp/instances/exampleAzureContainerRunner.entity.json
+++ b/example/app/data/DemoDataSource/apps/MySignalApp/instances/exampleAzureContainerRunner.entity.json
@@ -1,12 +1,12 @@
 {
   "name": "testContainerJobRunner",
   "type": "dmss://DemoDataSource/apps/MySignalApp/models/SignalGeneratorAzureContainerJob",
+  "environmentVariables": [],
   "image": {
     "type": "dmss://WorkflowDS/Blueprints/ContainerImage",
     "description": "",
     "imageName": "dmt-job/generate-signal",
-    "version": "latest",
-    "registryName": "datamodelingtool.azurecr.io"
-  },
-  "environmentVariables": []
+    "registryName": "datamodelingtool.azurecr.io",
+    "version": "latest"
+  }
 }

--- a/example/app/data/DemoDataSource/apps/MySignalApp/models/JobList.blueprint.json
+++ b/example/app/data/DemoDataSource/apps/MySignalApp/models/JobList.blueprint.json
@@ -15,10 +15,10 @@
     {
       "name": "jobs",
       "type": "CORE:BlueprintAttribute",
-      "label": "Jobs",
       "attributeType": "JOBCORE:Job",
-      "optional": false,
-      "dimensions": "*"
+      "dimensions": "*",
+      "label": "Jobs",
+      "optional": false
     }
   ]
 }

--- a/example/app/data/DemoDataSource/apps/MySignalApp/models/SignalApp.blueprint.json
+++ b/example/app/data/DemoDataSource/apps/MySignalApp/models/SignalApp.blueprint.json
@@ -7,15 +7,15 @@
     {
       "name": "study",
       "type": "CORE:BlueprintAttribute",
-      "label": "Study",
       "attributeType": "./signals_simple/Study",
+      "label": "Study",
       "optional": false
     },
     {
       "name": "studyNC",
       "type": "CORE:BlueprintAttribute",
-      "label": "Study NC",
       "attributeType": "./signals_simple/StudyNC",
+      "label": "Study NC",
       "optional": false
     }
   ]

--- a/example/app/data/DemoDataSource/apps/MySignalApp/models/containers/EquallySpacedSignal.blueprint.json
+++ b/example/app/data/DemoDataSource/apps/MySignalApp/models/containers/EquallySpacedSignal.blueprint.json
@@ -13,8 +13,8 @@
       "type": "CORE:BlueprintAttribute",
       "description": "variable name for named accessing",
       "attributeType": "string",
-      "default": "signal",
       "contained": true,
+      "default": "signal",
       "optional": false
     },
     {
@@ -22,8 +22,8 @@
       "type": "CORE:BlueprintAttribute",
       "description": "instance description",
       "attributeType": "string",
-      "default": "signal desc",
       "contained": true,
+      "default": "signal desc",
       "optional": true
     },
     {
@@ -31,8 +31,8 @@
       "type": "CORE:BlueprintAttribute",
       "description": "data points.",
       "attributeType": "number",
-      "dimensions": "*",
       "contained": true,
+      "dimensions": "*",
       "optional": false
     },
     {
@@ -56,8 +56,8 @@
       "type": "CORE:BlueprintAttribute",
       "description": "x-axis unit.",
       "attributeType": "string",
-      "default": "s",
       "contained": true,
+      "default": "s",
       "optional": true
     },
     {
@@ -83,8 +83,8 @@
       "type": "CORE:BlueprintAttribute",
       "description": "label for the x-axis.",
       "attributeType": "string",
-      "default": "time",
       "contained": true,
+      "default": "time",
       "optional": false
     },
     {
@@ -92,8 +92,8 @@
       "type": "CORE:BlueprintAttribute",
       "description": "label for the y-axis.",
       "attributeType": "string",
-      "default": " ",
       "contained": true,
+      "default": " ",
       "optional": false
     },
     {
@@ -101,8 +101,8 @@
       "type": "CORE:BlueprintAttribute",
       "description": "description of xy values to be used as legend.",
       "attributeType": "string",
-      "default": " ",
       "contained": true,
+      "default": " ",
       "optional": false
     },
     {
@@ -110,8 +110,8 @@
       "type": "CORE:BlueprintAttribute",
       "description": "data unit.",
       "attributeType": "string",
-      "default": "m",
       "contained": true,
+      "default": "m",
       "optional": false
     }
   ]

--- a/example/app/data/DemoDataSource/apps/MySignalApp/models/signals_simple/Study.blueprint.json
+++ b/example/app/data/DemoDataSource/apps/MySignalApp/models/signals_simple/Study.blueprint.json
@@ -11,10 +11,10 @@
     {
       "name": "cases",
       "type": "CORE:BlueprintAttribute",
-      "label": "Cases",
       "attributeType": "./Case",
+      "contained": true,
       "dimensions": "*",
-      "contained": true
+      "label": "Cases"
     },
     {
       "name": "jobTemplate",

--- a/example/app/data/DemoDataSource/apps/MySignalApp/models/signals_simple/StudyNC.blueprint.json
+++ b/example/app/data/DemoDataSource/apps/MySignalApp/models/signals_simple/StudyNC.blueprint.json
@@ -11,10 +11,10 @@
     {
       "name": "cases",
       "type": "CORE:BlueprintAttribute",
-      "label": "Cases",
       "attributeType": "./Case",
+      "contained": false,
       "dimensions": "*",
-      "contained": false
+      "label": "Cases"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/apps/MySignalApp/signalApp.entity.json
+++ b/example/app/data/DemoDataSource/apps/MySignalApp/signalApp.entity.json
@@ -3,29 +3,15 @@
   "name": "signalApp",
   "type": "AppModels:SignalApp",
   "description": "This is an app for generating and plotting sin signals.",
-  "label": "Signal App",
   "dataSources": ["AppStorage"],
+  "label": "Signal App",
   "study": {
     "type": "AppModels:signals_simple/Study",
-    "jobTemplate": {
-      "label": "signal job",
-      "name": "exampleJob",
-      "type": "JOBCORE:Job",
-      "status": "not started",
-      "triggeredBy": "me",
-      "outputTarget": ".signal",
-      "applicationInput": {},
-      "runner": {
-        "type": "dmss://DemoDataSource/apps/MySignalApp/models/SignalGeneratorJob"
-      }
-    },
     "cases": [
       {
         "name": "case1",
         "type": "AppModels:signals_simple/Case",
         "description": "",
-        "duration": 100,
-        "timeStep": 0.1,
         "components": [
           {
             "type": "AppModels:signals_simple/SinComp",
@@ -46,21 +32,35 @@
             "phase": 0.05
           }
         ],
+        "duration": 100,
         "signal": {
           "name": "signal",
           "type": "AppModels:containers/EquallySpacedSignal",
-          "value": [],
-          "xname": "time",
-          "xunit": "s",
-          "xdelta": 0.1,
-          "xstart": 0,
-          "xlabel": "Time",
           "label": " ",
           "legend": " ",
-          "unit": "m"
-        }
+          "unit": "m",
+          "value": [],
+          "xdelta": 0.1,
+          "xlabel": "Time",
+          "xname": "time",
+          "xstart": 0,
+          "xunit": "s"
+        },
+        "timeStep": 0.1
       }
-    ]
+    ],
+    "jobTemplate": {
+      "name": "exampleJob",
+      "type": "JOBCORE:Job",
+      "applicationInput": {},
+      "label": "signal job",
+      "outputTarget": ".signal",
+      "runner": {
+        "type": "dmss://DemoDataSource/apps/MySignalApp/models/SignalGeneratorJob"
+      },
+      "status": "not started",
+      "triggeredBy": "me"
+    }
   },
   "studyNC": {
     "type": "AppModels:signals_simple/StudyNC",

--- a/example/app/data/DemoDataSource/plugins/data_grid/default/default.entity.json
+++ b/example/app/data/DemoDataSource/plugins/data_grid/default/default.entity.json
@@ -1,7 +1,7 @@
 {
   "_id": "Default",
-  "type": "./blueprints/Default",
   "name": "Default",
+  "type": "./blueprints/Default",
   "data": [
     ["Dodge", "Bentley Model T", "Extended Cab Pickup", "1D3MX48D48B28FPJU"],
     ["Volvo", "Volvo Camry", "Cargo Van", "5XYZGDAG8BDE8J42H"],

--- a/example/app/data/DemoDataSource/plugins/data_grid/multiple_primitives/multiplePrimitives.entity.json
+++ b/example/app/data/DemoDataSource/plugins/data_grid/multiple_primitives/multiplePrimitives.entity.json
@@ -1,8 +1,7 @@
 {
   "_id": "MultiplePrimitives",
-  "type": "./blueprints/MultiplePrimitives",
   "name": "MultiplePrimitives",
-  "manufacturer": ["Dodge", "Volvo", "Lamborghini", "Land Rover", "Ford"],
+  "type": "./blueprints/MultiplePrimitives",
   "car_name": [
     "Bentley Model T",
     "Volvo Camry",
@@ -10,6 +9,7 @@
     "Mazda Countach",
     "Jeep Spyder"
   ],
+  "manufacturer": ["Dodge", "Volvo", "Lamborghini", "Land Rover", "Ford"],
   "model": [
     "Extended Cab Pickup",
     "Cargo Van",

--- a/example/app/data/DemoDataSource/plugins/default_recipe/TableList.entity.json
+++ b/example/app/data/DemoDataSource/plugins/default_recipe/TableList.entity.json
@@ -6,8 +6,8 @@
     {
       "name": "Volvo",
       "type": "./blueprints/Table",
-      "model": "XC40",
-      "color": "White"
+      "color": "White",
+      "model": "XC40"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/plugins/default_recipe/blueprints/Table.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/default_recipe/blueprints/Table.blueprint.json
@@ -12,20 +12,20 @@
     {
       "name": "name",
       "type": "CORE:BlueprintAttribute",
-      "label": "Manufacturer",
-      "attributeType": "string"
+      "attributeType": "string",
+      "label": "Manufacturer"
     },
     {
       "name": "model",
       "type": "CORE:BlueprintAttribute",
-      "label": "Model",
-      "attributeType": "string"
+      "attributeType": "string",
+      "label": "Model"
     },
     {
       "name": "color",
       "type": "CORE:BlueprintAttribute",
-      "label": "Color",
       "attributeType": "string",
+      "label": "Color",
       "optional": true
     }
   ]

--- a/example/app/data/DemoDataSource/plugins/default_recipe/blueprints/TableList.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/default_recipe/blueprints/TableList.blueprint.json
@@ -18,8 +18,8 @@
     {
       "name": "cars",
       "type": "CORE:BlueprintAttribute",
-      "dimensions": "*",
       "attributeType": "./Table",
+      "dimensions": "*",
       "optional": true
     }
   ]

--- a/example/app/data/DemoDataSource/plugins/default_recipe/form.entity.json
+++ b/example/app/data/DemoDataSource/plugins/default_recipe/form.entity.json
@@ -2,9 +2,9 @@
   "_id": "Form",
   "name": "Form",
   "type": "./blueprints/Form",
-  "stringRequired": "This form has no dedicated UI Recipe",
+  "date": "2023-10-17T13:30",
   "numberRequired": 2,
-  "stringOptional": "This form uses the default UI Recipe",
   "requiredCheckbox": false,
-  "date": "2023-10-17T13:30"
+  "stringOptional": "This form uses the default UI Recipe",
+  "stringRequired": "This form has no dedicated UI Recipe"
 }

--- a/example/app/data/DemoDataSource/plugins/form/dimensional_scalar/WaveForm.entity.json
+++ b/example/app/data/DemoDataSource/plugins/form/dimensional_scalar/WaveForm.entity.json
@@ -1,38 +1,38 @@
 {
   "name": "waveForm",
   "type": "./blueprints/WaveForm",
-  "significantWaveHeight": {
-    "name": "significantWaveHeight",
+  "maximumWaveHeight": {
+    "name": "maximumWaveHeight",
     "type": "./blueprints/SignificantWaveHeight",
-    "description": "Wave height above sea level null",
-    "value": 14.687,
-    "label": "Significant Hs",
-    "unit": "m"
+    "description": "Maximum wave height",
+    "label": "Maximum Hs",
+    "unit": "m",
+    "value": 7.12
   },
   "medianWaveHeight": {
     "name": "medianWaveHeight",
     "type": "./blueprints/SignificantWaveHeight",
     "description": "Median wave height",
-    "value": 7.12,
     "label": "Median Hs",
-    "unit": "m"
+    "unit": "m",
+    "value": 7.12
   },
   "minimumWaveHeight": {
     "name": "minimumWaveHeight",
     "type": "./blueprints/SignificantWaveHeight",
     "description": "Minimum",
-    "value": 32.9,
     "label": "Minimum Hs",
-    "unit": "m"
-  },
-  "maximumWaveHeight": {
-    "name": "maximumWaveHeight",
-    "type": "./blueprints/SignificantWaveHeight",
-    "description": "Maximum wave height",
-    "value": 7.12,
-    "label": "Maximum Hs",
-    "unit": "m"
+    "unit": "m",
+    "value": 32.9
   },
   "number": 10,
+  "significantWaveHeight": {
+    "name": "significantWaveHeight",
+    "type": "./blueprints/SignificantWaveHeight",
+    "description": "Wave height above sea level null",
+    "label": "Significant Hs",
+    "unit": "m",
+    "value": 14.687
+  },
   "string": "One Hundred"
 }

--- a/example/app/data/DemoDataSource/plugins/form/enums/blueprints/Enums.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/form/enums/blueprints/Enums.blueprint.json
@@ -11,18 +11,18 @@
       "name": "singleString",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "string",
-      "label": "Select a single string option",
       "enumType": "./StringOptions",
+      "label": "Select a single string option",
       "optional": true
     },
     {
       "name": "manyStrings",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "string",
-      "label": "Select one or many string options",
+      "dimensions": "*",
       "enumType": "./StringOptions",
-      "optional": true,
-      "dimensions": "*"
+      "label": "Select one or many string options",
+      "optional": true
     }
   ]
 }

--- a/example/app/data/DemoDataSource/plugins/form/enums/blueprints/StringOptions.entity.json
+++ b/example/app/data/DemoDataSource/plugins/form/enums/blueprints/StringOptions.entity.json
@@ -2,6 +2,6 @@
   "name": "StringOptions",
   "type": "CORE:Enum",
   "description": "This describes a list of options",
-  "values": ["option1", "option2", "option3"],
-  "labels": ["Option A", "Option B", "Option C"]
+  "labels": ["Option A", "Option B", "Option C"],
+  "values": ["option1", "option2", "option3"]
 }

--- a/example/app/data/DemoDataSource/plugins/form/enums/enums.entity.json
+++ b/example/app/data/DemoDataSource/plugins/form/enums/enums.entity.json
@@ -1,6 +1,6 @@
 {
   "_id": "StringEnums",
   "type": "./blueprints/Enums",
-  "singleString": "option2",
-  "manyStrings": ["option3"]
+  "manyStrings": ["option3"],
+  "singleString": "option2"
 }

--- a/example/app/data/DemoDataSource/plugins/form/hyperlinks/LinkForm.entity.json
+++ b/example/app/data/DemoDataSource/plugins/form/hyperlinks/LinkForm.entity.json
@@ -1,17 +1,17 @@
 {
+  "_id": "linkForm",
   "name": "linkForm",
   "type": "./LinkForm",
-  "_id": "linkForm",
   "stringLink1": "https://google.com",
   "stringLink2": "http://localhost:3000/view/?documentId=dmss://DemoDataSource/$linkForm",
   "urlLink1": {
     "type": "CORE:Url",
-    "value": "http://example.com",
-    "label": "Url Complex Link"
+    "label": "Url Complex Link",
+    "value": "http://example.com"
   },
   "urlLink2": {
     "type": "CORE:Url",
-    "value": "http://localhost:3000/view/?documentId=dmss://DemoDataSource/$linkForm",
-    "label": "Core:Url"
+    "label": "Core:Url",
+    "value": "http://localhost:3000/view/?documentId=dmss://DemoDataSource/$linkForm"
   }
 }

--- a/example/app/data/DemoDataSource/plugins/form/model_uncontained/complex_attribute/blueprints/Ship.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/form/model_uncontained/complex_attribute/blueprints/Ship.blueprint.json
@@ -19,8 +19,8 @@
       "name": "captain",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "./Person",
-      "label": "Captain",
-      "contained": false
+      "contained": false,
+      "label": "Captain"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/plugins/form/model_uncontained/task_list/blueprints/Task.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/form/model_uncontained/task_list/blueprints/Task.blueprint.json
@@ -31,8 +31,8 @@
       "name": "complete",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "boolean",
-      "label": "Mark task as complete",
-      "default": false
+      "default": false,
+      "label": "Mark task as complete"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/plugins/form/model_uncontained/task_list/blueprints/TaskList.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/form/model_uncontained/task_list/blueprints/TaskList.blueprint.json
@@ -16,8 +16,8 @@
       "name": "tasks",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "./Task",
-      "dimensions": "*",
-      "contained": false
+      "contained": false,
+      "dimensions": "*"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/plugins/form/nested/blueprints/CarRentalCompany.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/form/nested/blueprints/CarRentalCompany.blueprint.json
@@ -30,14 +30,14 @@
       "name": "ceo",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "./Person",
-      "label": "CEO",
-      "optional": true,
       "default": {
         "name": "Elon Musk",
         "type": "./Person",
-        "phoneNumber": 420420,
-        "age": 32
-      }
+        "age": 32,
+        "phoneNumber": 420420
+      },
+      "label": "CEO",
+      "optional": true
     },
     {
       "name": "accountant",

--- a/example/app/data/DemoDataSource/plugins/form/nested/blueprints/Customer.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/form/nested/blueprints/Customer.blueprint.json
@@ -7,8 +7,8 @@
       "name": "car",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "./Car",
-      "label": "Rented Car",
       "contained": false,
+      "label": "Rented Car",
       "optional": true
     }
   ]

--- a/example/app/data/DemoDataSource/plugins/form/nested/myCarRentalCompany.entity.json
+++ b/example/app/data/DemoDataSource/plugins/form/nested/myCarRentalCompany.entity.json
@@ -1,12 +1,6 @@
 {
   "_id": "Nested",
   "type": "./blueprints/CarRentalCompany",
-  "owner": {
-    "name": "Miranda",
-    "type": "./blueprints/Person",
-    "age": 32,
-    "phoneNumber": 1337
-  },
   "accountant": {
     "name": "John",
     "type": "./blueprints/Person",
@@ -29,25 +23,31 @@
     {
       "name": "Jane",
       "type": "./blueprints/Customer",
-      "phoneNumber": 1337,
       "age": 32,
       "car": {
         "type": "CORE:Reference",
         "address": "^.cars[1]",
         "referenceType": "link"
-      }
+      },
+      "phoneNumber": 1337
     },
     {
       "name": "Matt",
       "type": "./blueprints/Customer",
-      "phoneNumber": 1337,
       "age": 32,
       "car": {
         "type": "CORE:Reference",
         "address": "^.cars[0]",
         "referenceType": "link"
-      }
+      },
+      "phoneNumber": 1337
     }
   ],
-  "locations": ["Trondheim"]
+  "locations": ["Trondheim"],
+  "owner": {
+    "name": "Miranda",
+    "type": "./blueprints/Person",
+    "age": 32,
+    "phoneNumber": 1337
+  }
 }

--- a/example/app/data/DemoDataSource/plugins/form/read_only/blueprints/CarRentalCompany.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/form/read_only/blueprints/CarRentalCompany.blueprint.json
@@ -59,9 +59,9 @@
       "name": "isBankrupt",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "boolean",
+      "default": false,
       "label": "Bankruptcy status",
-      "optional": true,
-      "default": false
+      "optional": true
     }
   ]
 }

--- a/example/app/data/DemoDataSource/plugins/form/read_only/blueprints/Customer.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/form/read_only/blueprints/Customer.blueprint.json
@@ -7,8 +7,8 @@
       "name": "car",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "./Car",
-      "label": "Rented Car",
       "contained": false,
+      "label": "Rented Car",
       "optional": true
     }
   ]

--- a/example/app/data/DemoDataSource/plugins/form/read_only/myCarRentalCompany.entity.json
+++ b/example/app/data/DemoDataSource/plugins/form/read_only/myCarRentalCompany.entity.json
@@ -1,11 +1,6 @@
 {
   "_id": "ReadOnly",
   "type": "./blueprints/CarRentalCompany",
-  "owner": {
-    "name": "Miranda",
-    "type": "./blueprints/Person",
-    "phoneNumber": 1337
-  },
   "accountant": {
     "name": "John",
     "type": "./blueprints/Person",
@@ -27,23 +22,28 @@
     {
       "name": "Jane",
       "type": "./blueprints/Customer",
-      "phoneNumber": 1337,
       "car": {
         "type": "CORE:Reference",
         "address": "^.cars[1]",
         "referenceType": "link"
-      }
+      },
+      "phoneNumber": 1337
     },
     {
       "name": "Matt",
       "type": "./blueprints/Customer",
-      "phoneNumber": 1337,
       "car": {
         "type": "CORE:Reference",
         "address": "^.cars[0]",
         "referenceType": "link"
-      }
+      },
+      "phoneNumber": 1337
     }
   ],
-  "locations": ["Trondheim"]
+  "locations": ["Trondheim"],
+  "owner": {
+    "name": "Miranda",
+    "type": "./blueprints/Person",
+    "phoneNumber": 1337
+  }
 }

--- a/example/app/data/DemoDataSource/plugins/form/read_only_primitives/blueprints/ReadOnlyPrimitives.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/form/read_only_primitives/blueprints/ReadOnlyPrimitives.blueprint.json
@@ -65,18 +65,18 @@
       "name": "singleString",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "string",
-      "label": "Select a single string option",
       "enumType": "./StringOptions",
+      "label": "Select a single string option",
       "optional": true
     },
     {
       "name": "manyStrings",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "string",
-      "label": "Select one or many string options",
+      "dimensions": "*",
       "enumType": "./StringOptions",
-      "optional": true,
-      "dimensions": "*"
+      "label": "Select one or many string options",
+      "optional": true
     },
     {
       "name": "date",

--- a/example/app/data/DemoDataSource/plugins/form/read_only_primitives/blueprints/StringOptions.entity.json
+++ b/example/app/data/DemoDataSource/plugins/form/read_only_primitives/blueprints/StringOptions.entity.json
@@ -2,6 +2,6 @@
   "name": "StringOptions",
   "type": "CORE:Enum",
   "description": "This describes a list of options",
-  "values": ["option1", "option2", "option3"],
-  "labels": ["Option A", "Option B", "Option C"]
+  "labels": ["Option A", "Option B", "Option C"],
+  "values": ["option1", "option2", "option3"]
 }

--- a/example/app/data/DemoDataSource/plugins/form/read_only_primitives/readOnlyPrimitives.entity.json
+++ b/example/app/data/DemoDataSource/plugins/form/read_only_primitives/readOnlyPrimitives.entity.json
@@ -2,14 +2,14 @@
   "_id": "readOnlyPrimitives",
   "name": "ReadOnlyPrimitives",
   "type": "./blueprints/ReadOnlyPrimitives",
-  "stringRequired": "A required string",
-  "stringOptional": "an optional string",
-  "numberRequired": 2.34,
-  "numberOptional": 3.14,
-  "integer": 30,
   "checkboxOptional": false,
   "checkboxRequired": true,
-  "singleString": "option2",
+  "date": "2023-10-17T13:30",
+  "integer": 30,
   "manyStrings": ["option3"],
-  "date": "2023-10-17T13:30"
+  "numberOptional": 3.14,
+  "numberRequired": 2.34,
+  "singleString": "option2",
+  "stringOptional": "an optional string",
+  "stringRequired": "A required string"
 }

--- a/example/app/data/DemoDataSource/plugins/form/relative_reference/blueprints/ChildTask.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/form/relative_reference/blueprints/ChildTask.blueprint.json
@@ -1,18 +1,18 @@
 {
-  "type": "CORE:Blueprint",
   "name": "ChildTask",
+  "type": "CORE:Blueprint",
   "description": "",
   "extends": ["CORE:NamedEntity"],
   "attributes": [
     {
-      "attributeType": "./Data",
+      "name": "data",
       "type": "CORE:BlueprintAttribute",
-      "name": "data"
+      "attributeType": "./Data"
     },
     {
-      "attributeType": "./Job",
-      "type": "CORE:BlueprintAttribute",
       "name": "job",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "./Job",
       "optional": true
     }
   ]

--- a/example/app/data/DemoDataSource/plugins/form/relative_reference/blueprints/Data.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/form/relative_reference/blueprints/Data.blueprint.json
@@ -1,6 +1,6 @@
 {
-  "type": "CORE:Blueprint",
   "name": "Data",
+  "type": "CORE:Blueprint",
   "description": "",
   "attributes": [
     {

--- a/example/app/data/DemoDataSource/plugins/form/relative_reference/blueprints/Job.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/form/relative_reference/blueprints/Job.blueprint.json
@@ -1,6 +1,6 @@
 {
-  "type": "CORE:Blueprint",
   "name": "Job",
+  "type": "CORE:Blueprint",
   "description": "",
   "extends": ["dmss://system/SIMOS/NamedEntity"],
   "attributes": [
@@ -9,8 +9,8 @@
       "type": "CORE:BlueprintAttribute",
       "description": "Input",
       "attributeType": "object",
-      "label": "Input",
       "contained": false,
+      "label": "Input",
       "optional": true
     }
   ]

--- a/example/app/data/DemoDataSource/plugins/form/relative_reference/blueprints/Task.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/form/relative_reference/blueprints/Task.blueprint.json
@@ -1,32 +1,32 @@
 {
-  "type": "CORE:Blueprint",
   "name": "Task",
+  "type": "CORE:Blueprint",
   "description": "",
   "extends": ["CORE:NamedEntity"],
   "attributes": [
     {
-      "attributeType": "./Data",
+      "name": "data",
       "type": "CORE:BlueprintAttribute",
-      "name": "data"
+      "attributeType": "./Data"
     },
     {
-      "attributeType": "./Job",
-      "type": "CORE:BlueprintAttribute",
       "name": "job",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "./Job",
       "optional": true
     },
     {
-      "attributeType": "./ChildTask",
-      "type": "CORE:BlueprintAttribute",
       "name": "task",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "./ChildTask",
       "optional": true
     },
     {
-      "attributeType": "./ChildTask",
-      "type": "CORE:BlueprintAttribute",
       "name": "tasks",
-      "optional": true,
-      "dimensions": "*"
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "./ChildTask",
+      "dimensions": "*",
+      "optional": true
     }
   ]
 }

--- a/example/app/data/DemoDataSource/plugins/form/relative_reference/task.entity.json
+++ b/example/app/data/DemoDataSource/plugins/form/relative_reference/task.entity.json
@@ -1,68 +1,68 @@
 {
   "_id": "relativeReference",
-  "type": "./blueprints/Task",
   "name": "TestData",
+  "type": "./blueprints/Task",
   "data": {
     "type": "./blueprints/Data",
     "aNumber": 100
   },
   "job": {
-    "type": "./blueprints/Job",
     "name": "Job",
+    "type": "./blueprints/Job",
     "input": {
-      "address": "~.~.data",
       "type": "CORE:Reference",
+      "address": "~.~.data",
       "referenceType": "link"
     }
   },
   "task": {
-    "type": "./blueprints/ChildTask",
     "name": "ChildTask",
+    "type": "./blueprints/ChildTask",
     "data": {
       "type": "./blueprints/Data",
       "aNumber": 200
     },
     "job": {
-      "type": "./blueprints/Job",
       "name": "Sub Job",
+      "type": "./blueprints/Job",
       "input": {
-        "address": "~.~.data",
         "type": "CORE:Reference",
+        "address": "~.~.data",
         "referenceType": "link"
       }
     }
   },
   "tasks": [
     {
-      "type": "./blueprints/ChildTask",
       "name": "ChildTask local reference",
+      "type": "./blueprints/ChildTask",
       "data": {
         "type": "./blueprints/Data",
         "aNumber": 300
       },
       "job": {
-        "type": "./blueprints/Job",
         "name": "Task 1",
+        "type": "./blueprints/Job",
         "input": {
-          "address": "~.~.data",
           "type": "CORE:Reference",
+          "address": "~.~.data",
           "referenceType": "link"
         }
       }
     },
     {
-      "type": "./blueprints/ChildTask",
       "name": "ChildTask root reference",
+      "type": "./blueprints/ChildTask",
       "data": {
         "type": "./blueprints/Data",
         "aNumber": 400
       },
       "job": {
-        "type": "./blueprints/Job",
         "name": "Task 2",
+        "type": "./blueprints/Job",
         "input": {
-          "address": "~.~.~.data",
           "type": "CORE:Reference",
+          "address": "~.~.~.data",
           "referenceType": "link"
         }
       }

--- a/example/app/data/DemoDataSource/plugins/form/simple/blueprints/Simple.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/form/simple/blueprints/Simple.blueprint.json
@@ -39,44 +39,44 @@
       "name": "listOfNumbers",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "number",
-      "label": "Numbers only",
-      "dimensions": "*"
+      "dimensions": "*",
+      "label": "Numbers only"
     },
     {
       "name": "2DListOfNumbers",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "number",
+      "dimensions": "7,4",
       "label": "Numbers only",
-      "optional": true,
-      "dimensions": "7,4"
+      "optional": true
     },
     {
       "name": "listOfStrings",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "string",
-      "label": "Many Strings",
-      "dimensions": "*"
+      "dimensions": "*",
+      "label": "Many Strings"
     },
     {
       "name": "2DListOfStrings",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "string",
-      "label": "Table of strings",
-      "dimensions": "*,*"
+      "dimensions": "*,*",
+      "label": "Table of strings"
     },
     {
       "name": "listOfBooleans",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "boolean",
-      "label": "Many booleans",
-      "dimensions": "*"
+      "dimensions": "*",
+      "label": "Many booleans"
     },
     {
       "name": "2DListOfBooleans",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "boolean",
-      "label": "Table of booleans",
-      "dimensions": "*,*"
+      "dimensions": "*,*",
+      "label": "Table of booleans"
     },
     {
       "name": "integer",

--- a/example/app/data/DemoDataSource/plugins/form/simple/simple.entity.json
+++ b/example/app/data/DemoDataSource/plugins/form/simple/simple.entity.json
@@ -1,11 +1,16 @@
 {
   "_id": "Simple",
   "type": "./blueprints/Simple",
-  "stringRequired": "",
-  "numberRequired": 2,
-  "stringOptional": "a prefilled optional string",
-  "requiredCheckbox": false,
+  "2DListOfBooleans": [
+    [true, false, true, false, true, false, true, false],
+    [true, false, true, false, true, true, false]
+  ],
+  "2DListOfStrings": [
+    ["abcdefgh", "kjhnfdgkjhghgbs", "SADKHKJ"],
+    ["abcdefgh", "kjhnfdgkjhghgbs", "SADKHKJ"]
+  ],
   "date": "2023-10-17T13:30",
+  "listOfBooleans": [true, false, true, false, true, false, true, false],
   "listOfNumbers": [9, 9, 9, 9, 9, 9],
   "listOfStrings": [
     "abcdefghijklmnopqrst",
@@ -23,13 +28,8 @@
     "abcdefghijklmnopqrst",
     "abcdefghijklmnopqrst"
   ],
-  "2DListOfStrings": [
-    ["abcdefgh", "kjhnfdgkjhghgbs", "SADKHKJ"],
-    ["abcdefgh", "kjhnfdgkjhghgbs", "SADKHKJ"]
-  ],
-  "listOfBooleans": [true, false, true, false, true, false, true, false],
-  "2DListOfBooleans": [
-    [true, false, true, false, true, false, true, false],
-    [true, false, true, false, true, true, false]
-  ]
+  "numberRequired": 2,
+  "requiredCheckbox": false,
+  "stringOptional": "a prefilled optional string",
+  "stringRequired": ""
 }

--- a/example/app/data/DemoDataSource/plugins/form/storage_uncontained/simulation1.entity.json
+++ b/example/app/data/DemoDataSource/plugins/form/storage_uncontained/simulation1.entity.json
@@ -3,14 +3,14 @@
   "name": "simulation1",
   "type": "./blueprints/Simulation",
   "description": "Example simulation",
-  "result": {
-    "type": "CORE:Reference",
-    "address": "/global/result.entity.json",
-    "referenceType": "storage"
-  },
   "plot": {
     "type": "CORE:Reference",
     "address": "/global/businessman.jpg",
+    "referenceType": "storage"
+  },
+  "result": {
+    "type": "CORE:Reference",
+    "address": "/global/result.entity.json",
     "referenceType": "storage"
   }
 }

--- a/example/app/data/DemoDataSource/plugins/form/uncontained_object/blueprints/Company.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/form/uncontained_object/blueprints/Company.blueprint.json
@@ -23,8 +23,8 @@
       "name": "ceo",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "./Person",
-      "label": "CEO",
       "contained": false,
+      "label": "CEO",
       "optional": false
     },
     {
@@ -38,8 +38,8 @@
       "name": "accountant",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "./Person",
-      "label": "Accountant",
       "contained": false,
+      "label": "Accountant",
       "optional": false
     },
     {
@@ -53,16 +53,16 @@
       "name": "assistant",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "./Person",
-      "label": "Assistant",
       "contained": false,
+      "label": "Assistant",
       "optional": true
     },
     {
       "name": "trainee",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "./Person",
-      "label": "Trainee",
       "contained": false,
+      "label": "Trainee",
       "optional": true
     },
     {

--- a/example/app/data/DemoDataSource/plugins/form/uncontained_object/company.entity.json
+++ b/example/app/data/DemoDataSource/plugins/form/uncontained_object/company.entity.json
@@ -2,9 +2,18 @@
   "_id": "UncontainedObject",
   "name": "UncontainedObject",
   "type": "./blueprints/Company",
-  "numberOfEmployees": 10,
   "description": "It's a super nice place to work. The people are happy and they love to create great applications for use in the moorling line simulations.",
+  "accountant": {
+    "type": "CORE:Reference",
+    "address": "^.employees[0]",
+    "referenceType": "link"
+  },
   "averageSalary": 800000,
+  "ceo": {
+    "type": "CORE:Reference",
+    "address": "^.employees[0]",
+    "referenceType": "link"
+  },
   "employees": [
     {
       "name": "Miranda",
@@ -17,14 +26,5 @@
       "phoneNumber": 1234
     }
   ],
-  "ceo": {
-    "type": "CORE:Reference",
-    "address": "^.employees[0]",
-    "referenceType": "link"
-  },
-  "accountant": {
-    "type": "CORE:Reference",
-    "address": "^.employees[0]",
-    "referenceType": "link"
-  }
+  "numberOfEmployees": 10
 }

--- a/example/app/data/DemoDataSource/plugins/grid/car_grid/blueprints/Car.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/grid/car_grid/blueprints/Car.blueprint.json
@@ -12,26 +12,26 @@
     {
       "name": "position",
       "type": "CORE:BlueprintAttribute",
-      "label": "Position",
-      "attributeType": "number"
+      "attributeType": "number",
+      "label": "Position"
     },
     {
       "name": "name",
       "type": "CORE:BlueprintAttribute",
-      "label": "Manufacturer",
-      "attributeType": "string"
+      "attributeType": "string",
+      "label": "Manufacturer"
     },
     {
       "name": "team",
       "type": "CORE:BlueprintAttribute",
-      "label": "Team",
-      "attributeType": "string"
+      "attributeType": "string",
+      "label": "Team"
     },
     {
       "name": "lap time",
       "type": "CORE:BlueprintAttribute",
-      "label": "Lap Time",
       "attributeType": "string",
+      "label": "Lap Time",
       "optional": true
     }
   ]

--- a/example/app/data/DemoDataSource/plugins/grid/car_grid/blueprints/CarList.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/grid/car_grid/blueprints/CarList.blueprint.json
@@ -18,14 +18,14 @@
     {
       "name": "Q1",
       "type": "CORE:BlueprintAttribute",
-      "dimensions": "*",
-      "attributeType": "./Car"
+      "attributeType": "./Car",
+      "dimensions": "*"
     },
     {
       "name": "Q2",
       "type": "CORE:BlueprintAttribute",
-      "dimensions": "*",
-      "attributeType": "./Car"
+      "attributeType": "./Car",
+      "dimensions": "*"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/plugins/grid/car_grid/raceCenter.entity.json
+++ b/example/app/data/DemoDataSource/plugins/grid/car_grid/raceCenter.entity.json
@@ -9,37 +9,37 @@
       {
         "name": "Lando Norris",
         "type": "./blueprints/Car",
+        "lap time": "1:29.03",
         "position": 1,
-        "team": "McLaren",
-        "lap time": "1:29.03"
+        "team": "McLaren"
       },
       {
         "name": "Kevin Magnussen",
         "type": "./blueprints/Car",
+        "lap time": "+ 0.103",
         "position": 2,
-        "team": "Haas",
-        "lap time": "+ 0.103"
+        "team": "Haas"
       }
     ],
     "Q2": [
       {
         "name": "Alexander Albon",
         "type": "./blueprints/Car",
+        "lap time": "1:30.231",
         "position": 1,
-        "team": "Williams",
-        "lap time": "1:30.231"
+        "team": "Williams"
       }
     ]
+  },
+  "nestedForm": {
+    "type": "./blueprints/Nested",
+    "bar": "hello",
+    "baz": "testing",
+    "foo": 1337
   },
   "tyreList": {
     "type": "CORE:Reference",
     "address": "dmss://DemoDataSource/$gridTyreList",
     "referenceType": "link"
-  },
-  "nestedForm": {
-    "type": "./blueprints/Nested",
-    "foo": 1337,
-    "bar": "hello",
-    "baz": "testing"
   }
 }

--- a/example/app/data/DemoDataSource/plugins/grid/example/dashboardExample.entity.json
+++ b/example/app/data/DemoDataSource/plugins/grid/example/dashboardExample.entity.json
@@ -2,31 +2,31 @@
   "_id": "dashboardExample",
   "name": "DashboardExample",
   "type": "./blueprints/Dashboard",
+  "aNestedObjectWithCustomUI": {
+    "type": "./blueprints/Nested",
+    "bar": "hello",
+    "baz": "testing",
+    "foo": 1337
+  },
+  "order": {
+    "type": "./blueprints/OrderItem",
+    "product": {
+      "name": "Product 1",
+      "type": "./blueprints/Product",
+      "something": "Asdf"
+    },
+    "quantity": 1
+  },
   "orders": [
     {
       "type": "./blueprints/OrderItem",
-      "quantity": 1,
       "product": {
         "_id": "product1",
         "name": "Product 1",
         "type": "./blueprints/Product",
         "something": "Asdf"
-      }
+      },
+      "quantity": 1
     }
-  ],
-  "order": {
-    "type": "./blueprints/OrderItem",
-    "quantity": 1,
-    "product": {
-      "name": "Product 1",
-      "type": "./blueprints/Product",
-      "something": "Asdf"
-    }
-  },
-  "aNestedObjectWithCustomUI": {
-    "type": "./blueprints/Nested",
-    "foo": 1337,
-    "bar": "hello",
-    "baz": "testing"
-  }
+  ]
 }

--- a/example/app/data/DemoDataSource/plugins/header/example_app/exampleApp.entity.json
+++ b/example/app/data/DemoDataSource/plugins/header/example_app/exampleApp.entity.json
@@ -3,8 +3,8 @@
   "name": "example",
   "type": "./blueprints/ExampleApplication",
   "description": "Application used to test and demo some '@development-framework' plugins",
+  "adminRole": "dmss-admin",
   "dataSources": ["system", "DemoDataSource"],
   "label": "Data Modelling Example App",
-  "adminRole": "dmss-admin",
   "roles": ["user", "expert-user", "domain-expert"]
 }

--- a/example/app/data/DemoDataSource/plugins/header/roles_header_example/person.entity.json
+++ b/example/app/data/DemoDataSource/plugins/header/roles_header_example/person.entity.json
@@ -1,8 +1,8 @@
 {
   "name": "elonMusk",
   "type": "./blueprints/Person",
-  "socialSecurityNumber": 420420420,
   "address": "Silicon Valley",
   "email": "elon@xcorp.com",
+  "socialSecurityNumber": 420420420,
   "twitterHandle": "@elon"
 }

--- a/example/app/data/DemoDataSource/plugins/job/JobContainer.json
+++ b/example/app/data/DemoDataSource/plugins/job/JobContainer.json
@@ -14,8 +14,8 @@
       "name": "_templates_",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "JOBCORE:Job",
-      "dimensions": "*",
-      "contained": true
+      "contained": true,
+      "dimensions": "*"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/plugins/job/helloWorldLocalContainerRunner.json
+++ b/example/app/data/DemoDataSource/plugins/job/helloWorldLocalContainerRunner.json
@@ -1,14 +1,14 @@
 {
   "name": "helloWorldLocalContainerRunner",
   "type": "JOBCORE:LocalContainer",
-  "label": "Hello world",
+  "environmentVariables": [],
   "image": {
     "type": "JOBCORE:ContainerImage",
     "description": "Hello world test container",
     "imageName": "hello-world",
-    "version": "latest",
-    "registryName": "library"
+    "registryName": "library",
+    "version": "latest"
   },
-  "network": "example_default",
-  "environmentVariables": []
+  "label": "Hello world",
+  "network": "example_default"
 }

--- a/example/app/data/DemoDataSource/plugins/job/jobContainer.entity.json
+++ b/example/app/data/DemoDataSource/plugins/job/jobContainer.entity.json
@@ -1,37 +1,37 @@
 {
   "name": "jobContainer",
-  "description": "some description",
   "type": "./JobContainer",
+  "description": "some description",
   "_templates_": [
     {
-      "label": "Example job",
       "name": "exampleJob",
       "type": "JOBCORE:Job",
-      "status": "not started",
-      "triggeredBy": "me",
       "applicationInput": {
-        "address": "/$5203cc68-4b9f-40a9-bd4c-a48c35815e06",
         "type": "CORE:Reference",
+        "address": "/$5203cc68-4b9f-40a9-bd4c-a48c35815e06",
         "referenceType": "link"
       },
+      "label": "Example job",
       "runner": {
         "type": "JOBCORE:ReverseDescription"
-      }
+      },
+      "status": "not started",
+      "triggeredBy": "me"
     },
     {
-      "label": "Example job2",
       "name": "exampleJob2",
       "type": "JOBCORE:Job",
-      "status": "not started",
-      "triggeredBy": "me",
       "applicationInput": {
-        "address": "/$5203cc68-4b9f-40a9-bd4c-a48c35815e06",
         "type": "CORE:Reference",
+        "address": "/$5203cc68-4b9f-40a9-bd4c-a48c35815e06",
         "referenceType": "link"
       },
+      "label": "Example job2",
       "runner": {
         "type": "JOBCORE:ReverseDescription"
-      }
+      },
+      "status": "not started",
+      "triggeredBy": "me"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/plugins/job/jobInput.json
+++ b/example/app/data/DemoDataSource/plugins/job/jobInput.json
@@ -1,6 +1,6 @@
 {
   "_id": "5203cc68-4b9f-40a9-bd4c-a48c35815e06",
   "name": "exampleJobInput",
-  "description": "sdrawkcaBsIsihT",
-  "type": "CORE:NamedEntity"
+  "type": "CORE:NamedEntity",
+  "description": "sdrawkcaBsIsihT"
 }

--- a/example/app/data/DemoDataSource/plugins/job/reverseJob.json
+++ b/example/app/data/DemoDataSource/plugins/job/reverseJob.json
@@ -1,14 +1,16 @@
 {
   "_id": "6303cc68-4b9f-40a9-bd4c-a48c35815e06",
-  "label": "Example job",
   "name": "exampleJob",
   "type": "JOBCORE:Job",
-  "status": "not started",
-  "triggeredBy": "me",
   "applicationInput": {
-    "address": "dmss://DemoDataSource/$5203cc68-4b9f-40a9-bd4c-a48c35815e06",
     "type": "CORE:Reference",
+    "address": "dmss://DemoDataSource/$5203cc68-4b9f-40a9-bd4c-a48c35815e06",
     "referenceType": "link"
   },
-  "runner": { "type": "JOBCORE:ReverseDescription" }
+  "label": "Example job",
+  "runner": {
+    "type": "JOBCORE:ReverseDescription"
+  },
+  "status": "not started",
+  "triggeredBy": "me"
 }

--- a/example/app/data/DemoDataSource/plugins/list/order_example/orderExample.entity.json
+++ b/example/app/data/DemoDataSource/plugins/list/order_example/orderExample.entity.json
@@ -4,30 +4,30 @@
   "items": [
     {
       "type": "./blueprints/OrderItem",
-      "quantity": 1,
       "product": {
         "name": "Product 1",
         "type": "./blueprints/Product",
         "something": "Asdf"
-      }
+      },
+      "quantity": 1
     },
     {
       "type": "./blueprints/OrderItem",
-      "quantity": 2,
       "product": {
         "name": "Product ABV",
         "type": "./blueprints/Product",
         "something": "222222222222"
-      }
+      },
+      "quantity": 2
     },
     {
       "type": "./blueprints/OrderItem",
-      "quantity": 3,
       "product": {
         "name": "Product 3333333333",
         "type": "./blueprints/Product",
         "something": "333333333333"
-      }
+      },
+      "quantity": 3
     }
   ]
 }

--- a/example/app/data/DemoDataSource/plugins/list/task_list/blueprints/Task.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/list/task_list/blueprints/Task.blueprint.json
@@ -31,8 +31,8 @@
       "name": "complete",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "boolean",
-      "label": "Mark task as complete",
       "default": false,
+      "label": "Mark task as complete",
       "optional": true
     }
   ]

--- a/example/app/data/DemoDataSource/plugins/list/task_list/blueprints/TaskList.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/list/task_list/blueprints/TaskList.blueprint.json
@@ -16,8 +16,8 @@
       "name": "task_list",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "./Task",
-      "dimensions": "*",
-      "contained": true
+      "contained": true,
+      "dimensions": "*"
     },
     {
       "name": "_template_",

--- a/example/app/data/DemoDataSource/plugins/list/task_list/blueprints/UncontainedTaskList.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/list/task_list/blueprints/UncontainedTaskList.blueprint.json
@@ -16,8 +16,8 @@
       "name": "task_list",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "./Task",
-      "dimensions": "*",
-      "contained": false
+      "contained": false,
+      "dimensions": "*"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/plugins/list/templates/blueprints/Task.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/list/templates/blueprints/Task.blueprint.json
@@ -31,8 +31,8 @@
       "name": "complete",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "boolean",
-      "label": "Mark task as complete",
       "default": false,
+      "label": "Mark task as complete",
       "optional": true
     }
   ]

--- a/example/app/data/DemoDataSource/plugins/list/templates/blueprints/TaskList.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/list/templates/blueprints/TaskList.blueprint.json
@@ -16,8 +16,8 @@
       "name": "task_list",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "./Task",
-      "dimensions": "*",
-      "contained": true
+      "contained": true,
+      "dimensions": "*"
     },
     {
       "name": "_templates_",

--- a/example/app/data/DemoDataSource/plugins/list/templates/blueprints/UncontainedTaskList.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/list/templates/blueprints/UncontainedTaskList.blueprint.json
@@ -16,8 +16,8 @@
       "name": "task_list",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "./Task",
-      "dimensions": "*",
-      "contained": false
+      "contained": false,
+      "dimensions": "*"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/plugins/package.json
+++ b/example/app/data/DemoDataSource/plugins/package.json
@@ -20,7 +20,7 @@
         "version": "0.0.1",
         "protocol": "dmss"
       },
-            {
+      {
         "type": "CORE:Dependency",
         "alias": "JOBCORE",
         "address": "WorkflowDS/Blueprints",

--- a/example/app/data/DemoDataSource/plugins/table/car_list/blueprints/Car.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/table/car_list/blueprints/Car.blueprint.json
@@ -12,27 +12,27 @@
     {
       "name": "name",
       "type": "CORE:BlueprintAttribute",
-      "label": "Manufacturer",
-      "attributeType": "string"
+      "attributeType": "string",
+      "label": "Manufacturer"
     },
     {
       "name": "model",
       "type": "CORE:BlueprintAttribute",
-      "label": "Model",
-      "attributeType": "string"
+      "attributeType": "string",
+      "label": "Model"
     },
     {
       "name": "color",
       "type": "CORE:BlueprintAttribute",
-      "label": "Color",
       "attributeType": "string",
+      "label": "Color",
       "optional": true
     },
     {
       "name": "engine",
       "type": "CORE:BlueprintAttribute",
-      "label": "Engine",
       "attributeType": "./Engine",
+      "label": "Engine",
       "optional": true
     }
   ]

--- a/example/app/data/DemoDataSource/plugins/table/car_list/blueprints/CarList.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/table/car_list/blueprints/CarList.blueprint.json
@@ -18,8 +18,8 @@
     {
       "name": "cars",
       "type": "CORE:BlueprintAttribute",
-      "dimensions": "*",
-      "attributeType": "./Car"
+      "attributeType": "./Car",
+      "dimensions": "*"
     },
     {
       "name": "_templates_",

--- a/example/app/data/DemoDataSource/plugins/table/car_list/blueprints/Engine.json
+++ b/example/app/data/DemoDataSource/plugins/table/car_list/blueprints/Engine.json
@@ -12,8 +12,8 @@
     {
       "name": "name",
       "type": "CORE:BlueprintAttribute",
-      "label": "Manufacturer",
-      "attributeType": "string"
+      "attributeType": "string",
+      "label": "Manufacturer"
     },
     {
       "name": "hp",

--- a/example/app/data/DemoDataSource/plugins/table/car_list/carList.entity.json
+++ b/example/app/data/DemoDataSource/plugins/table/car_list/carList.entity.json
@@ -1,53 +1,53 @@
 {
-  "type": "./blueprints/CarList",
   "_id": "carList",
   "name": "CarList",
+  "type": "./blueprints/CarList",
   "_templates_": [
     {
       "name": "Audi",
       "type": "./blueprints/Car",
-      "model": "A2",
       "color": "Black",
       "engine": {
-        "type": "./blueprints/Engine",
         "name": "TDI 1.6",
+        "type": "./blueprints/Engine",
         "hp": 120
-      }
+      },
+      "model": "A2"
     },
     {
       "name": "BMW",
       "type": "./blueprints/Car",
-      "model": "X1",
       "color": "Blue",
       "engine": {
-        "type": "./blueprints/Engine",
         "name": "TDI 1.8",
+        "type": "./blueprints/Engine",
         "hp": 122
-      }
+      },
+      "model": "X1"
     },
     {
       "name": "Chevrolet",
       "type": "./blueprints/Car",
-      "model": "Corvette",
       "color": "Cyan",
       "engine": {
-        "type": "./blueprints/Engine",
         "name": "TDI 2.0",
+        "type": "./blueprints/Engine",
         "hp": 123
-      }
+      },
+      "model": "Corvette"
     }
   ],
   "cars": [
     {
       "name": "Volvo",
       "type": "./blueprints/Car",
-      "model": "XC40",
       "color": "White",
       "engine": {
-        "type": "./blueprints/Engine",
         "name": "V60",
+        "type": "./blueprints/Engine",
         "hp": 1000
-      }
+      },
+      "model": "XC40"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/plugins/table/dm_plugins/blueprints/Plugin.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/table/dm_plugins/blueprints/Plugin.blueprint.json
@@ -12,14 +12,14 @@
     {
       "name": "name",
       "type": "CORE:BlueprintAttribute",
-      "label": "Name of plugin",
-      "attributeType": "string"
+      "attributeType": "string",
+      "label": "Name of plugin"
     },
     {
       "name": "path",
       "type": "CORE:BlueprintAttribute",
-      "label": "Plugin path",
       "attributeType": "string",
+      "label": "Plugin path",
       "optional": true
     },
     {

--- a/example/app/data/DemoDataSource/plugins/table/dm_plugins/blueprints/PluginsList.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/table/dm_plugins/blueprints/PluginsList.blueprint.json
@@ -18,8 +18,8 @@
     {
       "name": "plugins",
       "type": "CORE:BlueprintAttribute",
-      "dimensions": "*",
-      "attributeType": "./Plugin"
+      "attributeType": "./Plugin",
+      "dimensions": "*"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/plugins/table/dm_plugins/pluginsList.entity.json
+++ b/example/app/data/DemoDataSource/plugins/table/dm_plugins/pluginsList.entity.json
@@ -6,26 +6,26 @@
     {
       "name": "Table",
       "type": "./blueprints/Plugin",
-      "path": "@development-framework/dm-core-plugins/table",
       "developed": true,
       "documented": false,
-      "importance": 5
+      "importance": 5,
+      "path": "@development-framework/dm-core-plugins/table"
     },
     {
       "name": "Form",
       "type": "./blueprints/Plugin",
-      "path": "@development-framework/dm-core-plugins/form",
       "developed": true,
       "documented": false,
-      "importance": 5
+      "importance": 5,
+      "path": "@development-framework/dm-core-plugins/form"
     },
     {
       "name": "List",
       "type": "./blueprints/Plugin",
-      "path": "@development-framework/dm-core-plugins/list",
       "developed": false,
       "documented": false,
-      "importance": 3
+      "importance": 3,
+      "path": "@development-framework/dm-core-plugins/list"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/plugins/view_selector/car_garage/blueprints/Car.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/view_selector/car_garage/blueprints/Car.blueprint.json
@@ -14,16 +14,16 @@
       "name": "Owner",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "./OwnerBlueprint",
-      "label": "View owner details and history",
       "contained": true,
+      "label": "View owner details and history",
       "optional": false
     },
     {
       "name": "Technical",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "./TechBlueprint",
-      "label": "View technical information",
       "contained": true,
+      "label": "View technical information",
       "optional": false
     }
   ]

--- a/example/app/data/DemoDataSource/plugins/view_selector/car_garage/carGarage.entity.json
+++ b/example/app/data/DemoDataSource/plugins/view_selector/car_garage/carGarage.entity.json
@@ -6,7 +6,6 @@
   "Audi": {
     "name": "Audi",
     "type": "./blueprints/CarBlueprint",
-    "model": "2023",
     "Owner": {
       "name": "Aiden",
       "type": "./blueprints/OwnerBlueprint",
@@ -16,16 +15,16 @@
       "name": "Technical",
       "type": "./blueprints/TechBlueprint",
       "controlDate": "2023-06-01",
-      "nextControl": "2025-06-01",
-      "width": 1800,
+      "heigth": 1600,
       "length": 4500,
-      "heigth": 1600
-    }
+      "nextControl": "2025-06-01",
+      "width": 1800
+    },
+    "model": "2023"
   },
   "Volvo": {
     "name": "Volvo",
     "type": "./blueprints/CarBlueprint",
-    "model": "2023",
     "Owner": {
       "name": "Devon",
       "type": "./blueprints/OwnerBlueprint",
@@ -36,10 +35,11 @@
       "name": "Technical",
       "type": "./blueprints/TechBlueprint",
       "controlDate": "2023-06-01",
-      "nextControl": "2025-06-01",
-      "width": 1800,
+      "heigth": 1600,
       "length": 4500,
-      "heigth": 1600
-    }
+      "nextControl": "2025-06-01",
+      "width": 1800
+    },
+    "model": "2023"
   }
 }

--- a/example/app/data/DemoDataSource/plugins/view_selector/roles_school_example/school.entity.json
+++ b/example/app/data/DemoDataSource/plugins/view_selector/roles_school_example/school.entity.json
@@ -30,6 +30,35 @@
       }
     ],
     "subjects": ["Defence against the Dark Arts", "Charms", "Herbology"],
+    "teacherSalaries": [
+      {
+        "type": "./blueprints/Salary",
+        "salary": 12345,
+        "teacher": {
+          "type": "CORE:Reference",
+          "address": "^.school.teachers[0]",
+          "referenceType": "link"
+        }
+      },
+      {
+        "type": "./blueprints/Salary",
+        "salary": 542,
+        "teacher": {
+          "type": "CORE:Reference",
+          "address": "^.school.teachers[1]",
+          "referenceType": "link"
+        }
+      },
+      {
+        "type": "./blueprints/Salary",
+        "salary": 99999,
+        "teacher": {
+          "type": "CORE:Reference",
+          "address": "^.school.teachers[2]",
+          "referenceType": "link"
+        }
+      }
+    ],
     "teachers": [
       {
         "name": "Severus Snape",
@@ -45,35 +74,6 @@
         "name": "Minerva McGonagall",
         "type": "./blueprints/Person",
         "age": 140
-      }
-    ],
-    "teacherSalaries": [
-      {
-        "type": "./blueprints/Salary",
-        "teacher": {
-          "type": "CORE:Reference",
-          "address": "^.school.teachers[0]",
-          "referenceType": "link"
-        },
-        "salary": 12345
-      },
-      {
-        "type": "./blueprints/Salary",
-        "teacher": {
-          "type": "CORE:Reference",
-          "address": "^.school.teachers[1]",
-          "referenceType": "link"
-        },
-        "salary": 542
-      },
-      {
-        "type": "./blueprints/Salary",
-        "teacher": {
-          "type": "CORE:Reference",
-          "address": "^.school.teachers[2]",
-          "referenceType": "link"
-        },
-        "salary": 99999
       }
     ]
   }

--- a/example/app/data/DemoDataSource/recipes/apps/EmployeeApp/employee.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/apps/EmployeeApp/employee.recipe.json
@@ -5,7 +5,6 @@
     "name": "Edit",
     "type": "CORE:UiRecipe",
     "description": "Default edit",
-    "plugin": "@development-framework/dm-core-plugins/form",
     "config": {
       "type": "PLUGINS:dm-core-plugins/form/FormInput",
       "attributes": [
@@ -15,26 +14,27 @@
           "widget": "TextareaWidget"
         }
       ]
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/form"
   },
   "uiRecipes": [
     {
       "name": "List",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/list",
-      "dimensions": "*",
       "config": {
         "type": "PLUGINS:dm-core-plugins/list/ListPluginConfig",
-        "headers": ["name", "description"],
         "functionality": {
           "type": "PLUGINS:dm-core-plugins/list/FunctionalityConfig",
           "delete": true,
           "expand": true,
           "open": true
         },
-        "labelByIndex": true,
-        "label": "Employee number"
-      }
+        "headers": ["name", "description"],
+        "label": "Employee number",
+        "labelByIndex": true
+      },
+      "dimensions": "*",
+      "plugin": "@development-framework/dm-core-plugins/list"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/recipes/apps/EmployeeApp/employeeApp.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/apps/EmployeeApp/employeeApp.recipe.json
@@ -4,7 +4,6 @@
   "initialUiRecipe": {
     "name": "UiRecipesSelector",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
     "config": {
       "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
       "items": [
@@ -18,6 +17,7 @@
           }
         }
       ]
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
   }
 }

--- a/example/app/data/DemoDataSource/recipes/apps/ExampleApplication/ExampleApplication.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/apps/ExampleApplication/ExampleApplication.recipe.json
@@ -4,13 +4,13 @@
   "initialUiRecipe": {
     "name": "Header",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/header",
     "config": {
       "type": "PLUGINS:dm-core-plugins/header/HeaderPluginConfig",
-      "uiRecipesList": ["Explorer", "Yaml"],
       "hideAbout": false,
-      "hideUserInfo": false
-    }
+      "hideUserInfo": false,
+      "uiRecipesList": ["Explorer", "Yaml"]
+    },
+    "plugin": "@development-framework/dm-core-plugins/header"
   },
   "uiRecipes": [
     {

--- a/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/appDefault.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/appDefault.recipe.json
@@ -4,11 +4,11 @@
   "initialUiRecipe": {
     "name": "Tabs",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
     "config": {
       "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
       "childTabsOnRender": true
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
   },
   "uiRecipes": [
     {

--- a/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/containers/equallySpacedSignal.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/containers/equallySpacedSignal.recipe.json
@@ -4,7 +4,6 @@
   "initialUiRecipe": {
     "name": "UiRecipesSelector",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
     "config": {
       "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
       "items": [
@@ -27,7 +26,8 @@
           }
         }
       ]
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
   },
   "uiRecipes": [
     {

--- a/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/signalApp.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/signalApp.recipe.json
@@ -4,13 +4,13 @@
   "initialUiRecipe": {
     "name": "Header",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/header",
     "config": {
       "type": "PLUGINS:dm-core-plugins/header/HeaderPluginConfig",
-      "uiRecipesList": ["View study", "Explorer", "Yaml"],
       "hideAbout": false,
-      "hideUserInfo": true
-    }
+      "hideUserInfo": true,
+      "uiRecipesList": ["View study", "Explorer", "Yaml"]
+    },
+    "plugin": "@development-framework/dm-core-plugins/header"
   },
   "uiRecipes": [
     {
@@ -26,7 +26,6 @@
     {
       "name": "View study",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/view_selector/sidebar",
       "config": {
         "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
         "childTabsOnRender": true,
@@ -35,15 +34,16 @@
             "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
             "label": "Study",
             "viewConfig": {
-              "eds_icon": "change_history",
               "type": "CORE:ReferenceViewConfig",
+              "eds_icon": "change_history",
               "recipe": "Tabs",
               "scope": "study",
               "showRefreshButton": true
             }
           }
         ]
-      }
+      },
+      "plugin": "@development-framework/dm-core-plugins/view_selector/sidebar"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/signals_simple/case.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/signals_simple/case.recipe.json
@@ -5,68 +5,67 @@
     "name": "Dashboard",
     "type": "CORE:UiRecipe",
     "description": "ESS Plot",
-    "showRefreshButton": true,
-    "plugin": "@development-framework/dm-core-plugins/grid",
     "config": {
       "type": "PLUGINS:dm-core-plugins/grid/GridPluginConfig",
+      "items": [
+        {
+          "type": "PLUGINS:dm-core-plugins/grid/GridItem",
+          "gridArea": {
+            "type": "PLUGINS:dm-core-plugins/grid/GridArea",
+            "columnEnd": 1,
+            "columnStart": 1,
+            "rowEnd": 3,
+            "rowStart": 1
+          },
+          "viewConfig": {
+            "type": "CORE:ReferenceViewConfig",
+            "recipe": "Tabs"
+          }
+        },
+        {
+          "type": "PLUGINS:dm-core-plugins/grid/GridItem",
+          "gridArea": {
+            "type": "PLUGINS:dm-core-plugins/grid/GridArea",
+            "columnEnd": 2,
+            "columnStart": 2,
+            "rowEnd": 3,
+            "rowStart": 1
+          },
+          "viewConfig": {
+            "type": "CORE:ReferenceViewConfig",
+            "recipe": "Plot",
+            "scope": "signal"
+          }
+        },
+        {
+          "type": "PLUGINS:dm-core-plugins/grid/GridItem",
+          "gridArea": {
+            "type": "PLUGINS:dm-core-plugins/grid/GridArea",
+            "columnEnd": 2,
+            "columnStart": 1,
+            "rowEnd": 4,
+            "rowStart": 4
+          },
+          "viewConfig": {
+            "type": "CORE:ReferenceViewConfig",
+            "recipe": "RunJob"
+          }
+        }
+      ],
+      "showItemBorders": false,
       "size": {
         "type": "PLUGINS:dm-core-plugins/grid/GridSize",
         "columns": 2,
         "rows": 4
-      },
-      "showItemBorders": false,
-      "items": [
-        {
-          "type": "PLUGINS:dm-core-plugins/grid/GridItem",
-          "viewConfig": {
-            "type": "CORE:ReferenceViewConfig",
-            "recipe": "Tabs"
-          },
-          "gridArea": {
-            "type": "PLUGINS:dm-core-plugins/grid/GridArea",
-            "rowStart": 1,
-            "columnStart": 1,
-            "rowEnd": 3,
-            "columnEnd": 1
-          }
-        },
-        {
-          "type": "PLUGINS:dm-core-plugins/grid/GridItem",
-          "viewConfig": {
-            "type": "CORE:ReferenceViewConfig",
-            "scope": "signal",
-            "recipe": "Plot"
-          },
-          "gridArea": {
-            "type": "PLUGINS:dm-core-plugins/grid/GridArea",
-            "rowStart": 1,
-            "columnStart": 2,
-            "rowEnd": 3,
-            "columnEnd": 2
-          }
-        },
-        {
-          "type": "PLUGINS:dm-core-plugins/grid/GridItem",
-          "viewConfig": {
-            "type": "CORE:ReferenceViewConfig",
-            "recipe": "RunJob"
-          },
-          "gridArea": {
-            "type": "PLUGINS:dm-core-plugins/grid/GridArea",
-            "rowStart": 4,
-            "columnStart": 1,
-            "rowEnd": 4,
-            "columnEnd": 2
-          }
-        }
-      ]
-    }
+      }
+    },
+    "plugin": "@development-framework/dm-core-plugins/grid",
+    "showRefreshButton": true
   },
   "uiRecipes": [
     {
       "name": "Tabs",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
       "config": {
         "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
         "childTabsOnRender": true,
@@ -80,54 +79,43 @@
             }
           }
         ]
-      }
+      },
+      "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
     },
     {
       "name": "Edit",
       "type": "CORE:UiRecipe",
       "description": "Default edit",
-      "plugin": "@development-framework/dm-core-plugins/form",
       "config": {
         "type": "PLUGINS:dm-core-plugins/form/FormInput",
         "fields": ["name", "description", "duration", "timeStep", "components"]
-      }
+      },
+      "plugin": "@development-framework/dm-core-plugins/form"
     },
     {
       "name": "RunJob",
       "type": "CORE:UiRecipe",
       "description": "running",
-      "plugin": "@development-framework/dm-core-plugins/job/create",
       "config": {
         "type": "PLUGINS:dm-core-plugins/job/CreateConfig",
-        "jobTargetAddress": ".job",
         "jobInputAddress": ".",
-        "recurring": false,
+        "jobTargetAddress": ".job",
         "jobTemplates": [
           {
             "type": "PLUGINS:dm-core-plugins/common/Template",
-            "path": "/$4483c9b0-d505-46c9-a157-94c79f4d7a6a.study.jobTemplate",
-            "label": "signal job"
+            "label": "signal job",
+            "path": "/$4483c9b0-d505-46c9-a157-94c79f4d7a6a.study.jobTemplate"
           }
-        ]
-      }
+        ],
+        "recurring": false
+      },
+      "plugin": "@development-framework/dm-core-plugins/job/create"
     },
     {
       "name": "Table",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/table",
-      "dimensions": "*",
       "config": {
         "type": "PLUGINS:dm-core-plugins/table/TablePluginConfig",
-        "variant": [
-          {
-            "name": "view",
-            "type": "PLUGINS:dm-core-plugins/table/TableVariantConfig"
-          },
-          {
-            "name": "edit",
-            "type": "PLUGINS:dm-core-plugins/table/TableVariantConfig"
-          }
-        ],
         "columns": [
           {
             "type": "PLUGINS:dm-core-plugins/table/TableColumnConfig",
@@ -148,15 +136,27 @@
         ],
         "expandableRecipeViewConfig": {
           "type": "CORE:InlineRecipeViewConfig",
-          "scope": "self",
           "recipe": {
             "name": "Edit",
             "type": "CORE:UiRecipe",
             "description": "Default edit",
             "plugin": "@development-framework/dm-core-plugins/form"
+          },
+          "scope": "self"
+        },
+        "variant": [
+          {
+            "name": "view",
+            "type": "PLUGINS:dm-core-plugins/table/TableVariantConfig"
+          },
+          {
+            "name": "edit",
+            "type": "PLUGINS:dm-core-plugins/table/TableVariantConfig"
           }
-        }
-      }
+        ]
+      },
+      "dimensions": "*",
+      "plugin": "@development-framework/dm-core-plugins/table"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/signals_simple/sinComp.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/signals_simple/sinComp.recipe.json
@@ -5,16 +5,8 @@
     {
       "name": "Table Edit",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/table",
-      "dimensions": "*",
       "config": {
         "type": "PLUGINS:dm-core-plugins/table/TablePluginConfig",
-        "variant": [
-          {
-            "name": "edit",
-            "type": "PLUGINS:dm-core-plugins/table/TableVariantConfig"
-          }
-        ],
         "columns": [
           {
             "type": "PLUGINS:dm-core-plugins/table/TableColumnConfig",
@@ -29,8 +21,16 @@
             "data": "phase",
             "label": "Phase"
           }
+        ],
+        "variant": [
+          {
+            "name": "edit",
+            "type": "PLUGINS:dm-core-plugins/table/TableVariantConfig"
+          }
         ]
-      }
+      },
+      "dimensions": "*",
+      "plugin": "@development-framework/dm-core-plugins/table"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/signals_simple/study.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/signals_simple/study.recipe.json
@@ -4,22 +4,22 @@
   "initialUiRecipe": {
     "name": "Tabs",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
     "config": {
       "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
       "childTabsOnRender": true,
       "items": [
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
-          "label": "Home",
           "eds_icon": "home",
+          "label": "Home",
           "viewConfig": {
             "type": "CORE:ReferenceViewConfig",
             "recipe": "Edit"
           }
         }
       ]
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
   },
   "uiRecipes": [
     {

--- a/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/signals_simple/studyNC.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/signals_simple/studyNC.recipe.json
@@ -4,11 +4,11 @@
   "initialUiRecipe": {
     "name": "Tabs",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
     "config": {
       "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
       "childTabsOnRender": true
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
   },
   "uiRecipes": [
     {

--- a/example/app/data/DemoDataSource/recipes/blueprint.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/blueprint.recipe.json
@@ -4,7 +4,6 @@
   "initialUiRecipe": {
     "name": "UiRecipesSelector",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/view_selector/sidebar",
     "config": {
       "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
       "childTabsOnRender": true,
@@ -38,7 +37,8 @@
           }
         }
       ]
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/view_selector/sidebar"
   },
   "uiRecipes": [
     {

--- a/example/app/data/DemoDataSource/recipes/job.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/job.recipe.json
@@ -4,25 +4,24 @@
   "initialUiRecipe": {
     "name": "Dashboard",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/grid",
     "config": {
       "type": "PLUGINS:dm-core-plugins/grid/GridPluginConfig",
-      "size": {
-        "type": "PLUGINS:dm-core-plugins/grid/GridSize",
-        "columns": 1,
-        "rows": 2
-      },
-      "showItemBorders": true,
       "items": [
         {
           "type": "PLUGINS:dm-core-plugins/grid/GridItem",
+          "gridArea": {
+            "type": "PLUGINS:dm-core-plugins/grid/GridArea",
+            "columnEnd": 1,
+            "columnStart": 1,
+            "rowEnd": 1,
+            "rowStart": 1
+          },
           "title": "Edit job",
           "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
             "recipe": {
               "name": "Job Edit",
               "type": "CORE:UiRecipe",
-              "plugin": "@development-framework/dm-core-plugins/form",
               "config": {
                 "type": "PLUGINS:dm-core-plugins/form/FormInput",
                 "attributes": [
@@ -72,8 +71,8 @@
                   {
                     "name": "runner",
                     "type": "PLUGINS:dm-core-plugins/form/fields/ObjectField",
-                    "showExpanded": false,
-                    "searchByType": true
+                    "searchByType": true,
+                    "showExpanded": false
                   }
                 ],
                 "fields": [
@@ -89,52 +88,53 @@
                   "applicationInput",
                   "runner"
                 ]
-              }
+              },
+              "plugin": "@development-framework/dm-core-plugins/form"
             }
-          },
-          "gridArea": {
-            "type": "PLUGINS:dm-core-plugins/grid/GridArea",
-            "rowStart": 1,
-            "columnStart": 1,
-            "rowEnd": 1,
-            "columnEnd": 1
           }
         },
         {
           "type": "PLUGINS:dm-core-plugins/grid/GridItem",
+          "gridArea": {
+            "type": "PLUGINS:dm-core-plugins/grid/GridArea",
+            "columnEnd": 1,
+            "columnStart": 1,
+            "rowEnd": 2,
+            "rowStart": 2
+          },
           "title": "Control job",
           "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
             "recipe": {
               "name": "job-control",
               "type": "CORE:UiRecipe",
-              "plugin": "@development-framework/dm-core-plugins/job",
               "config": {
                 "type": "PLUGINS:dm-core-plugins/job/ControlConfig",
                 "runnerTemplates": [
                   {
                     "type": "PLUGINS:dm-core-plugins/common/Template",
-                    "path": "dmss://DemoDataSource/plugins/job/helloWorldLocalContainerRunner",
-                    "label": "Hello world"
+                    "label": "Hello world",
+                    "path": "dmss://DemoDataSource/plugins/job/helloWorldLocalContainerRunner"
                   },
                   {
                     "type": "PLUGINS:dm-core-plugins/common/Template",
-                    "path": "dmss://DemoDataSource/plugins/job/reverseDescriptionRunner",
-                    "label": "Reverse description"
+                    "label": "Reverse description",
+                    "path": "dmss://DemoDataSource/plugins/job/reverseDescriptionRunner"
                   }
                 ]
-              }
+              },
+              "plugin": "@development-framework/dm-core-plugins/job"
             }
-          },
-          "gridArea": {
-            "type": "PLUGINS:dm-core-plugins/grid/GridArea",
-            "rowStart": 2,
-            "columnStart": 1,
-            "rowEnd": 2,
-            "columnEnd": 1
           }
         }
-      ]
-    }
+      ],
+      "showItemBorders": true,
+      "size": {
+        "type": "PLUGINS:dm-core-plugins/grid/GridSize",
+        "columns": 1,
+        "rows": 2
+      }
+    },
+    "plugin": "@development-framework/dm-core-plugins/grid"
   }
 }

--- a/example/app/data/DemoDataSource/recipes/package.json
+++ b/example/app/data/DemoDataSource/recipes/package.json
@@ -1,46 +1,46 @@
 {
   "name": "recipes",
   "type": "CORE:Package",
-  "isRoot": false,
   "_meta_": {
     "type": "CORE:Meta",
-    "version": "0.0.1",
     "dependencies": [
       {
         "type": "CORE:Dependency",
-        "alias": "CORE",
         "address": "system/SIMOS",
-        "version": "0.0.1",
-        "protocol": "dmss"
+        "alias": "CORE",
+        "protocol": "dmss",
+        "version": "0.0.1"
       },
       {
         "type": "CORE:Dependency",
-        "alias": "PLUGINS",
         "address": "system/Plugins",
-        "version": "0.0.1",
-        "protocol": "dmss"
+        "alias": "PLUGINS",
+        "protocol": "dmss",
+        "version": "0.0.1"
       },
       {
         "type": "CORE:Dependency",
-        "alias": "AppModels",
         "address": "DemoDataSource/apps/MySignalApp/models",
-        "version": "0.0.1",
-        "protocol": "dmss"
+        "alias": "AppModels",
+        "protocol": "dmss",
+        "version": "0.0.1"
       },
       {
         "type": "CORE:Dependency",
-        "alias": "JOBCORE",
         "address": "WorkflowDS/Blueprints",
-        "version": "0.0.1",
-        "protocol": "dmss"
+        "alias": "JOBCORE",
+        "protocol": "dmss",
+        "version": "0.0.1"
       },
       {
         "type": "CORE:Dependency",
-        "alias": "SIMA",
         "address": "SIMADS/sima4.2.1",
-        "version": "4.2.1",
-        "protocol": "dmss"
+        "alias": "SIMA",
+        "protocol": "dmss",
+        "version": "4.2.1"
       }
-    ]
-  }
+    ],
+    "version": "0.0.1"
+  },
+  "isRoot": false
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/data_grid/default/default.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/data_grid/default/default.recipe.json
@@ -4,7 +4,6 @@
   "initialUiRecipe": {
     "name": "ViewSelector",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
     "config": {
       "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
       "items": [
@@ -17,11 +16,11 @@
               "name": "Default",
               "type": "CORE:UiRecipe",
               "description": "Single multidimensional primitive",
-              "plugin": "@development-framework/dm-core-plugins/data_grid",
               "config": {
                 "type": "PLUGINS:dm-core-plugins/data_grid/DataGridPluginConfig",
                 "fieldNames": ["data"]
-              }
+              },
+              "plugin": "@development-framework/dm-core-plugins/data_grid"
             },
             "scope": "self"
           }
@@ -34,13 +33,13 @@
             "recipe": {
               "name": "Set Dimensions",
               "type": "CORE:UiRecipe",
-              "plugin": "@development-framework/dm-core-plugins/data_grid",
               "config": {
                 "type": "PLUGINS:dm-core-plugins/data_grid/DataGridPluginConfig",
+                "description": "Dimensions are set to 4,5",
                 "fieldNames": ["dimensional"],
-                "title": "Datagrid with set dimensions",
-                "description": "Dimensions are set to 4,5"
-              }
+                "title": "Datagrid with set dimensions"
+              },
+              "plugin": "@development-framework/dm-core-plugins/data_grid"
             },
             "scope": "self"
           }
@@ -53,14 +52,14 @@
             "recipe": {
               "name": "Vertical  (Set dimensions)",
               "type": "CORE:UiRecipe",
-              "plugin": "@development-framework/dm-core-plugins/data_grid",
               "config": {
                 "type": "PLUGINS:dm-core-plugins/data_grid/DataGridPluginConfig",
-                "fieldNames": ["dimensional"],
-                "title": "Vertical (Set dimensions)",
                 "description": "Vertical printing with set dimensions",
-                "printDirection": "vertical"
-              }
+                "fieldNames": ["dimensional"],
+                "printDirection": "vertical",
+                "title": "Vertical (Set dimensions)"
+              },
+              "plugin": "@development-framework/dm-core-plugins/data_grid"
             },
             "scope": "self"
           }
@@ -73,14 +72,14 @@
             "recipe": {
               "name": "Vertical  (Unknown dimensions)",
               "type": "CORE:UiRecipe",
-              "plugin": "@development-framework/dm-core-plugins/data_grid",
               "config": {
                 "type": "PLUGINS:dm-core-plugins/data_grid/DataGridPluginConfig",
-                "fieldNames": ["data"],
-                "title": "Vertical (Unknown dimensions)",
                 "description": "Vertical printing with unknown dimensions",
-                "printDirection": "vertical"
-              }
+                "fieldNames": ["data"],
+                "printDirection": "vertical",
+                "title": "Vertical (Unknown dimensions)"
+              },
+              "plugin": "@development-framework/dm-core-plugins/data_grid"
             },
             "scope": "self"
           }
@@ -93,15 +92,15 @@
             "recipe": {
               "name": "Custom labels",
               "type": "CORE:UiRecipe",
-              "plugin": "@development-framework/dm-core-plugins/data_grid",
               "config": {
                 "type": "PLUGINS:dm-core-plugins/data_grid/DataGridPluginConfig",
-                "fieldNames": ["dimensional"],
-                "title": "Datagrid with custom labels",
                 "description": "Set dimensions: 4,5. Custom column and row labels.",
                 "columnLabels": ["Manufacturer", "Name", "Type", "VIN"],
-                "rowLabels": ["John", "Joe", "Jason", "Jack", "Jay"]
-              }
+                "fieldNames": ["dimensional"],
+                "rowLabels": ["John", "Joe", "Jason", "Jack", "Jay"],
+                "title": "Datagrid with custom labels"
+              },
+              "plugin": "@development-framework/dm-core-plugins/data_grid"
             },
             "scope": "self"
           }
@@ -114,15 +113,15 @@
             "recipe": {
               "name": "Combined labels",
               "type": "CORE:UiRecipe",
-              "plugin": "@development-framework/dm-core-plugins/data_grid",
               "config": {
                 "type": "PLUGINS:dm-core-plugins/data_grid/DataGridPluginConfig",
-                "fieldNames": ["dimensional"],
-                "title": "Datagrid with combined labels",
                 "description": "Set dimensions: 4,5. Combined custom and pre-defined column and row labels.",
                 "columnLabels": ["Manufacturer", "Name", "Type", "VIN"],
-                "rowLabels": ["John", "...123"]
-              }
+                "fieldNames": ["dimensional"],
+                "rowLabels": ["John", "...123"],
+                "title": "Datagrid with combined labels"
+              },
+              "plugin": "@development-framework/dm-core-plugins/data_grid"
             },
             "scope": "self"
           }
@@ -135,16 +134,16 @@
             "recipe": {
               "name": "Hidden labels",
               "type": "CORE:UiRecipe",
-              "plugin": "@development-framework/dm-core-plugins/data_grid",
               "config": {
                 "type": "PLUGINS:dm-core-plugins/data_grid/DataGridPluginConfig",
-                "fieldNames": ["dimensional"],
-                "title": "Hidden labels",
-                "editable": false,
                 "description": "Hide labels for rows and columns. Set dimensions: 4,5.",
+                "editable": false,
+                "fieldNames": ["dimensional"],
                 "showColumns": false,
-                "showRows": false
-              }
+                "showRows": false,
+                "title": "Hidden labels"
+              },
+              "plugin": "@development-framework/dm-core-plugins/data_grid"
             },
             "scope": "self"
           }
@@ -157,15 +156,15 @@
             "recipe": {
               "name": "No-edit columns and rows",
               "type": "CORE:UiRecipe",
-              "plugin": "@development-framework/dm-core-plugins/data_grid",
               "config": {
                 "type": "PLUGINS:dm-core-plugins/data_grid/DataGridPluginConfig",
-                "fieldNames": ["data"],
-                "title": "No-edit columns and rows",
                 "description": "No-edit columns and rows. No set dimensions.",
                 "adjustableColumns": false,
-                "adjustableRows": false
-              }
+                "adjustableRows": false,
+                "fieldNames": ["data"],
+                "title": "No-edit columns and rows"
+              },
+              "plugin": "@development-framework/dm-core-plugins/data_grid"
             },
             "scope": "self"
           }
@@ -178,21 +177,22 @@
             "recipe": {
               "name": "Non-editable",
               "type": "CORE:UiRecipe",
-              "plugin": "@development-framework/dm-core-plugins/data_grid",
               "config": {
                 "type": "PLUGINS:dm-core-plugins/data_grid/DataGridPluginConfig",
-                "fieldNames": ["data"],
-                "title": "Non-editable datagrid",
-                "editable": false,
                 "description": "Non-editable. Unknown dimensions. Custom column and row labels.",
                 "columnLabels": ["Manufacturer", "Name", "Type", "VIN"],
-                "rowLabels": ["John", "Joe", "Jason", "Jack", "Jay"]
-              }
+                "editable": false,
+                "fieldNames": ["data"],
+                "rowLabels": ["John", "Joe", "Jason", "Jack", "Jay"],
+                "title": "Non-editable datagrid"
+              },
+              "plugin": "@development-framework/dm-core-plugins/data_grid"
             },
             "scope": "self"
           }
         }
       ]
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
   }
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/data_grid/multiple_primitives/multiplePrimitives.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/data_grid/multiple_primitives/multiplePrimitives.recipe.json
@@ -4,7 +4,6 @@
   "initialUiRecipe": {
     "name": "ViewSelector",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
     "config": {
       "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
       "items": [
@@ -17,13 +16,13 @@
               "name": "Multiple Primitives",
               "type": "CORE:UiRecipe",
               "description": "Multiple primitives combined in datagrid",
-              "plugin": "@development-framework/dm-core-plugins/data_grid",
               "config": {
                 "type": "PLUGINS:dm-core-plugins/data_grid/DataGridPluginConfig",
-                "rowLabels": ["Manufacturer", "Name", "Type", "VIN"],
                 "fieldNames": ["manufacturer", "car_name", "model", "vin"],
+                "rowLabels": ["Manufacturer", "Name", "Type", "VIN"],
                 "title": "Multiple primitives datagrid"
-              }
+              },
+              "plugin": "@development-framework/dm-core-plugins/data_grid"
             },
             "scope": "self"
           }
@@ -37,19 +36,20 @@
               "name": "Vertical printing",
               "type": "CORE:UiRecipe",
               "description": "Printdirection: vertical .Multiple primitives combined in datagrid",
-              "plugin": "@development-framework/dm-core-plugins/data_grid",
               "config": {
                 "type": "PLUGINS:dm-core-plugins/data_grid/DataGridPluginConfig",
                 "columnLabels": ["Manufacturer", "Name", "Type", "VIN"],
                 "fieldNames": ["manufacturer", "car_name", "model", "vin"],
-                "title": "Vertically printed datagrid",
-                "printDirection": "vertical"
-              }
+                "printDirection": "vertical",
+                "title": "Vertically printed datagrid"
+              },
+              "plugin": "@development-framework/dm-core-plugins/data_grid"
             },
             "scope": "self"
           }
         }
       ]
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
   }
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/form/dimensional_scalar/WaveForm.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/dimensional_scalar/WaveForm.recipe.json
@@ -5,84 +5,82 @@
     "name": "Edit",
     "type": "CORE:UiRecipe",
     "description": "Default edit",
-    "showRefreshButton": true,
-    "plugin": "@development-framework/dm-core-plugins/form",
     "config": {
       "type": "PLUGINS:dm-core-plugins/form/FormInput",
       "attributes": [
         {
           "name": "significantWaveHeight",
           "type": "PLUGINS:dm-core-plugins/form/fields/ObjectField",
-          "widget": "DimensionalScalarWidget",
           "config": {
             "type": "PLUGINS:dm-core-plugins/form/widgets/DimensionalScalarWidgetConfig",
             "description": "config tooltip",
-            "label": "significantWaveHeight (config)",
-            "inline": true,
             "compact": true,
+            "inline": true,
+            "label": "significantWaveHeight (config)",
             "width": "500px"
-          }
+          },
+          "widget": "DimensionalScalarWidget"
         },
         {
           "name": "medianWaveHeight",
           "type": "PLUGINS:dm-core-plugins/form/fields/ObjectField",
-          "widget": "DimensionalScalarWidget",
           "config": {
             "type": "PLUGINS:dm-core-plugins/form/widgets/DimensionalScalarWidgetConfig",
-            "inline": true,
             "compact": true,
+            "inline": true,
             "width": "500px"
-          }
+          },
+          "widget": "DimensionalScalarWidget"
         },
         {
           "name": "minimumWaveHeight",
           "type": "PLUGINS:dm-core-plugins/form/fields/ObjectField",
-          "widget": "DimensionalScalarWidget",
           "config": {
             "type": "PLUGINS:dm-core-plugins/form/widgets/DimensionalScalarWidgetConfig",
-            "inline": true,
             "compact": true,
+            "inline": true,
             "width": "500px"
-          }
+          },
+          "widget": "DimensionalScalarWidget"
         },
         {
           "name": "maximumWaveHeight",
           "type": "PLUGINS:dm-core-plugins/form/fields/ObjectField",
-          "widget": "DimensionalScalarWidget",
           "config": {
             "type": "PLUGINS:dm-core-plugins/form/widgets/DimensionalScalarWidgetConfig",
+            "compact": true,
             "inline": true,
-            "width": "500px",
-            "compact": true
-          }
+            "width": "500px"
+          },
+          "widget": "DimensionalScalarWidget"
         },
         {
           "name": "number",
           "type": "PLUGINS:dm-core-plugins/form/fields/NumberField",
-          "widget": "DimensionalScalarWidget",
           "config": {
             "type": "PLUGINS:dm-core-plugins/form/widgets/DimensionalScalarWidgetConfig",
             "description": "This is a primitive.",
-            "label": "Primitive",
             "compact": true,
-            "width": "500px",
-            "unit": "m/s"
-          }
+            "label": "Primitive",
+            "unit": "m/s",
+            "width": "500px"
+          },
+          "widget": "DimensionalScalarWidget"
         },
         {
           "name": "string",
           "type": "PLUGINS:dm-core-plugins/form/fields/NumberField",
-          "widget": "DimensionalScalarWidget",
           "config": {
             "type": "PLUGINS:dm-core-plugins/form/widgets/DimensionalScalarWidgetConfig",
             "description": "This is a primitive string.",
+            "compact": true,
             "inline": true,
             "inputBoxWidth": "50%",
-            "width": "500px",
-            "compact": true,
             "label": "Primitive String notinlines long long long label",
-            "unit": "cm"
-          }
+            "unit": "cm",
+            "width": "500px"
+          },
+          "widget": "DimensionalScalarWidget"
         }
       ],
       "fields": [
@@ -93,6 +91,8 @@
         "string",
         "number"
       ]
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/form",
+    "showRefreshButton": true
   }
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/form/enums/enums.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/enums/enums.recipe.json
@@ -4,7 +4,6 @@
   "initialUiRecipe": {
     "name": "ViewSelector",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
     "config": {
       "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
       "childTabsOnRender": true,
@@ -26,43 +25,44 @@
               "name": "Yaml",
               "type": "CORE:UiRecipe",
               "description": "Yaml view",
-              "showRefreshButton": true,
-              "plugin": "@development-framework/dm-core-plugins/yaml"
+              "plugin": "@development-framework/dm-core-plugins/yaml",
+              "showRefreshButton": true
             },
             "scope": "self"
           }
         }
       ]
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
   },
   "uiRecipes": [
     {
       "name": "Enums",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/form",
       "config": {
         "type": "PLUGINS:dm-core-plugins/form/FormInput",
         "attributes": [
           {
             "name": "singleString",
             "type": "PLUGINS:dm-core-plugins/form/fields/StringField",
-            "widget": "SelectWidget",
             "config": {
               "type": "PLUGINS:dm-core-plugins/form/widgets/SelectWidgetConfig",
               "multiline": false
-            }
+            },
+            "widget": "SelectWidget"
           },
           {
             "name": "manyStrings",
             "type": "PLUGINS:dm-core-plugins/form/fields/StringField",
-            "widget": "SelectWidget",
             "config": {
               "type": "PLUGINS:dm-core-plugins/form/widgets/SelectWidgetConfig",
               "multiline": true
-            }
+            },
+            "widget": "SelectWidget"
           }
         ]
-      }
+      },
+      "plugin": "@development-framework/dm-core-plugins/form"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/form/hyperlinks/LinkForm.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/hyperlinks/LinkForm.recipe.json
@@ -5,10 +5,8 @@
     "name": "Edit",
     "type": "CORE:UiRecipe",
     "description": "Default edit",
-    "plugin": "@development-framework/dm-core-plugins/form",
     "config": {
       "type": "PLUGINS:dm-core-plugins/form/FormInput",
-      "readOnly": true,
       "attributes": [
         {
           "name": "stringLink1",
@@ -18,20 +16,20 @@
         {
           "name": "stringLink2",
           "type": "PLUGINS:dm-core-plugins/form/fields/StringField",
-          "widget": "HyperlinkWidget",
           "config": {
             "type": "PLUGINS:dm-core-plugins/form/widgets/HyperlinkWidgetConfig",
             "label": "Go To This Page"
-          }
+          },
+          "widget": "HyperlinkWidget"
         },
         {
           "name": "urlLink1",
           "type": "PLUGINS:dm-core-plugins/form/fields/ObjectField",
-          "widget": "HyperlinkWidget",
           "config": {
             "type": "PLUGINS:dm-core-plugins/form/widgets/HyperlinkWidgetConfig",
             "label": "Overwritten from Config"
-          }
+          },
+          "widget": "HyperlinkWidget"
         },
         {
           "name": "urlLink2",
@@ -39,7 +37,9 @@
           "widget": "HyperlinkWidget"
         }
       ],
-      "fields": ["stringLink1", "stringLink2", "urlLink1", "urlLink2"]
-    }
+      "fields": ["stringLink1", "stringLink2", "urlLink1", "urlLink2"],
+      "readOnly": true
+    },
+    "plugin": "@development-framework/dm-core-plugins/form"
   }
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/form/nested/car.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/nested/car.recipe.json
@@ -10,19 +10,19 @@
     {
       "name": "List",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/list",
-      "dimensions": "*",
       "config": {
         "type": "PLUGINS:dm-core-plugins/list/ListPluginConfig",
-        "headers": ["name", "type", "plateNumber"],
         "compact": true,
         "defaultPaginationRowsPerPage": 7,
         "functionality": {
           "type": "PLUGINS:dm-core-plugins/list/FunctionalityConfig",
           "delete": true,
           "expand": true
-        }
-      }
+        },
+        "headers": ["name", "type", "plateNumber"]
+      },
+      "dimensions": "*",
+      "plugin": "@development-framework/dm-core-plugins/list"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/form/nested/carRentalCompany.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/nested/carRentalCompany.recipe.json
@@ -4,7 +4,6 @@
   "initialUiRecipe": {
     "name": "ViewSelector",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
     "config": {
       "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
       "childTabsOnRender": true,
@@ -17,13 +16,13 @@
           }
         }
       ]
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
   },
   "uiRecipes": [
     {
       "name": "Edit",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/form",
       "category": "edit",
       "config": {
         "type": "PLUGINS:dm-core-plugins/form/FormInput",
@@ -31,23 +30,23 @@
           {
             "name": "owner",
             "type": "PLUGINS:dm-core-plugins/form/fields/ObjectField",
-            "uiRecipe": "defaultForm",
             "functionality": {
               "type": "PLUGINS:dm-core-plugins/form/FormFunctionalityConfig",
-              "open": true,
-              "expand": true
-            }
+              "expand": true,
+              "open": true
+            },
+            "uiRecipe": "defaultForm"
           },
           {
             "name": "trainee",
             "type": "PLUGINS:dm-core-plugins/form/fields/ObjectField",
-            "uiRecipe": "defaultForm",
-            "hideOptionalLabel": true,
             "functionality": {
               "type": "PLUGINS:dm-core-plugins/form/FormFunctionalityConfig",
-              "open": false,
-              "expand": true
-            }
+              "expand": true,
+              "open": false
+            },
+            "hideOptionalLabel": true,
+            "uiRecipe": "defaultForm"
           },
           {
             "name": "name",
@@ -57,33 +56,33 @@
           {
             "name": "accountant",
             "type": "PLUGINS:dm-core-plugins/form/fields/ObjectField",
-            "uiRecipe": "defaultYaml",
-            "showExpanded": true,
             "functionality": {
               "type": "PLUGINS:dm-core-plugins/form/FormFunctionalityConfig",
-              "open": false,
-              "expand": true
+              "expand": true,
+              "open": false
             },
-            "tooltip": "This is my accountant. "
+            "showExpanded": true,
+            "tooltip": "This is my accountant. ",
+            "uiRecipe": "defaultYaml"
           },
           {
             "name": "cars",
             "type": "PLUGINS:dm-core-plugins/form/fields/ArrayField",
             "functionality": {
               "type": "PLUGINS:dm-core-plugins/form/FormFunctionalityConfig",
-              "open": false,
-              "expand": true
+              "expand": true,
+              "open": false
             }
           },
           {
             "name": "locations",
             "type": "PLUGINS:dm-core-plugins/form/fields/ArrayField",
-            "template": "ArrayPrimitiveListTemplate",
             "functionality": {
               "type": "PLUGINS:dm-core-plugins/form/FormFunctionalityConfig",
-              "open": false,
-              "expand": true
+              "expand": true,
+              "open": false
             },
+            "template": "ArrayPrimitiveListTemplate",
             "tooltip": "Locations"
           },
           {
@@ -93,7 +92,6 @@
           }
         ],
         "compactButtons": true,
-        "showExpanded": true,
         "fields": [
           "owner",
           "ceo",
@@ -104,8 +102,10 @@
           "locations",
           "cars",
           "customers"
-        ]
-      }
+        ],
+        "showExpanded": true
+      },
+      "plugin": "@development-framework/dm-core-plugins/form"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/form/nested/customer.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/nested/customer.recipe.json
@@ -10,14 +10,14 @@
     {
       "name": "defaultYaml",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/yaml",
-      "category": "view"
+      "category": "view",
+      "plugin": "@development-framework/dm-core-plugins/yaml"
     },
     {
       "name": "defaultForm",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/form",
-      "category": "edit"
+      "category": "edit",
+      "plugin": "@development-framework/dm-core-plugins/form"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/form/nested/person.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/nested/person.recipe.json
@@ -4,7 +4,6 @@
   "initialUiRecipe": {
     "name": "ViewSelector",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
     "config": {
       "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
       "childTabsOnRender": true,
@@ -23,20 +22,21 @@
           }
         }
       ]
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
   },
   "uiRecipes": [
     {
       "name": "defaultYaml",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/yaml",
-      "category": "view"
+      "category": "view",
+      "plugin": "@development-framework/dm-core-plugins/yaml"
     },
     {
       "name": "defaultForm",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/form",
-      "category": "edit"
+      "category": "edit",
+      "plugin": "@development-framework/dm-core-plugins/form"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/form/read_only/car.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/read_only/car.recipe.json
@@ -4,7 +4,6 @@
   "initialUiRecipe": {
     "name": "form",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/form",
     "config": {
       "type": "PLUGINS:dm-core-plugins/form/FormInput",
       "fields": [
@@ -16,6 +15,7 @@
         "plateNumber"
       ],
       "readOnly": true
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/form"
   }
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/form/read_only/carRentalCompany.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/read_only/carRentalCompany.recipe.json
@@ -4,7 +4,6 @@
   "initialUiRecipe": {
     "name": "ViewSelector",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
     "config": {
       "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
       "childTabsOnRender": true,
@@ -17,13 +16,13 @@
           }
         }
       ]
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
   },
   "uiRecipes": [
     {
       "name": "ReadOnly",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/form",
       "category": "edit",
       "config": {
         "type": "PLUGINS:dm-core-plugins/form/FormInput",
@@ -46,20 +45,20 @@
           {
             "name": "accountant",
             "type": "PLUGINS:dm-core-plugins/form/fields/ObjectField",
-            "uiRecipe": "defaultYaml",
             "functionality": {
               "type": "PLUGINS:dm-core-plugins/form/FormFunctionalityConfig",
-              "open": false,
-              "expand": true
-            }
+              "expand": true,
+              "open": false
+            },
+            "uiRecipe": "defaultYaml"
           },
           {
             "name": "cars",
             "type": "PLUGINS:dm-core-plugins/form/fields/ArrayField",
             "functionality": {
               "type": "PLUGINS:dm-core-plugins/form/FormFunctionalityConfig",
-              "open": false,
-              "expand": true
+              "expand": true,
+              "open": false
             }
           },
           {
@@ -67,8 +66,8 @@
             "type": "PLUGINS:dm-core-plugins/form/fields/ArrayField",
             "functionality": {
               "type": "PLUGINS:dm-core-plugins/form/FormFunctionalityConfig",
-              "open": false,
-              "expand": true
+              "expand": true,
+              "open": false
             }
           },
           {
@@ -87,7 +86,8 @@
           "isBankrupt"
         ],
         "readOnly": true
-      }
+      },
+      "plugin": "@development-framework/dm-core-plugins/form"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/form/read_only/customer.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/read_only/customer.recipe.json
@@ -4,24 +4,24 @@
   "initialUiRecipe": {
     "name": "form",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/form",
     "config": {
       "type": "PLUGINS:dm-core-plugins/form/FormInput",
       "readOnly": true
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/form"
   },
   "uiRecipes": [
     {
       "name": "defaultYaml",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/yaml",
-      "category": "view"
+      "category": "view",
+      "plugin": "@development-framework/dm-core-plugins/yaml"
     },
     {
       "name": "defaultForm",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/form",
-      "category": "edit"
+      "category": "edit",
+      "plugin": "@development-framework/dm-core-plugins/form"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/form/read_only/person.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/read_only/person.recipe.json
@@ -4,7 +4,6 @@
   "initialUiRecipe": {
     "name": "ViewSelector",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
     "config": {
       "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
       "childTabsOnRender": true,
@@ -23,24 +22,25 @@
           }
         }
       ]
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
   },
   "uiRecipes": [
     {
       "name": "defaultYaml",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/yaml",
-      "category": "view"
+      "category": "view",
+      "plugin": "@development-framework/dm-core-plugins/yaml"
     },
     {
       "name": "defaultForm",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/form",
       "category": "edit",
       "config": {
         "type": "PLUGINS:dm-core-plugins/form/FormInput",
         "readOnly": true
-      }
+      },
+      "plugin": "@development-framework/dm-core-plugins/form"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/form/read_only_primitives/readOnlyPrimitives.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/read_only_primitives/readOnlyPrimitives.recipe.json
@@ -4,7 +4,6 @@
   "initialUiRecipe": {
     "name": "ReadOnly",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/form",
     "category": "edit",
     "config": {
       "type": "PLUGINS:dm-core-plugins/form/FormInput",
@@ -12,13 +11,13 @@
         {
           "name": "date",
           "type": "PLUGINS:dm-core-plugins/form/fields/StringField",
-          "widget": "DateTimeWidget",
           "config": {
             "type": "PLUGINS:dm-core-plugins/form/widgets/DateTimeWidgetConfig",
-            "variant": "datetime",
             "label": "Date & Time",
-            "useMinutes": true
-          }
+            "useMinutes": true,
+            "variant": "datetime"
+          },
+          "widget": "DateTimeWidget"
         }
       ],
       "fields": [
@@ -34,6 +33,7 @@
         "date"
       ],
       "readOnly": true
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/form"
   }
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/form/simple/simple.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/simple/simple.recipe.json
@@ -5,23 +5,23 @@
     "name": "Edit",
     "type": "CORE:UiRecipe",
     "description": "Default edit",
-    "showRefreshButton": true,
-    "plugin": "@development-framework/dm-core-plugins/form",
     "config": {
       "type": "PLUGINS:dm-core-plugins/form/FormInput",
       "attributes": [
         {
           "name": "date",
           "type": "PLUGINS:dm-core-plugins/form/fields/StringField",
-          "widget": "DateTimeWidget",
           "config": {
             "type": "PLUGINS:dm-core-plugins/form/widgets/DateTimeWidgetConfig",
-            "variant": "datetime",
             "label": "Date & Time",
-            "useMinutes": true
-          }
+            "useMinutes": true,
+            "variant": "datetime"
+          },
+          "widget": "DateTimeWidget"
         }
       ]
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/form",
+    "showRefreshButton": true
   }
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/form/storage_uncontained/simulation.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/storage_uncontained/simulation.recipe.json
@@ -5,7 +5,6 @@
     "name": "Tabs",
     "type": "CORE:UiRecipe",
     "description": "Default edit",
-    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
     "config": {
       "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
       "items": [
@@ -18,31 +17,9 @@
           }
         }
       ]
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
   },
-  "uiRecipes": [
-    {
-      "name": "Edit",
-      "type": "CORE:UiRecipe",
-      "description": "Default edit",
-      "plugin": "@development-framework/dm-core-plugins/form",
-      "config": {
-        "type": "PLUGINS:dm-core-plugins/form/FormInput",
-        "attributes": [
-          {
-            "name": "result",
-            "type": "PLUGINS:dm-core-plugins/form/fields/ObjectField",
-            "uiRecipe": "Form",
-            "functionality": {
-              "type": "PLUGINS:dm-core-plugins/form/FormFunctionalityConfig",
-              "open": true,
-              "expand": true
-            }
-          }
-        ]
-      }
-    }
-  ],
   "storageRecipes": [
     {
       "name": "DEFAULT",
@@ -60,6 +37,29 @@
           "contained": false
         }
       ]
+    }
+  ],
+  "uiRecipes": [
+    {
+      "name": "Edit",
+      "type": "CORE:UiRecipe",
+      "description": "Default edit",
+      "config": {
+        "type": "PLUGINS:dm-core-plugins/form/FormInput",
+        "attributes": [
+          {
+            "name": "result",
+            "type": "PLUGINS:dm-core-plugins/form/fields/ObjectField",
+            "functionality": {
+              "type": "PLUGINS:dm-core-plugins/form/FormFunctionalityConfig",
+              "expand": true,
+              "open": true
+            },
+            "uiRecipe": "Form"
+          }
+        ]
+      },
+      "plugin": "@development-framework/dm-core-plugins/form"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/form/tests/primitivearray.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/tests/primitivearray.recipe.json
@@ -5,18 +5,18 @@
     "name": "Edit",
     "type": "CORE:UiRecipe",
     "description": "Default edit",
-    "showRefreshButton": true,
-    "plugin": "@development-framework/dm-core-plugins/form",
     "config": {
       "type": "PLUGINS:dm-core-plugins/form/FormInput",
       "attributes": [
         {
-          "type": "PLUGINS:dm-core-plugins/form/fields/ArrayField",
           "name": "array",
+          "type": "PLUGINS:dm-core-plugins/form/fields/ArrayField",
           "template": "ArrayPrimitiveListTemplate"
         }
       ],
       "fields": ["array"]
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/form",
+    "showRefreshButton": true
   }
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/form/uncontained/company.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/uncontained/company.recipe.json
@@ -4,7 +4,6 @@
   "initialUiRecipe": {
     "name": "ViewSelector",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
     "config": {
       "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
       "childTabsOnRender": true,
@@ -17,13 +16,13 @@
           }
         }
       ]
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
   },
   "uiRecipes": [
     {
       "name": "Edit",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/form",
       "category": "edit",
       "config": {
         "type": "PLUGINS:dm-core-plugins/form/FormInput",
@@ -40,41 +39,41 @@
               "type": "CORE:ReferenceViewConfig",
               "recipe": "defaultYaml"
             },
+            "functionality": {
+              "type": "PLUGINS:dm-core-plugins/form/FormFunctionalityConfig",
+              "expand": true,
+              "open": true
+            },
             "openViewConfig": {
               "type": "CORE:ReferenceViewConfig",
               "recipe": "defaultForm"
             },
-            "showExpanded": true,
-            "functionality": {
-              "type": "PLUGINS:dm-core-plugins/form/FormFunctionalityConfig",
-              "open": true,
-              "expand": true
-            }
+            "showExpanded": true
           },
           {
             "name": "assistant",
             "type": "PLUGINS:dm-core-plugins/form/fields/ObjectField",
-            "uiRecipe": "defaultYaml",
-            "hideOptionalLabel": true
+            "hideOptionalLabel": true,
+            "uiRecipe": "defaultYaml"
           },
           {
             "name": "trainee",
             "type": "PLUGINS:dm-core-plugins/form/fields/ObjectField",
-            "uiRecipe": "defaultYaml",
             "functionality": {
               "type": "PLUGINS:dm-core-plugins/form/FormFunctionalityConfig",
-              "open": false,
-              "expand": true
+              "expand": true,
+              "open": false
             },
-            "label": "The Trainee"
+            "label": "The Trainee",
+            "uiRecipe": "defaultYaml"
           },
           {
             "name": "description",
             "type": "PLUGINS:dm-core-plugins/form/fields/StringField",
-            "widget": "TextareaWidget",
             "hideOptionalLabel": true,
             "readOnly": true,
-            "tooltip": "tooltip"
+            "tooltip": "tooltip",
+            "widget": "TextareaWidget"
           },
           {
             "name": "averageSalary",
@@ -94,7 +93,8 @@
           "assistant",
           "trainee"
         ]
-      }
+      },
+      "plugin": "@development-framework/dm-core-plugins/form"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/form/uncontained/person.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/uncontained/person.recipe.json
@@ -4,7 +4,6 @@
   "initialUiRecipe": {
     "name": "ViewSelector",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
     "config": {
       "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
       "childTabsOnRender": true,
@@ -23,20 +22,21 @@
           }
         }
       ]
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
   },
   "uiRecipes": [
     {
       "name": "defaultYaml",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/yaml",
-      "category": "view"
+      "category": "view",
+      "plugin": "@development-framework/dm-core-plugins/yaml"
     },
     {
       "name": "defaultForm",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/form",
-      "category": "edit"
+      "category": "edit",
+      "plugin": "@development-framework/dm-core-plugins/form"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/grid/car_grid/car.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/grid/car_grid/car.recipe.json
@@ -11,20 +11,8 @@
       "name": "cars",
       "type": "CORE:UiRecipe",
       "description": "List of cars",
-      "plugin": "@development-framework/dm-core-plugins/table",
       "config": {
         "type": "PLUGINS:dm-core-plugins/table/TablePluginConfig",
-        "variant": [
-          {
-            "name": "view",
-            "type": "PLUGINS:dm-core-plugins/table/TableVariantConfig",
-            "functionality": {
-              "type": "PLUGINS:dm-core-plugins/table/TableFunctionalityConfig",
-              "delete": false,
-              "add": false
-            }
-          }
-        ],
         "columns": [
           {
             "type": "PLUGINS:dm-core-plugins/table/TableColumnConfig",
@@ -50,8 +38,20 @@
             "label": "lap time",
             "sortable": true
           }
+        ],
+        "variant": [
+          {
+            "name": "view",
+            "type": "PLUGINS:dm-core-plugins/table/TableVariantConfig",
+            "functionality": {
+              "type": "PLUGINS:dm-core-plugins/table/TableFunctionalityConfig",
+              "add": false,
+              "delete": false
+            }
+          }
         ]
-      }
+      },
+      "plugin": "@development-framework/dm-core-plugins/table"
     },
     {
       "name": "Yaml",

--- a/example/app/data/DemoDataSource/recipes/plugins/grid/car_grid/carList.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/grid/car_grid/carList.recipe.json
@@ -4,7 +4,6 @@
   "initialUiRecipe": {
     "name": "CarList",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
     "config": {
       "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
       "items": [
@@ -25,6 +24,7 @@
           }
         }
       ]
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
   }
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/grid/car_grid/nested.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/grid/car_grid/nested.recipe.json
@@ -4,15 +4,15 @@
   "initialUiRecipe": {
     "name": "ViewSelector",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/view_selector",
-    "config": {}
+    "config": {},
+    "plugin": "@development-framework/dm-core-plugins/view_selector"
   },
   "uiRecipes": [
     {
       "name": "custom",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/yaml",
-      "category": "view"
+      "category": "view",
+      "plugin": "@development-framework/dm-core-plugins/yaml"
     },
     {
       "name": "Form",

--- a/example/app/data/DemoDataSource/recipes/plugins/grid/car_grid/raceCenter.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/grid/car_grid/raceCenter.recipe.json
@@ -4,84 +4,80 @@
   "initialUiRecipe": {
     "name": "RaceCenter",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/grid",
     "config": {
       "type": "PLUGINS:dm-core-plugins/grid/GridPluginConfig",
-      "size": {
-        "type": "PLUGINS:dm-core-plugins/grid/GridSize",
-        "columns": 2,
-        "rows": 3,
-        "rowSizes": ["2fr", "2fr", "1fr"],
-        "columnSizes": ["4fr", "1fr"]
-      },
       "itemBorder": {
         "type": "PLUGINS:dm-core-plugins/grid/GridBorder",
-        "size": "1px",
         "color": "#bbb",
-        "style": "solid",
-        "radius": "5px"
+        "radius": "5px",
+        "size": "1px",
+        "style": "solid"
       },
-      "showItemBorders": true,
       "items": [
         {
           "type": "PLUGINS:dm-core-plugins/grid/GridItem",
+          "gridArea": {
+            "type": "PLUGINS:dm-core-plugins/grid/GridArea",
+            "columnEnd": 1,
+            "columnStart": 1,
+            "rowEnd": 1,
+            "rowStart": 1
+          },
           "title": "List of cars",
           "viewConfig": {
             "type": "CORE:ReferenceViewConfig",
-            "scope": "carsOnGrid",
-            "recipe": "CarList"
-          },
-          "gridArea": {
-            "type": "PLUGINS:dm-core-plugins/grid/GridArea",
-            "rowStart": 1,
-            "columnStart": 1,
-            "rowEnd": 1,
-            "columnEnd": 1
+            "recipe": "CarList",
+            "scope": "carsOnGrid"
           }
         },
         {
           "type": "PLUGINS:dm-core-plugins/grid/GridItem",
+          "gridArea": {
+            "type": "PLUGINS:dm-core-plugins/grid/GridArea",
+            "columnEnd": 1,
+            "columnStart": 1,
+            "rowEnd": 2,
+            "rowStart": 2
+          },
           "title": "List of tires",
           "viewConfig": {
             "type": "CORE:ReferenceViewConfig",
-            "scope": "tyreList",
-            "recipe": "Edit"
-          },
-          "gridArea": {
-            "type": "PLUGINS:dm-core-plugins/grid/GridArea",
-            "rowStart": 2,
-            "columnStart": 1,
-            "rowEnd": 2,
-            "columnEnd": 1
+            "recipe": "Edit",
+            "scope": "tyreList"
           }
         },
         {
           "type": "PLUGINS:dm-core-plugins/grid/GridItem",
+          "gridArea": {
+            "type": "PLUGINS:dm-core-plugins/grid/GridArea",
+            "columnEnd": 1,
+            "columnStart": 1,
+            "rowEnd": 3,
+            "rowStart": 3
+          },
           "title": "Reference to list of tires",
           "viewConfig": {
             "type": "CORE:ReferenceViewConfig",
-            "scope": "tyreList",
             "recipe": "Edit",
-            "resolve": false
-          },
-          "gridArea": {
-            "type": "PLUGINS:dm-core-plugins/grid/GridArea",
-            "rowStart": 3,
-            "columnStart": 1,
-            "rowEnd": 3,
-            "columnEnd": 1
+            "resolve": false,
+            "scope": "tyreList"
           }
         },
         {
           "type": "PLUGINS:dm-core-plugins/grid/GridItem",
+          "gridArea": {
+            "type": "PLUGINS:dm-core-plugins/grid/GridArea",
+            "columnEnd": 2,
+            "columnStart": 2,
+            "rowEnd": 3,
+            "rowStart": 1
+          },
           "title": "Some nested form to show",
           "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
-            "scope": "nestedForm",
             "recipe": {
               "name": "form",
               "type": "CORE:UiRecipe",
-              "plugin": "@development-framework/dm-core-plugins/form",
               "config": {
                 "type": "PLUGINS:dm-core-plugins/form/FormInput",
                 "attributes": [
@@ -91,19 +87,23 @@
                     "widget": "TextareaWidget"
                   }
                 ]
-              }
-            }
-          },
-          "gridArea": {
-            "type": "PLUGINS:dm-core-plugins/grid/GridArea",
-            "rowStart": 1,
-            "columnStart": 2,
-            "rowEnd": 3,
-            "columnEnd": 2
+              },
+              "plugin": "@development-framework/dm-core-plugins/form"
+            },
+            "scope": "nestedForm"
           }
         }
-      ]
-    }
+      ],
+      "showItemBorders": true,
+      "size": {
+        "type": "PLUGINS:dm-core-plugins/grid/GridSize",
+        "columnSizes": ["4fr", "1fr"],
+        "columns": 2,
+        "rowSizes": ["2fr", "2fr", "1fr"],
+        "rows": 3
+      }
+    },
+    "plugin": "@development-framework/dm-core-plugins/grid"
   },
   "uiRecipes": [
     {

--- a/example/app/data/DemoDataSource/recipes/plugins/grid/car_grid/tyre.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/grid/car_grid/tyre.recipe.json
@@ -4,7 +4,6 @@
   "initialUiRecipe": {
     "name": "UiRecipesSelector",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
     "config": {
       "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
       "items": [
@@ -17,7 +16,6 @@
               "name": "Edit",
               "type": "CORE:UiRecipe",
               "description": "Default edit",
-              "plugin": "@development-framework/dm-core-plugins/form",
               "config": {
                 "type": "PLUGINS:dm-core-plugins/form/FormInput",
                 "attributes": [
@@ -27,13 +25,15 @@
                     "widget": "TextareaWidget"
                   }
                 ]
-              }
+              },
+              "plugin": "@development-framework/dm-core-plugins/form"
             },
             "scope": "self"
           }
         }
       ]
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
   },
   "uiRecipes": [
     {
@@ -49,19 +49,19 @@
     {
       "name": "List",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/list",
-      "dimensions": "*",
       "config": {
         "type": "PLUGINS:dm-core-plugins/list/ListPluginConfig",
-        "headers": ["name", "compound"],
         "functionality": {
           "type": "PLUGINS:dm-core-plugins/list/FunctionalityConfig",
-          "delete": true,
           "add": true,
+          "delete": true,
           "expand": true,
           "sort": true
-        }
-      }
+        },
+        "headers": ["name", "compound"]
+      },
+      "dimensions": "*",
+      "plugin": "@development-framework/dm-core-plugins/list"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/grid/car_grid/tyreList.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/grid/car_grid/tyreList.recipe.json
@@ -4,11 +4,11 @@
   "initialUiRecipe": {
     "name": "TyreList",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
     "config": {
       "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
       "childTabsOnRender": true
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
   },
   "uiRecipes": [
     {
@@ -24,12 +24,12 @@
     {
       "name": "List",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/list",
-      "dimensions": "*",
       "config": {
         "type": "PLUGINS:dm-core-plugins/list/ListPluginConfig",
         "headers": ["name", "compound"]
-      }
+      },
+      "dimensions": "*",
+      "plugin": "@development-framework/dm-core-plugins/list"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/grid/example/dashboard.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/grid/example/dashboard.recipe.json
@@ -4,39 +4,38 @@
   "initialUiRecipe": {
     "name": "Dashboard",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/grid",
     "config": {
       "type": "PLUGINS:dm-core-plugins/grid/GridPluginConfig",
-      "size": {
-        "type": "PLUGINS:dm-core-plugins/grid/GridSize",
-        "columns": 6,
-        "rows": 5
-      },
       "items": [
         {
           "type": "PLUGINS:dm-core-plugins/grid/GridItem",
-          "viewConfig": {
-            "type": "CORE:ReferenceViewConfig",
-            "scope": "aNestedObjectWithCustomUI",
-            "recipe": "aRecipeName"
-          },
           "gridArea": {
             "type": "PLUGINS:dm-core-plugins/grid/GridArea",
-            "rowStart": 1,
+            "columnEnd": 6,
             "columnStart": 1,
             "rowEnd": 1,
-            "columnEnd": 6
+            "rowStart": 1
+          },
+          "viewConfig": {
+            "type": "CORE:ReferenceViewConfig",
+            "recipe": "aRecipeName",
+            "scope": "aNestedObjectWithCustomUI"
           }
         },
         {
           "type": "PLUGINS:dm-core-plugins/grid/GridItem",
+          "gridArea": {
+            "type": "PLUGINS:dm-core-plugins/grid/GridArea",
+            "columnEnd": 6,
+            "columnStart": 4,
+            "rowEnd": 2,
+            "rowStart": 2
+          },
           "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
-            "scope": "aNestedObjectWithCustomUI",
             "recipe": {
               "name": "form",
               "type": "CORE:UiRecipe",
-              "plugin": "@development-framework/dm-core-plugins/form",
               "config": {
                 "type": "PLUGINS:dm-core-plugins/form/FormInput",
                 "attributes": [
@@ -46,49 +45,51 @@
                     "widget": "TextareaWidget"
                   }
                 ]
-              }
-            }
-          },
-          "gridArea": {
-            "type": "PLUGINS:dm-core-plugins/grid/GridArea",
-            "rowStart": 2,
-            "columnStart": 4,
-            "rowEnd": 2,
-            "columnEnd": 6
+              },
+              "plugin": "@development-framework/dm-core-plugins/form"
+            },
+            "scope": "aNestedObjectWithCustomUI"
           }
         },
         {
           "type": "PLUGINS:dm-core-plugins/grid/GridItem",
-          "viewConfig": {
-            "type": "CORE:ReferenceViewConfig",
-            "scope": "orders[0].product",
-            "recipe": "Yaml"
-          },
           "gridArea": {
             "type": "PLUGINS:dm-core-plugins/grid/GridArea",
-            "rowStart": 4,
+            "columnEnd": 3,
             "columnStart": 1,
             "rowEnd": 4,
-            "columnEnd": 3
-          }
-        },
-        {
-          "type": "PLUGINS:dm-core-plugins/grid/GridItem",
+            "rowStart": 4
+          },
           "viewConfig": {
             "type": "CORE:ReferenceViewConfig",
-            "scope": "order.product",
-            "recipe": "Form"
-          },
-          "gridArea": {
-            "type": "PLUGINS:dm-core-plugins/grid/GridArea",
-            "rowStart": 4,
-            "columnStart": 4,
-            "rowEnd": 4,
-            "columnEnd": 6
+            "recipe": "Yaml",
+            "scope": "orders[0].product"
           }
         },
         {
           "type": "PLUGINS:dm-core-plugins/grid/GridItem",
+          "gridArea": {
+            "type": "PLUGINS:dm-core-plugins/grid/GridArea",
+            "columnEnd": 6,
+            "columnStart": 4,
+            "rowEnd": 4,
+            "rowStart": 4
+          },
+          "viewConfig": {
+            "type": "CORE:ReferenceViewConfig",
+            "recipe": "Form",
+            "scope": "order.product"
+          }
+        },
+        {
+          "type": "PLUGINS:dm-core-plugins/grid/GridItem",
+          "gridArea": {
+            "type": "PLUGINS:dm-core-plugins/grid/GridArea",
+            "columnEnd": 6,
+            "columnStart": 1,
+            "rowEnd": 5,
+            "rowStart": 5
+          },
           "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
             "recipe": {
@@ -96,17 +97,16 @@
               "type": "CORE:UiRecipe",
               "plugin": "@development-framework/dm-core-plugins/json"
             }
-          },
-          "gridArea": {
-            "type": "PLUGINS:dm-core-plugins/grid/GridArea",
-            "rowStart": 5,
-            "columnStart": 1,
-            "rowEnd": 5,
-            "columnEnd": 6
           }
         }
-      ]
-    }
+      ],
+      "size": {
+        "type": "PLUGINS:dm-core-plugins/grid/GridSize",
+        "columns": 6,
+        "rows": 5
+      }
+    },
+    "plugin": "@development-framework/dm-core-plugins/grid"
   },
   "uiRecipes": [
     {

--- a/example/app/data/DemoDataSource/recipes/plugins/grid/example/nested.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/grid/example/nested.recipe.json
@@ -4,26 +4,25 @@
   "initialUiRecipe": {
     "name": "ViewSelector",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
-    "config": {}
+    "config": {},
+    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
   },
   "uiRecipes": [
     {
       "name": "custom",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/yaml",
-      "category": "view"
+      "category": "view",
+      "plugin": "@development-framework/dm-core-plugins/yaml"
     },
     {
       "name": "Form",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/form",
-      "category": "edit"
+      "category": "edit",
+      "plugin": "@development-framework/dm-core-plugins/form"
     },
     {
       "name": "aRecipeName",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/form",
       "category": "edit",
       "config": {
         "type": "PLUGINS:dm-core-plugins/form/FormInput",
@@ -34,7 +33,8 @@
             "widget": "TextareaWidget"
           }
         ]
-      }
+      },
+      "plugin": "@development-framework/dm-core-plugins/form"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/grid/example/order.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/grid/example/order.recipe.json
@@ -4,11 +4,11 @@
   "initialUiRecipe": {
     "name": "ViewSelector",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
     "config": {
       "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
       "childTabsOnRender": true
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
   },
   "uiRecipes": [
     {
@@ -24,16 +24,16 @@
     {
       "name": "List",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/list",
-      "dimensions": "*",
       "config": {
         "type": "PLUGINS:dm-core-plugins/list/ListPluginConfig",
-        "headers": ["name", "description"],
         "functionality": {
           "type": "PLUGINS:dm-core-plugins/list/FunctionalityConfig",
           "delete": true
-        }
-      }
+        },
+        "headers": ["name", "description"]
+      },
+      "dimensions": "*",
+      "plugin": "@development-framework/dm-core-plugins/list"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/grid/example/orderItem.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/grid/example/orderItem.recipe.json
@@ -4,7 +4,6 @@
   "initialUiRecipe": {
     "name": "UiRecipesSelector",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
     "config": {
       "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
       "items": [
@@ -23,7 +22,8 @@
           }
         }
       ]
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
   },
   "uiRecipes": [
     {
@@ -39,17 +39,17 @@
     {
       "name": "List",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/list",
-      "dimensions": "*",
       "config": {
         "type": "PLUGINS:dm-core-plugins/list/ListPluginConfig",
-        "headers": ["name", "quantity", "type"],
         "functionality": {
           "type": "PLUGINS:dm-core-plugins/list/FunctionalityConfig",
           "delete": true,
           "expand": true
-        }
-      }
+        },
+        "headers": ["name", "quantity", "type"]
+      },
+      "dimensions": "*",
+      "plugin": "@development-framework/dm-core-plugins/list"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/header/example_app/exampleApplication.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/header/example_app/exampleApplication.recipe.json
@@ -4,13 +4,13 @@
   "initialUiRecipe": {
     "name": "Header",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/header",
     "config": {
       "type": "PLUGINS:dm-core-plugins/header/HeaderPluginConfig",
-      "uiRecipesList": ["Yaml", "Edit", "Explorer"],
       "hideAbout": false,
-      "hideUserInfo": false
-    }
+      "hideUserInfo": false,
+      "uiRecipesList": ["Yaml", "Edit", "Explorer"]
+    },
+    "plugin": "@development-framework/dm-core-plugins/header"
   },
   "uiRecipes": [
     {

--- a/example/app/data/DemoDataSource/recipes/plugins/header/roles_header_example/person.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/header/roles_header_example/person.recipe.json
@@ -4,7 +4,6 @@
   "initialUiRecipe": {
     "name": "RoleFilter",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/role_filter",
     "config": {
       "type": "PLUGINS:dm-core-plugins/role_filter/RoleFilterConfig",
       "viewConfigs": [
@@ -23,30 +22,31 @@
           "recipe": "Yaml"
         }
       ]
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/role_filter"
   },
   "uiRecipes": [
     {
       "name": "AdminHeader",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/header",
       "config": {
         "type": "PLUGINS:dm-core-plugins/header/HeaderPluginConfig",
-        "uiRecipesList": ["Yaml", "Edit", "Explorer"],
         "hideAbout": false,
-        "hideUserInfo": true
-      }
+        "hideUserInfo": true,
+        "uiRecipesList": ["Yaml", "Edit", "Explorer"]
+      },
+      "plugin": "@development-framework/dm-core-plugins/header"
     },
     {
       "name": "OperatorHeader",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/header",
       "config": {
         "type": "PLUGINS:dm-core-plugins/header/HeaderPluginConfig",
-        "uiRecipesList": ["Yaml", "Explorer"],
         "hideAbout": false,
-        "hideUserInfo": true
-      }
+        "hideUserInfo": true,
+        "uiRecipesList": ["Yaml", "Explorer"]
+      },
+      "plugin": "@development-framework/dm-core-plugins/header"
     },
     {
       "name": "Yaml",

--- a/example/app/data/DemoDataSource/recipes/plugins/job/jobContainer.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/job/jobContainer.recipe.json
@@ -4,24 +4,24 @@
   "initialUiRecipe": {
     "name": "Create job",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/job/create",
     "config": {
       "type": "PLUGINS:dm-core-plugins/job/CreateConfig",
-      "recurring": false,
       "hideLogs": true,
+      "jobTargetAddress": ".job",
       "jobTemplates": [
         {
           "type": "PLUGINS:dm-core-plugins/common/Template",
-          "path": "._templates_[0]",
-          "label": "Reverse description job"
+          "label": "Reverse description job",
+          "path": "._templates_[0]"
         },
         {
           "type": "PLUGINS:dm-core-plugins/common/Template",
-          "path": "._templates_[1]",
-          "label": "Also a reverse description job"
+          "label": "Also a reverse description job",
+          "path": "._templates_[1]"
         }
       ],
-      "jobTargetAddress": ".job"
-    }
+      "recurring": false
+    },
+    "plugin": "@development-framework/dm-core-plugins/job/create"
   }
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/list/order_example/order.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/list/order_example/order.recipe.json
@@ -4,11 +4,11 @@
   "initialUiRecipe": {
     "name": "ViewSelector",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
     "config": {
       "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
       "childTabsOnRender": true
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
   },
   "uiRecipes": [
     {
@@ -24,17 +24,17 @@
     {
       "name": "List",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/list",
-      "dimensions": "*",
       "config": {
         "type": "PLUGINS:dm-core-plugins/list/ListPluginConfig",
-        "headers": ["name", "description"],
         "functionality": {
           "type": "PLUGINS:dm-core-plugins/list/FunctionalityConfig",
           "delete": true,
           "expand": true
-        }
-      }
+        },
+        "headers": ["name", "description"]
+      },
+      "dimensions": "*",
+      "plugin": "@development-framework/dm-core-plugins/list"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/list/order_example/orderItem.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/list/order_example/orderItem.recipe.json
@@ -4,7 +4,6 @@
   "initialUiRecipe": {
     "name": "UiRecipesSelector",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
     "config": {
       "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
       "items": [
@@ -23,7 +22,8 @@
           }
         }
       ]
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
   },
   "uiRecipes": [
     {
@@ -39,17 +39,15 @@
     {
       "name": "List",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/list",
-      "dimensions": "*",
       "config": {
         "type": "PLUGINS:dm-core-plugins/list/ListPluginConfig",
-        "headers": ["quantity", "type"],
         "functionality": {
           "type": "PLUGINS:dm-core-plugins/list/FunctionalityConfig",
-          "delete": true,
           "add": true,
+          "delete": true,
           "expand": true
         },
+        "headers": ["quantity", "type"],
         "openViewConfig": {
           "type": "CORE:InlineRecipeViewConfig",
           "recipe": {
@@ -59,7 +57,9 @@
           },
           "scope": "self"
         }
-      }
+      },
+      "dimensions": "*",
+      "plugin": "@development-framework/dm-core-plugins/list"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/list/task_list/task.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/list/task_list/task.recipe.json
@@ -4,7 +4,6 @@
   "initialUiRecipe": {
     "name": "UiRecipesSelector",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
     "config": {
       "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
       "items": [
@@ -17,7 +16,6 @@
               "name": "Edit",
               "type": "CORE:UiRecipe",
               "description": "Default edit",
-              "plugin": "@development-framework/dm-core-plugins/form",
               "config": {
                 "type": "PLUGINS:dm-core-plugins/form/FormInput",
                 "attributes": [
@@ -27,13 +25,15 @@
                     "widget": "TextareaWidget"
                   }
                 ]
-              }
+              },
+              "plugin": "@development-framework/dm-core-plugins/form"
             },
             "scope": "self"
           }
         }
       ]
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
   },
   "uiRecipes": [
     {
@@ -49,30 +49,30 @@
     {
       "name": "List",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/list",
-      "dimensions": "*",
       "config": {
         "type": "PLUGINS:dm-core-plugins/list/ListPluginConfig",
-        "templates": [
-          {
-            "type": "PLUGINS:dm-core-plugins/common/Template",
-            "path": "~._template_",
-            "label": "Template1"
-          }
-        ],
-        "selectFromScope": "dmss://DemoDataSource/plugins/list/task_list",
-        "hideInvalidTypes": true,
-        "headers": ["name", "assigned"],
-        "saveExpanded": false,
         "defaultPaginationRowsPerPage": 5,
         "functionality": {
           "type": "PLUGINS:dm-core-plugins/list/FunctionalityConfig",
-          "delete": true,
           "add": true,
-          "sort": true,
-          "expand": true
-        }
-      }
+          "delete": true,
+          "expand": true,
+          "sort": true
+        },
+        "headers": ["name", "assigned"],
+        "hideInvalidTypes": true,
+        "saveExpanded": false,
+        "selectFromScope": "dmss://DemoDataSource/plugins/list/task_list",
+        "templates": [
+          {
+            "type": "PLUGINS:dm-core-plugins/common/Template",
+            "label": "Template1",
+            "path": "~._template_"
+          }
+        ]
+      },
+      "dimensions": "*",
+      "plugin": "@development-framework/dm-core-plugins/list"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/list/templates/task.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/list/templates/task.recipe.json
@@ -4,7 +4,6 @@
   "initialUiRecipe": {
     "name": "UiRecipesSelector",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
     "config": {
       "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
       "items": [
@@ -17,7 +16,6 @@
               "name": "Edit",
               "type": "CORE:UiRecipe",
               "description": "Default edit",
-              "plugin": "@development-framework/dm-core-plugins/form",
               "config": {
                 "type": "PLUGINS:dm-core-plugins/form/FormInput",
                 "attributes": [
@@ -27,13 +25,15 @@
                     "widget": "TextareaWidget"
                   }
                 ]
-              }
+              },
+              "plugin": "@development-framework/dm-core-plugins/form"
             },
             "scope": "self"
           }
         }
       ]
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
   },
   "uiRecipes": [
     {
@@ -49,34 +49,34 @@
     {
       "name": "List",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/list",
-      "dimensions": "*",
       "config": {
         "type": "PLUGINS:dm-core-plugins/list/ListPluginConfig",
+        "functionality": {
+          "type": "PLUGINS:dm-core-plugins/list/FunctionalityConfig",
+          "add": true,
+          "delete": true,
+          "expand": true,
+          "sort": true
+        },
+        "headers": ["name", "assigned"],
+        "hideInvalidTypes": true,
+        "saveExpanded": false,
+        "selectFromScope": "dmss://DemoDataSource/plugins/list/templates",
         "templates": [
           {
             "type": "PLUGINS:dm-core-plugins/common/Template",
-            "path": "~._templates_[0]",
-            "label": "Template1"
+            "label": "Template1",
+            "path": "~._templates_[0]"
           },
           {
             "type": "PLUGINS:dm-core-plugins/common/Template",
-            "path": "~._templates_[1]",
-            "label": "Template2"
+            "label": "Template2",
+            "path": "~._templates_[1]"
           }
-        ],
-        "selectFromScope": "dmss://DemoDataSource/plugins/list/templates",
-        "hideInvalidTypes": true,
-        "headers": ["name", "assigned"],
-        "saveExpanded": false,
-        "functionality": {
-          "type": "PLUGINS:dm-core-plugins/list/FunctionalityConfig",
-          "delete": true,
-          "add": true,
-          "sort": true,
-          "expand": true
-        }
-      }
+        ]
+      },
+      "dimensions": "*",
+      "plugin": "@development-framework/dm-core-plugins/list"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/mediaViewer/mediaViewer.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/mediaViewer/mediaViewer.recipe.json
@@ -4,23 +4,23 @@
   "initialUiRecipe": {
     "name": "SingleView",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/single_view",
     "config": {
-      "scope": "file",
       "type": "CORE:InlineRecipeViewConfig",
       "recipe": {
         "name": "Edit",
         "type": "CORE:UiRecipe",
         "description": "Default edit",
-        "plugin": "@development-framework/dm-core-plugins/media-viewer",
         "config": {
           "type": "PLUGINS:dm-core-plugins/media_viewer/MediaViewerConfig",
-          "width": 1000,
-          "showMeta": true,
+          "description": "some description",
           "caption": "some header",
-          "description": "some description"
-        }
-      }
-    }
+          "showMeta": true,
+          "width": 1000
+        },
+        "plugin": "@development-framework/dm-core-plugins/media-viewer"
+      },
+      "scope": "file"
+    },
+    "plugin": "@development-framework/dm-core-plugins/single_view"
   }
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/table/car_list/carList.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/table/car_list/carList.recipe.json
@@ -4,7 +4,6 @@
   "initialUiRecipe": {
     "name": "ViewSelector",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
     "config": {
       "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
       "items": [
@@ -12,25 +11,13 @@
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
           "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
-            "scope": "cars",
             "label": "cars (no template)",
             "recipe": {
               "name": "cars",
               "type": "CORE:UiRecipe",
               "description": "List of cars",
-              "plugin": "@development-framework/dm-core-plugins/table",
               "config": {
                 "type": "PLUGINS:dm-core-plugins/table/TablePluginConfig",
-                "variant": [
-                  {
-                    "name": "view",
-                    "type": "PLUGINS:dm-core-plugins/table/TableVariantConfig"
-                  },
-                  {
-                    "name": "edit",
-                    "type": "PLUGINS:dm-core-plugins/table/TableVariantConfig"
-                  }
-                ],
                 "columns": [
                   {
                     "type": "PLUGINS:dm-core-plugins/table/TableColumnConfig",
@@ -60,9 +47,21 @@
                     "type": "PLUGINS:dm-core-plugins/table/TableColumnConfig",
                     "data": "^tab"
                   }
+                ],
+                "variant": [
+                  {
+                    "name": "view",
+                    "type": "PLUGINS:dm-core-plugins/table/TableVariantConfig"
+                  },
+                  {
+                    "name": "edit",
+                    "type": "PLUGINS:dm-core-plugins/table/TableVariantConfig"
+                  }
                 ]
-              }
-            }
+              },
+              "plugin": "@development-framework/dm-core-plugins/table"
+            },
+            "scope": "cars"
           }
         },
         {
@@ -70,41 +69,12 @@
           "label": "cars (using many templates)",
           "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
-            "scope": "cars",
             "recipe": {
               "name": "cars",
               "type": "CORE:UiRecipe",
               "description": "List of cars",
-              "plugin": "@development-framework/dm-core-plugins/table",
               "config": {
                 "type": "PLUGINS:dm-core-plugins/table/TablePluginConfig",
-                "templates": [
-                  {
-                    "type": "PLUGINS:dm-core-plugins/common/Template",
-                    "path": "~._templates_[0]",
-                    "label": "Template1"
-                  },
-                  {
-                    "type": "PLUGINS:dm-core-plugins/common/Template",
-                    "path": "~._templates_[1]",
-                    "label": "Template2"
-                  },
-                  {
-                    "type": "PLUGINS:dm-core-plugins/common/Template",
-                    "path": "~._templates_[2]",
-                    "label": "Template3"
-                  }
-                ],
-                "variant": [
-                  {
-                    "name": "view",
-                    "type": "PLUGINS:dm-core-plugins/table/TableVariantConfig"
-                  },
-                  {
-                    "name": "edit",
-                    "type": "PLUGINS:dm-core-plugins/table/TableVariantConfig"
-                  }
-                ],
                 "columns": [
                   {
                     "type": "PLUGINS:dm-core-plugins/table/TableColumnConfig",
@@ -134,9 +104,38 @@
                     "type": "PLUGINS:dm-core-plugins/table/TableColumnConfig",
                     "data": "^tab"
                   }
+                ],
+                "templates": [
+                  {
+                    "type": "PLUGINS:dm-core-plugins/common/Template",
+                    "label": "Template1",
+                    "path": "~._templates_[0]"
+                  },
+                  {
+                    "type": "PLUGINS:dm-core-plugins/common/Template",
+                    "label": "Template2",
+                    "path": "~._templates_[1]"
+                  },
+                  {
+                    "type": "PLUGINS:dm-core-plugins/common/Template",
+                    "label": "Template3",
+                    "path": "~._templates_[2]"
+                  }
+                ],
+                "variant": [
+                  {
+                    "name": "view",
+                    "type": "PLUGINS:dm-core-plugins/table/TableVariantConfig"
+                  },
+                  {
+                    "name": "edit",
+                    "type": "PLUGINS:dm-core-plugins/table/TableVariantConfig"
+                  }
                 ]
-              }
-            }
+              },
+              "plugin": "@development-framework/dm-core-plugins/table"
+            },
+            "scope": "cars"
           }
         },
         {
@@ -144,31 +143,12 @@
           "label": "cars (using one template)",
           "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
-            "scope": "cars",
             "recipe": {
               "name": "cars",
               "type": "CORE:UiRecipe",
               "description": "List of cars",
-              "plugin": "@development-framework/dm-core-plugins/table",
               "config": {
                 "type": "PLUGINS:dm-core-plugins/table/TablePluginConfig",
-                "templates": [
-                  {
-                    "type": "PLUGINS:dm-core-plugins/common/Template",
-                    "path": "~._templates_[0]",
-                    "label": "Template1"
-                  }
-                ],
-                "variant": [
-                  {
-                    "name": "view",
-                    "type": "PLUGINS:dm-core-plugins/table/TableVariantConfig"
-                  },
-                  {
-                    "name": "edit",
-                    "type": "PLUGINS:dm-core-plugins/table/TableVariantConfig"
-                  }
-                ],
                 "columns": [
                   {
                     "type": "PLUGINS:dm-core-plugins/table/TableColumnConfig",
@@ -198,9 +178,28 @@
                     "type": "PLUGINS:dm-core-plugins/table/TableColumnConfig",
                     "data": "^tab"
                   }
+                ],
+                "templates": [
+                  {
+                    "type": "PLUGINS:dm-core-plugins/common/Template",
+                    "label": "Template1",
+                    "path": "~._templates_[0]"
+                  }
+                ],
+                "variant": [
+                  {
+                    "name": "view",
+                    "type": "PLUGINS:dm-core-plugins/table/TableVariantConfig"
+                  },
+                  {
+                    "name": "edit",
+                    "type": "PLUGINS:dm-core-plugins/table/TableVariantConfig"
+                  }
                 ]
-              }
-            }
+              },
+              "plugin": "@development-framework/dm-core-plugins/table"
+            },
+            "scope": "cars"
           }
         },
         {
@@ -208,32 +207,12 @@
           "label": "cars (using caption)",
           "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
-            "scope": "cars",
             "recipe": {
               "name": "cars",
               "type": "CORE:UiRecipe",
               "description": "List of cars",
-              "plugin": "@development-framework/dm-core-plugins/table",
               "config": {
-                "label": "Car_",
                 "type": "PLUGINS:dm-core-plugins/table/TablePluginConfig",
-                "templates": [
-                  {
-                    "type": "PLUGINS:dm-core-plugins/common/Template",
-                    "path": "~._templates_[0]",
-                    "label": "Template1"
-                  }
-                ],
-                "variant": [
-                  {
-                    "name": "view",
-                    "type": "PLUGINS:dm-core-plugins/table/TableVariantConfig"
-                  },
-                  {
-                    "name": "edit",
-                    "type": "PLUGINS:dm-core-plugins/table/TableVariantConfig"
-                  }
-                ],
                 "columns": [
                   {
                     "type": "PLUGINS:dm-core-plugins/table/TableColumnConfig",
@@ -263,12 +242,33 @@
                     "type": "PLUGINS:dm-core-plugins/table/TableColumnConfig",
                     "data": "^tab"
                   }
+                ],
+                "label": "Car_",
+                "templates": [
+                  {
+                    "type": "PLUGINS:dm-core-plugins/common/Template",
+                    "label": "Template1",
+                    "path": "~._templates_[0]"
+                  }
+                ],
+                "variant": [
+                  {
+                    "name": "view",
+                    "type": "PLUGINS:dm-core-plugins/table/TableVariantConfig"
+                  },
+                  {
+                    "name": "edit",
+                    "type": "PLUGINS:dm-core-plugins/table/TableVariantConfig"
+                  }
                 ]
-              }
-            }
+              },
+              "plugin": "@development-framework/dm-core-plugins/table"
+            },
+            "scope": "cars"
           }
         }
       ]
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
   }
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/table/dm_plugins/pluginsList.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/table/dm_plugins/pluginsList.recipe.json
@@ -4,7 +4,6 @@
   "initialUiRecipe": {
     "name": "ViewSelector",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
     "config": {
       "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
       "items": [
@@ -16,19 +15,8 @@
               "name": "plugins",
               "type": "CORE:UiRecipe",
               "description": "List of plugins",
-              "plugin": "@development-framework/dm-core-plugins/table",
               "config": {
                 "type": "PLUGINS:dm-core-plugins/table/TablePluginConfig",
-                "variant": [
-                  {
-                    "name": "view",
-                    "type": "PLUGINS:dm-core-plugins/table/TableVariantConfig"
-                  },
-                  {
-                    "name": "edit",
-                    "type": "PLUGINS:dm-core-plugins/table/TableVariantConfig"
-                  }
-                ],
                 "columns": [
                   {
                     "type": "PLUGINS:dm-core-plugins/table/TableColumnConfig",
@@ -39,35 +27,47 @@
                   {
                     "type": "PLUGINS:dm-core-plugins/table/TableColumnConfig",
                     "data": "developed",
-                    "label": "Developed",
                     "dataType": "boolean",
+                    "label": "Developed",
                     "sortable": true
                   },
                   {
                     "type": "PLUGINS:dm-core-plugins/table/TableColumnConfig",
                     "data": "documented",
-                    "label": "Documented",
                     "dataType": "boolean",
+                    "label": "Documented",
                     "presentAs": "text"
                   },
                   {
                     "type": "PLUGINS:dm-core-plugins/table/TableColumnConfig",
                     "data": "importance",
-                    "label": "Importance",
                     "dataType": "number",
+                    "label": "Importance",
                     "sortable": true
                   },
                   {
                     "type": "PLUGINS:dm-core-plugins/table/TableColumnConfig",
                     "data": "^tab"
                   }
+                ],
+                "variant": [
+                  {
+                    "name": "view",
+                    "type": "PLUGINS:dm-core-plugins/table/TableVariantConfig"
+                  },
+                  {
+                    "name": "edit",
+                    "type": "PLUGINS:dm-core-plugins/table/TableVariantConfig"
+                  }
                 ]
-              }
+              },
+              "plugin": "@development-framework/dm-core-plugins/table"
             },
             "scope": "plugins"
           }
         }
       ]
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
   }
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/view_selector/car_infosys/car.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/view_selector/car_infosys/car.recipe.json
@@ -4,38 +4,38 @@
   "initialUiRecipe": {
     "name": "ViewSelector",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
     "config": {
       "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
       "childTabsOnRender": true,
       "items": [
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
-          "label": "Home",
           "eds_icon": "home",
+          "label": "Home",
           "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
             "recipe": {
               "name": "Edit",
               "type": "CORE:UiRecipe",
               "description": "Default edit",
-              "plugin": "@development-framework/dm-core-plugins/form",
               "config": {
                 "type": "PLUGINS:dm-core-plugins/form/FormInput",
                 "fields": ["name", "model", "Owner", "Technical"]
-              }
+              },
+              "plugin": "@development-framework/dm-core-plugins/form"
             }
           }
         }
       ]
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
   },
   "uiRecipes": [
     {
       "name": "Yaml",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/yaml",
-      "category": "container"
+      "category": "container",
+      "plugin": "@development-framework/dm-core-plugins/yaml"
     },
     {
       "name": "Edit",

--- a/example/app/data/DemoDataSource/recipes/plugins/view_selector/car_infosys/carGarage.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/view_selector/car_infosys/carGarage.recipe.json
@@ -4,7 +4,6 @@
   "initialUiRecipe": {
     "name": "ViewSelector",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/view_selector/sidebar",
     "config": {
       "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
       "childTabsOnRender": true,
@@ -18,11 +17,11 @@
               "name": "Edit",
               "type": "CORE:UiRecipe",
               "description": "Default edit",
-              "plugin": "@development-framework/dm-core-plugins/form",
               "config": {
                 "type": "PLUGINS:dm-core-plugins/form/FormInput",
                 "fields": ["name", "description"]
-              }
+              },
+              "plugin": "@development-framework/dm-core-plugins/form"
             },
             "scope": "self"
           }
@@ -44,7 +43,8 @@
           }
         }
       ]
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/view_selector/sidebar"
   },
   "uiRecipes": [
     {

--- a/example/app/data/DemoDataSource/recipes/plugins/view_selector/car_infosys/owner.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/view_selector/car_infosys/owner.recipe.json
@@ -4,26 +4,25 @@
   "initialUiRecipe": {
     "name": "ViewSelector",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
     "config": {
       "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
       "childTabsOnRender": true,
       "items": [
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
-          "label": "Owner details",
           "eds_icon": "person",
+          "label": "Owner details",
           "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
             "recipe": {
               "name": "Edit",
               "type": "CORE:UiRecipe",
               "description": "Default edit",
-              "plugin": "@development-framework/dm-core-plugins/form",
               "config": {
                 "type": "PLUGINS:dm-core-plugins/form/FormInput",
                 "fields": ["name", "DateOwned"]
-              }
+              },
+              "plugin": "@development-framework/dm-core-plugins/form"
             }
           }
         },
@@ -32,28 +31,29 @@
           "label": "Owner history",
           "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
+            "eds_icon": "group",
             "recipe": {
               "name": "Edit",
               "type": "CORE:UiRecipe",
               "description": "Default edit",
-              "plugin": "@development-framework/dm-core-plugins/form",
               "config": {
                 "type": "PLUGINS:dm-core-plugins/form/FormInput",
                 "fields": ["earlierOwners"]
-              }
-            },
-            "eds_icon": "group"
+              },
+              "plugin": "@development-framework/dm-core-plugins/form"
+            }
           }
         }
       ]
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
   },
   "uiRecipes": [
     {
       "name": "Yaml",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/yaml",
-      "category": "container"
+      "category": "container",
+      "plugin": "@development-framework/dm-core-plugins/yaml"
     },
     {
       "name": "Edit",

--- a/example/app/data/DemoDataSource/recipes/plugins/view_selector/car_infosys/technical.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/view_selector/car_infosys/technical.recipe.json
@@ -4,56 +4,56 @@
   "initialUiRecipe": {
     "name": "ViewSelector",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
     "config": {
       "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
       "childTabsOnRender": true,
       "items": [
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
-          "label": "EU control",
           "eds_icon": "check",
+          "label": "EU control",
           "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
             "recipe": {
               "name": "Edit",
               "type": "CORE:UiRecipe",
               "description": "Default edit",
-              "plugin": "@development-framework/dm-core-plugins/form",
               "config": {
                 "type": "PLUGINS:dm-core-plugins/form/FormInput",
                 "fields": ["controlDate", "nextControl"]
-              }
+              },
+              "plugin": "@development-framework/dm-core-plugins/form"
             }
           }
         },
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
-          "label": "Dimensions",
           "eds_icon": "car",
+          "label": "Dimensions",
           "viewConfig": {
             "type": "CORE:InlineRecipeViewConfig",
             "recipe": {
               "name": "Edit",
               "type": "CORE:UiRecipe",
               "description": "Default edit",
-              "plugin": "@development-framework/dm-core-plugins/form",
               "config": {
                 "type": "PLUGINS:dm-core-plugins/form/FormInput",
                 "fields": ["width", "length", "heigth"]
-              }
+              },
+              "plugin": "@development-framework/dm-core-plugins/form"
             }
           }
         }
       ]
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
   },
   "uiRecipes": [
     {
       "name": "Yaml",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/yaml",
-      "category": "container"
+      "category": "container",
+      "plugin": "@development-framework/dm-core-plugins/yaml"
     },
     {
       "name": "Edit",

--- a/example/app/data/DemoDataSource/recipes/plugins/view_selector/roles_school_example/school.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/view_selector/roles_school_example/school.recipe.json
@@ -4,15 +4,14 @@
   "initialUiRecipe": {
     "name": "ViewSelector",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",
     "config": {
       "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
       "childTabsOnRender": true,
       "items": [
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
-          "label": "Headmaster view",
           "eds_icon": "visibility",
+          "label": "Headmaster view",
           "viewConfig": {
             "type": "CORE:ReferenceViewConfig",
             "recipe": "AdminView"
@@ -20,15 +19,16 @@
         },
         {
           "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
-          "label": "Student view",
           "eds_icon": "visibility",
+          "label": "Student view",
           "viewConfig": {
             "type": "CORE:ReferenceViewConfig",
             "recipe": "OperatorView"
           }
         }
       ]
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
   },
   "uiRecipes": [
     {
@@ -39,12 +39,12 @@
     {
       "name": "OperatorView",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/form",
       "config": {
         "type": "PLUGINS:dm-core-plugins/form/FormInput",
-        "readOnly": true,
-        "fields": ["name", "headmaster", "teachers", "subjects"]
-      }
+        "fields": ["name", "headmaster", "teachers", "subjects"],
+        "readOnly": true
+      },
+      "plugin": "@development-framework/dm-core-plugins/form"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/view_selector/roles_school_example/schoolDistrict.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/view_selector/roles_school_example/schoolDistrict.recipe.json
@@ -4,7 +4,6 @@
   "initialUiRecipe": {
     "name": "RoleFilter",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/role_filter",
     "config": {
       "type": "PLUGINS:dm-core-plugins/role_filter/RoleFilterConfig",
       "viewConfigs": [
@@ -19,26 +18,21 @@
           "roles": ["operator"]
         }
       ]
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/role_filter"
   },
   "uiRecipes": [
     {
       "name": "AdminViewSelector",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/view_selector/sidebar",
       "config": {
         "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
         "childTabsOnRender": true,
         "items": [
           {
             "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
-            "label": "Hogwarts Admin",
             "eds_icon": "home",
-            "viewConfig": {
-              "type": "CORE:ReferenceViewConfig",
-              "scope": "school",
-              "recipe": "AdminView"
-            },
+            "label": "Hogwarts Admin",
             "subItems": [
               {
                 "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
@@ -64,41 +58,47 @@
                   "scope": "school.teachers"
                 }
               }
-            ]
+            ],
+            "viewConfig": {
+              "type": "CORE:ReferenceViewConfig",
+              "recipe": "AdminView",
+              "scope": "school"
+            }
           },
           {
             "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
-            "label": "Hogwarts All",
             "eds_icon": "home",
+            "label": "Hogwarts All",
             "viewConfig": {
               "type": "CORE:ReferenceViewConfig",
-              "scope": "school",
-              "recipe": "OperatorView"
+              "recipe": "OperatorView",
+              "scope": "school"
             }
           }
         ]
-      }
+      },
+      "plugin": "@development-framework/dm-core-plugins/view_selector/sidebar"
     },
     {
       "name": "OperatorViewSelector",
       "type": "CORE:UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/view_selector/sidebar",
       "config": {
         "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
         "childTabsOnRender": true,
         "items": [
           {
             "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
-            "label": "Hogwarts All",
             "eds_icon": "home",
+            "label": "Hogwarts All",
             "viewConfig": {
               "type": "CORE:ReferenceViewConfig",
-              "scope": "school",
-              "recipe": "OperatorView"
+              "recipe": "OperatorView",
+              "scope": "school"
             }
           }
         ]
-      }
+      },
+      "plugin": "@development-framework/dm-core-plugins/view_selector/sidebar"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/view_selector/single_view/singleView.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/view_selector/single_view/singleView.recipe.json
@@ -4,10 +4,10 @@
   "initialUiRecipe": {
     "name": "SingleView",
     "type": "CORE:UiRecipe",
-    "plugin": "@development-framework/dm-core-plugins/single_view",
     "config": {
       "type": "CORE:ViewConfig",
       "scope": "content"
-    }
+    },
+    "plugin": "@development-framework/dm-core-plugins/single_view"
   }
 }

--- a/example/app/data_sources/DemoDataSource.json
+++ b/example/app/data_sources/DemoDataSource.json
@@ -1,17 +1,17 @@
 {
   "name": "DemoDataSource",
+  "global_folders": ["global"],
   "repositories": {
     "exampleRepo": {
       "type": "mongo-db",
-      "host": "db",
-      "port": 27017,
-      "username": "maf",
-      "password": "xd7wCEhEx4kszsecYFfC",
-      "tls": false,
-      "database": "DemoDataSource",
       "collection": "default",
-      "data_types": ["blob"]
+      "data_types": ["blob"],
+      "database": "DemoDataSource",
+      "host": "db",
+      "password": "xd7wCEhEx4kszsecYFfC",
+      "port": 27017,
+      "tls": false,
+      "username": "maf"
     }
-  },
-  "global_folders": ["global"]
+  }
 }

--- a/example/app/data_sources/ExtraDataSource.json
+++ b/example/app/data_sources/ExtraDataSource.json
@@ -3,14 +3,14 @@
   "repositories": {
     "exampleRepo": {
       "type": "mongo-db",
-      "host": "db",
-      "port": 27017,
-      "username": "maf",
-      "password": "xd7wCEhEx4kszsecYFfC",
-      "tls": false,
-      "database": "ExtraDataSource",
       "collection": "default",
-      "data_types": []
+      "data_types": [],
+      "database": "ExtraDataSource",
+      "host": "db",
+      "password": "xd7wCEhEx4kszsecYFfC",
+      "port": 27017,
+      "tls": false,
+      "username": "maf"
     }
   }
 }

--- a/packages/dm-core-plugins/blueprints/data_grid/DataGridPluginConfig.json
+++ b/packages/dm-core-plugins/blueprints/data_grid/DataGridPluginConfig.json
@@ -11,15 +11,15 @@
       "name": "title",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "string",
-      "optional": true,
-      "default": ""
+      "default": "",
+      "optional": true
     },
     {
       "name": "description",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "string",
-      "optional": true,
-      "default": ""
+      "default": "",
+      "optional": true
     },
     {
       "name": "fieldNames",
@@ -32,85 +32,85 @@
       "name": "editable",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "boolean",
-      "optional": true,
-      "default": true
+      "default": true,
+      "optional": true
     },
     {
       "name": "showColumns",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "boolean",
-      "optional": true,
-      "default": true
+      "default": true,
+      "optional": true
     },
     {
       "name": "adjustableColumns",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "boolean",
-      "optional": true,
-      "default": true
+      "default": true,
+      "optional": true
     },
     {
       "name": "columnLabels",
       "type": "CORE:BlueprintAttribute",
       "description": "Define column labels or use predefined columns. Predefined values are ABC, ZYX, 123 and you can select those by using the spread operator ['...ABC']. You can also merge the two like this: ['custom field', 'custom field2', '...ABC']",
       "attributeType": "string",
-      "optional": true,
       "default": ["...ABC"],
-      "dimensions": "*"
+      "dimensions": "*",
+      "optional": true
     },
     {
       "name": "showRows",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "boolean",
-      "optional": true,
-      "default": true
+      "default": true,
+      "optional": true
     },
     {
       "name": "adjustableRows",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "boolean",
-      "optional": true,
-      "default": true
+      "default": true,
+      "optional": true
     },
     {
       "name": "movableRows",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "boolean",
-      "optional": true,
-      "default": true
+      "default": true,
+      "optional": true
     },
     {
       "name": "rowLabels",
       "type": "CORE:BlueprintAttribute",
       "description": "Define row labels or use predefined rows. Predefined values are ABC, ZYX, 123and you can select those by using the spread operator ['...ABC']. You can also merge the two like this: ['custom field', 'custom field2', '...ABC']",
       "attributeType": "string",
-      "optional": true,
       "default": ["...123"],
-      "dimensions": "*"
+      "dimensions": "*",
+      "optional": true
     },
     {
       "name": "printDirection",
       "type": "CORE:BlueprintAttribute",
       "description": "Which direction should rows be printed. Horizontal means printing rows top-down, vertical means left-right.",
       "attributeType": "string",
-      "optional": true,
-      "default": "horizontal"
+      "default": "horizontal",
+      "optional": true
     },
     {
       "name": "rowsPerPage",
       "type": "CORE:BlueprintAttribute",
       "description": "How many rows per page should be pre-selected in the pagination when datagrid loads.",
       "attributeType": "number",
-      "optional": true,
-      "default": 25
+      "default": 25,
+      "optional": true
     },
     {
       "name": "hidePaginationIfLessThan",
       "type": "CORE:BlueprintAttribute",
       "description": "Hide the pagination if rows are less than x values.",
       "attributeType": "number",
-      "optional": true,
-      "default": 0
+      "default": 0,
+      "optional": true
     }
   ]
 }

--- a/packages/dm-core-plugins/blueprints/form/FormFunctionalityConfig.json
+++ b/packages/dm-core-plugins/blueprints/form/FormFunctionalityConfig.json
@@ -11,15 +11,15 @@
       "name": "open",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "boolean",
-      "optional": true,
-      "default": true
+      "default": true,
+      "optional": true
     },
     {
       "name": "expand",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "boolean",
-      "optional": true,
-      "default": false
+      "default": false,
+      "optional": true
     }
   ]
 }

--- a/packages/dm-core-plugins/blueprints/form/FormInput.json
+++ b/packages/dm-core-plugins/blueprints/form/FormInput.json
@@ -12,42 +12,42 @@
       "name": "attributes",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
       "attributeType": "PLUGINS:dm-core-plugins/form/fields/Field",
+      "contained": true,
       "dimensions": "*",
-      "optional": true,
-      "contained": true
+      "optional": true
     },
     {
       "name": "fields",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
       "description": "Define which attributes should be shown, and in what order",
       "attributeType": "string",
+      "contained": true,
       "dimensions": "*",
-      "optional": true,
-      "contained": true
+      "optional": true
     },
     {
       "name": "readOnly",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
       "attributeType": "boolean",
-      "optional": true,
       "contained": true,
-      "default": false
+      "default": false,
+      "optional": true
     },
     {
       "name": "showExpanded",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
       "description": "If true, fields will be expanded by default if shown inline.",
       "attributeType": "boolean",
-      "optional": true,
-      "default": true
+      "default": true,
+      "optional": true
     },
     {
       "name": "compactButtons",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
       "description": "If true, the submit and redo buttons in the form will be compact. ",
       "attributeType": "boolean",
-      "optional": true,
-      "default": false
+      "default": false,
+      "optional": true
     },
     {
       "name": "functionality",

--- a/packages/dm-core-plugins/blueprints/form/fields/ArrayField.json
+++ b/packages/dm-core-plugins/blueprints/form/fields/ArrayField.json
@@ -6,22 +6,22 @@
     {
       "name": "widget",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
-      "optional": true,
-      "attributeType": "string"
+      "attributeType": "string",
+      "optional": true
     },
     {
       "name": "uiRecipe",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
-      "optional": true,
-      "attributeType": "string"
+      "attributeType": "string",
+      "optional": true
     },
     {
       "name": "showExpanded",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
       "description": "If true, the attribute will be expanded if shown inline.",
-      "optional": true,
+      "attributeType": "boolean",
       "default": false,
-      "attributeType": "boolean"
+      "optional": true
     },
     {
       "name": "functionality",
@@ -33,8 +33,8 @@
     {
       "name": "template",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
-      "optional": true,
-      "attributeType": "string"
+      "attributeType": "string",
+      "optional": true
     }
   ]
 }

--- a/packages/dm-core-plugins/blueprints/form/fields/Field.json
+++ b/packages/dm-core-plugins/blueprints/form/fields/Field.json
@@ -7,9 +7,9 @@
       "name": "showInline",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
       "description": "If true, the attribute will be shown inline. If false, it will be opened in a new tab if possible",
-      "optional": true,
+      "attributeType": "boolean",
       "default": false,
-      "attributeType": "boolean"
+      "optional": true
     },
     {
       "name": "config",
@@ -22,23 +22,23 @@
       "name": "readOnly",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
       "attributeType": "boolean",
-      "optional": true,
       "contained": true,
-      "default": false
+      "default": false,
+      "optional": true
     },
     {
       "name": "hideOptionalLabel",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
       "attributeType": "boolean",
-      "optional": true,
-      "default": false
+      "default": false,
+      "optional": true
     },
     {
       "name": "label",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "What will be displayed in form. If this is not set, then form will use the attribute 'name'.",
       "attributeType": "string",
-      "optional": true,
-      "description": "What will be displayed in form. If this is not set, then form will use the attribute 'name'."
+      "optional": true
     },
     {
       "name": "tooltip",

--- a/packages/dm-core-plugins/blueprints/form/fields/NumberField.json
+++ b/packages/dm-core-plugins/blueprints/form/fields/NumberField.json
@@ -6,8 +6,8 @@
     {
       "name": "widget",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
-      "optional": true,
-      "attributeType": "string"
+      "attributeType": "string",
+      "optional": true
     },
     {
       "name": "config",

--- a/packages/dm-core-plugins/blueprints/form/fields/ObjectField.json
+++ b/packages/dm-core-plugins/blueprints/form/fields/ObjectField.json
@@ -6,21 +6,21 @@
     {
       "name": "widget",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
-      "optional": true,
-      "attributeType": "string"
+      "attributeType": "string",
+      "optional": true
     },
     {
       "name": "searchByType",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
       "attributeType": "boolean",
-      "optional": true,
-      "default": false
+      "default": false,
+      "optional": true
     },
     {
       "name": "uiRecipe",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
-      "optional": true,
-      "attributeType": "string"
+      "attributeType": "string",
+      "optional": true
     },
     {
       "name": "expandViewConfig",
@@ -47,9 +47,9 @@
       "name": "showExpanded",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
       "description": "If true, the attribute will be expanded if shown inline.",
-      "optional": true,
+      "attributeType": "boolean",
       "default": false,
-      "attributeType": "boolean"
+      "optional": true
     }
   ]
 }

--- a/packages/dm-core-plugins/blueprints/form/fields/StringField.json
+++ b/packages/dm-core-plugins/blueprints/form/fields/StringField.json
@@ -6,15 +6,15 @@
     {
       "name": "widget",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
-      "optional": true,
-      "attributeType": "string"
+      "attributeType": "string",
+      "optional": true
     },
     {
       "name": "format",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
       "attributeType": "string",
-      "label": "Format",
       "default": "",
+      "label": "Format",
       "optional": true
     }
   ]

--- a/packages/dm-core-plugins/blueprints/form/package.json
+++ b/packages/dm-core-plugins/blueprints/form/package.json
@@ -1,25 +1,25 @@
 {
   "name": "form",
   "type": "CORE:Package",
-  "isRoot": false,
   "_meta_": {
     "type": "CORE:Meta",
-    "version": "0.0.1",
     "dependencies": [
       {
         "type": "CORE:Dependency",
-        "alias": "CORE",
         "address": "system/SIMOS",
-        "version": "0.0.1",
-        "protocol": "dmss"
+        "alias": "CORE",
+        "protocol": "dmss",
+        "version": "0.0.1"
       },
       {
         "type": "CORE:Dependency",
-        "alias": "PLUGINS",
         "address": "system/Plugins",
-        "version": "0.0.1",
-        "protocol": "dmss"
+        "alias": "PLUGINS",
+        "protocol": "dmss",
+        "version": "0.0.1"
       }
-    ]
-  }
+    ],
+    "version": "0.0.1"
+  },
+  "isRoot": false
 }

--- a/packages/dm-core-plugins/blueprints/form/widgets/DateTimeWidgetConfig.json
+++ b/packages/dm-core-plugins/blueprints/form/widgets/DateTimeWidgetConfig.json
@@ -27,8 +27,8 @@
       "type": "CORE:BlueprintAttribute",
       "description": "Allow specifying minutes",
       "attributeType": "boolean",
-      "optional": true,
-      "default": false
+      "default": false,
+      "optional": true
     }
   ]
 }

--- a/packages/dm-core-plugins/blueprints/form/widgets/DimensionalScalarWidgetConfig.json
+++ b/packages/dm-core-plugins/blueprints/form/widgets/DimensionalScalarWidgetConfig.json
@@ -6,9 +6,9 @@
     {
       "name": "width",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "Width of the complete widget",
       "attributeType": "string",
-      "optional": true,
-      "description": "Width of the complete widget"
+      "optional": true
     },
     {
       "name": "label",
@@ -37,25 +37,25 @@
     {
       "name": "inputBoxWidth",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "Width of the input box field.",
       "attributeType": "string",
-      "optional": true,
-      "description": "Width of the input box field."
+      "optional": true
     },
     {
       "name": "inline",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "If true, it shows the label of the left side of the input box instead of on the top.",
       "attributeType": "boolean",
-      "optional": true,
       "default": true,
-      "description": "If true, it shows the label of the left side of the input box instead of on the top."
+      "optional": true
     },
     {
       "name": "compact",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "Makes the input box more compact",
       "attributeType": "boolean",
-      "optional": true,
       "default": false,
-      "description": "Makes the input box more compact"
+      "optional": true
     }
   ]
 }

--- a/packages/dm-core-plugins/blueprints/form/widgets/SelectWidgetConfig.json
+++ b/packages/dm-core-plugins/blueprints/form/widgets/SelectWidgetConfig.json
@@ -5,15 +5,15 @@
     {
       "name": "type",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
-      "optional": false,
-      "attributeType": "string"
+      "attributeType": "string",
+      "optional": false
     },
     {
       "name": "multiline",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
-      "optional": true,
+      "attributeType": "boolean",
       "default": false,
-      "attributeType": "boolean"
+      "optional": true
     }
   ]
 }

--- a/packages/dm-core-plugins/blueprints/grid/GridBorder.json
+++ b/packages/dm-core-plugins/blueprints/grid/GridBorder.json
@@ -11,29 +11,29 @@
       "name": "size",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "string",
-      "optional": true,
-      "default": "1px"
+      "default": "1px",
+      "optional": true
     },
     {
       "name": "color",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "string",
-      "optional": true,
-      "default": "black"
+      "default": "black",
+      "optional": true
     },
     {
       "name": "style",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "string",
-      "optional": true,
-      "default": "solid"
+      "default": "solid",
+      "optional": true
     },
     {
       "name": "radius",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "string",
-      "optional": true,
-      "default": "solid"
+      "default": "solid",
+      "optional": true
     }
   ]
 }

--- a/packages/dm-core-plugins/blueprints/grid/GridSize.json
+++ b/packages/dm-core-plugins/blueprints/grid/GridSize.json
@@ -17,8 +17,8 @@
       "name": "columnSizes",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "string",
-      "optional": true,
-      "dimensions": "*"
+      "dimensions": "*",
+      "optional": true
     },
     {
       "name": "rows",
@@ -32,22 +32,22 @@
       "type": "CORE:BlueprintAttribute",
       "description": "Defines row sizes in relation to each other.",
       "attributeType": "string",
-      "optional": true,
-      "dimensions": "*"
+      "dimensions": "*",
+      "optional": true
     },
     {
       "name": "rowGap",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "string",
-      "optional": true,
-      "default": "16px"
+      "default": "16px",
+      "optional": true
     },
     {
       "name": "columnGap",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "string",
-      "optional": true,
-      "default": "16px"
+      "default": "16px",
+      "optional": true
     }
   ]
 }

--- a/packages/dm-core-plugins/blueprints/job/ControlConfig.json
+++ b/packages/dm-core-plugins/blueprints/job/ControlConfig.json
@@ -12,15 +12,15 @@
       "name": "hideLogs",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "boolean",
-      "optional": true,
-      "default": false
+      "default": false,
+      "optional": true
     },
     {
       "name": "runnerTemplates",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "PLUGINS:dm-core-plugins/common/Template",
-      "optional": true,
-      "dimensions": "*"
+      "dimensions": "*",
+      "optional": true
     }
   ]
 }

--- a/packages/dm-core-plugins/blueprints/job/CreateConfig.json
+++ b/packages/dm-core-plugins/blueprints/job/CreateConfig.json
@@ -12,33 +12,33 @@
       "name": "recurring",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "boolean",
-      "optional": true,
-      "default": false
+      "default": false,
+      "optional": true
     },
     {
       "name": "hideLogs",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "boolean",
-      "optional": true,
-      "default": false
+      "default": false,
+      "optional": true
     },
     {
       "name": "jobTemplates",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "PLUGINS:dm-core-plugins/common/Template",
-      "optional": true,
-      "dimensions": "*"
+      "dimensions": "*",
+      "optional": true
     },
     {
       "name": "jobTargetAddress",
-      "description": "Where the created jobs should be placed. Absolute or relative address",
       "type": "CORE:BlueprintAttribute",
+      "description": "Where the created jobs should be placed. Absolute or relative address",
       "attributeType": "string"
     },
     {
       "name": "jobInputAddress",
-      "description": "'applicationInput' for the created job. Absolute or relative address",
       "type": "CORE:BlueprintAttribute",
+      "description": "'applicationInput' for the created job. Absolute or relative address",
       "attributeType": "string",
       "optional": true
     }

--- a/packages/dm-core-plugins/blueprints/list/FunctionalityConfig.json
+++ b/packages/dm-core-plugins/blueprints/list/FunctionalityConfig.json
@@ -11,43 +11,43 @@
       "name": "delete",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "boolean",
-      "optional": true,
-      "default": true
+      "default": true,
+      "optional": true
     },
     {
       "name": "add",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "boolean",
-      "optional": true,
-      "default": true
+      "default": true,
+      "optional": true
     },
     {
       "name": "edit",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "boolean",
-      "optional": true,
-      "default": true
+      "default": true,
+      "optional": true
     },
     {
       "name": "sort",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "boolean",
-      "optional": true,
-      "default": true
+      "default": true,
+      "optional": true
     },
     {
       "name": "open",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "boolean",
-      "optional": true,
-      "default": false
+      "default": false,
+      "optional": true
     },
     {
       "name": "expand",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "boolean",
-      "optional": true,
-      "default": true
+      "default": true,
+      "optional": true
     }
   ]
 }

--- a/packages/dm-core-plugins/blueprints/list/ListPluginConfig.json
+++ b/packages/dm-core-plugins/blueprints/list/ListPluginConfig.json
@@ -12,24 +12,24 @@
       "type": "CORE:BlueprintAttribute",
       "description": "Initial expand state for items in list",
       "attributeType": "boolean",
-      "optional": true,
-      "default": false
+      "default": false,
+      "optional": true
     },
     {
       "name": "compact",
       "type": "CORE:BlueprintAttribute",
       "description": "If table should be more compact, with less padding and smaller icons. ",
       "attributeType": "boolean",
-      "optional": true,
-      "default": false
+      "default": false,
+      "optional": true
     },
     {
       "name": "saveExpanded",
       "type": "CORE:BlueprintAttribute",
       "description": "Use save button to save expanded items.",
       "attributeType": "boolean",
-      "optional": true,
-      "default": false
+      "default": false,
+      "optional": true
     },
     {
       "name": "selectFromScope",
@@ -43,8 +43,8 @@
       "type": "CORE:BlueprintAttribute",
       "description": "When appending to the list, whether or not the user should see invalid types in the entity selector",
       "attributeType": "boolean",
-      "optional": true,
-      "default": false
+      "default": false,
+      "optional": true
     },
     {
       "name": "headers",
@@ -80,16 +80,16 @@
       "type": "CORE:BlueprintAttribute",
       "description": "Attribute on parent (of same type as list) which should be used as template when instantiating new items. (e.g. 'template' will use the 'template' attribute on the parent.)",
       "attributeType": "PLUGINS:dm-core-plugins/common/Template",
-      "optional": true,
-      "dimensions": "*"
+      "dimensions": "*",
+      "optional": true
     },
     {
       "name": "labelByIndex",
       "type": "CORE:BlueprintAttribute",
       "description": "Control whether index should be appended to label when list item is opened.",
       "attributeType": "boolean",
-      "optional": true,
-      "default": false
+      "default": false,
+      "optional": true
     },
     {
       "name": "label",

--- a/packages/dm-core-plugins/blueprints/table/TableColumnConfig.json
+++ b/packages/dm-core-plugins/blueprints/table/TableColumnConfig.json
@@ -18,8 +18,8 @@
       "name": "dataType",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "string",
-      "optional": true,
-      "default": "string"
+      "default": "string",
+      "optional": true
     },
     {
       "name": "presentAs",
@@ -41,15 +41,15 @@
       "type": "CORE:BlueprintAttribute",
       "description": "Should data be editable in table edit mode.",
       "attributeType": "boolean",
-      "optional": true,
-      "default": true
+      "default": true,
+      "optional": true
     },
     {
       "name": "sortable",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "boolean",
-      "optional": true,
-      "default": true
+      "default": true,
+      "optional": true
     }
   ]
 }

--- a/packages/dm-core-plugins/blueprints/table/TableFunctionalityConfig.json
+++ b/packages/dm-core-plugins/blueprints/table/TableFunctionalityConfig.json
@@ -11,15 +11,15 @@
       "name": "delete",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "boolean",
-      "optional": true,
-      "default": false
+      "default": false,
+      "optional": true
     },
     {
       "name": "add",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "boolean",
-      "optional": true,
-      "default": false
+      "default": false,
+      "optional": true
     }
   ]
 }

--- a/packages/dm-core-plugins/blueprints/table/TablePluginConfig.json
+++ b/packages/dm-core-plugins/blueprints/table/TablePluginConfig.json
@@ -12,21 +12,20 @@
       "type": "CORE:BlueprintAttribute",
       "description": "Define table variants. Initial variant will be decided by which variant is passed first. Variants are 'view' and 'edit'",
       "attributeType": "PLUGINS:dm-core-plugins/table/TableVariantConfig",
-      "optional": true,
-      "dimensions": "*",
       "default": [
         {
           "name": "view",
           "type": "PLUGINS:dm-core-plugins/table/TableVariantConfig"
         }
-      ]
+      ],
+      "dimensions": "*",
+      "optional": true
     },
     {
       "name": "columns",
       "type": "CORE:BlueprintAttribute",
       "description": "Name of primitive child attributes to display in header of item",
       "attributeType": "PLUGINS:dm-core-plugins/table/TableColumnConfig",
-      "optional": true,
       "default": [
         {
           "type": "./TableColumnConfig",
@@ -39,7 +38,8 @@
           "editable": false
         }
       ],
-      "dimensions": "*"
+      "dimensions": "*",
+      "optional": true
     },
     {
       "name": "expandableRecipeViewConfig",
@@ -52,16 +52,16 @@
       "type": "CORE:BlueprintAttribute",
       "description": "Attribute on parent (of same type as list) which should be used as template when instantiating new items. (e.g. 'template' will use the 'template' attribute on the parent.)",
       "attributeType": "PLUGINS:dm-core-plugins/common/Template",
-      "optional": true,
-      "dimensions": "*"
+      "dimensions": "*",
+      "optional": true
     },
     {
       "name": "labelByIndex",
       "type": "CORE:BlueprintAttribute",
       "description": "Control whether index should be appended to label when table item is opened.",
       "attributeType": "boolean",
-      "optional": true,
-      "default": false
+      "default": false,
+      "optional": true
     },
     {
       "name": "label",

--- a/packages/dm-core-plugins/blueprints/table/TableVariantConfig.json
+++ b/packages/dm-core-plugins/blueprints/table/TableVariantConfig.json
@@ -26,12 +26,12 @@
       "type": "CORE:BlueprintAttribute",
       "description": "Table functionality config",
       "attributeType": "PLUGINS:dm-core-plugins/table/TableFunctionalityConfig",
-      "optional": true,
       "default": {
         "type": "PLUGINS:dm-core-plugins/table/TableFunctionalityConfig",
         "add": true,
         "delete": true
-      }
+      },
+      "optional": true
     }
   ]
 }

--- a/packages/dm-core-plugins/blueprints/view_selector/RecipeSelectorConfig.json
+++ b/packages/dm-core-plugins/blueprints/view_selector/RecipeSelectorConfig.json
@@ -11,8 +11,8 @@
       "name": "viewConfig",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "CORE:ViewConfig",
-      "dimensions": "*",
       "contained": true,
+      "dimensions": "*",
       "optional": true
     }
   ]

--- a/packages/dm-core-plugins/blueprints/view_selector/ViewSelectorConfig.json
+++ b/packages/dm-core-plugins/blueprints/view_selector/ViewSelectorConfig.json
@@ -11,15 +11,15 @@
       "name": "childTabsOnRender",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "boolean",
-      "optional": true,
-      "default": true
+      "default": true,
+      "optional": true
     },
     {
       "name": "items",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
-      "dimensions": "*",
       "contained": true,
+      "dimensions": "*",
       "optional": true
     }
   ]

--- a/packages/dm-core-plugins/blueprints/view_selector/ViewSelectorItem.json
+++ b/packages/dm-core-plugins/blueprints/view_selector/ViewSelectorItem.json
@@ -29,8 +29,8 @@
       "name": "subItems",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
-      "optional": true,
-      "dimensions": "*"
+      "dimensions": "*",
+      "optional": true
     }
   ]
 }

--- a/packages/dm-core-plugins/tsconfig.json
+++ b/packages/dm-core-plugins/tsconfig.json
@@ -9,5 +9,9 @@
     "src",
     "src/**/*.json"
   ],
-  "exclude": ["node_modules", "src/**/*.spec.ts", "dist"]
+  "exclude": [
+    "node_modules",
+    "src/**/*.spec.ts",
+    "dist"
+  ]
 }

--- a/packages/dm-core/tsconfig.json
+++ b/packages/dm-core/tsconfig.json
@@ -8,7 +8,6 @@
       "dom.iterable",
       "esnext"
     ],
-    
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,12 +1,70 @@
 {
-  "release-type": "node",
-  "monorepo-tags": true,
+  "always-link-local": true,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
-  "prerelease": true,
-  "separate-pull-requests": false,
-  "plugins": ["node-workspace"],
-  "always-link-local": true,
+  "changelog-sections": [
+    {
+      "type": "feat",
+      "hidden": false,
+      "section": "Features"
+    },
+    {
+      "type": "feature",
+      "hidden": false,
+      "section": "Features"
+    },
+    {
+      "type": "fix",
+      "hidden": false,
+      "section": "Bug Fixes"
+    },
+    {
+      "type": "perf",
+      "hidden": false,
+      "section": "Performance Improvements"
+    },
+    {
+      "type": "revert",
+      "hidden": false,
+      "section": "Reverts"
+    },
+    {
+      "type": "docs",
+      "hidden": false,
+      "section": "Documentation"
+    },
+    {
+      "type": "style",
+      "hidden": false,
+      "section": "Styles"
+    },
+    {
+      "type": "chore",
+      "hidden": false,
+      "section": "Miscellaneous Chores"
+    },
+    {
+      "type": "refactor",
+      "hidden": false,
+      "section": "Code Refactoring"
+    },
+    {
+      "type": "test",
+      "hidden": false,
+      "section": "Tests"
+    },
+    {
+      "type": "build",
+      "hidden": false,
+      "section": "Build System"
+    },
+    {
+      "type": "ci",
+      "hidden": false,
+      "section": "Continuous Integration"
+    }
+  ],
+  "monorepo-tags": true,
   "packages": {
     "packages/dm-core": {
       "package-name": "@development-framework/dm-core"
@@ -15,18 +73,8 @@
       "package-name": "@development-framework/dm-core-plugins"
     }
   },
-  "changelog-sections": [
-    { "type": "feat", "section": "Features", "hidden": false },
-    { "type": "feature", "section": "Features", "hidden": false },
-    { "type": "fix", "section": "Bug Fixes", "hidden": false },
-    { "type": "perf", "section": "Performance Improvements", "hidden": false },
-    { "type": "revert", "section": "Reverts", "hidden": false },
-    { "type": "docs", "section": "Documentation", "hidden": false },
-    { "type": "style", "section": "Styles", "hidden": false },
-    { "type": "chore", "section": "Miscellaneous Chores", "hidden": false },
-    { "type": "refactor", "section": "Code Refactoring", "hidden": false },
-    { "type": "test", "section": "Tests", "hidden": false },
-    { "type": "build", "section": "Build System", "hidden": false },
-    { "type": "ci", "section": "Continuous Integration", "hidden": false }
-  ]
+  "plugins": ["node-workspace"],
+  "prerelease": true,
+  "release-type": "node",
+  "separate-pull-requests": false
 }


### PR DESCRIPTION
## What does this pull request change?

Makes sure "name", "_id", "description", "extends" is on top. 
Then it sorts keys alfabetically. 
Is not enabled all the time due to issues with biome linter that also lints json, so double linter is not necessary. 

## Why is this pull request needed?

## Issues related to this change

