### PR TITLE
fix: adding files from outside package created bad dist structure

### DIFF
--- a/packages/dm-core-plugins/tsconfig.json
+++ b/packages/dm-core-plugins/tsconfig.json
@@ -7,8 +7,7 @@
   },
   "include": [
     "src",
-    "src/**/*.json",
-    "../dm-core/src/components/NewListItemButton.tsx"
+    "src/**/*.json"
   ],
   "exclude": ["node_modules", "src/**/*.spec.ts", "dist"]
 }


### PR DESCRIPTION
## What does this pull request change?
- Don't include files from outside package. That caused the build dist folder to have an unexpected structure

## Why is this pull request needed?
- All imports from dm-core-plugins failed
