### PR TITLE
feat: CopyDialog can now hide provided fields and overwrite title

### DIFF
--- a/packages/dm-core/src/Enums.ts
+++ b/packages/dm-core/src/Enums.ts
@@ -22,6 +22,7 @@ export enum EBlueprint {
 
   CRON_JOB = 'dmss://WorkflowDS/Blueprints/CronJob',
   REFERENCE = 'dmss://system/SIMOS/Reference',
+  META = 'dmss://system/SIMOS/Meta',
   FILE = 'dmss://system/SIMOS/File',
 }
 

--- a/packages/dm-core/src/components/CopyLinkDialog.tsx
+++ b/packages/dm-core/src/components/CopyLinkDialog.tsx
@@ -19,13 +19,23 @@ type TProps = {
   open: boolean
   setOpen: (v: boolean) => void
   mode?: 'copy' | 'link'
+  title?: string
+  buttonText?: string
   destination?: string
   hideProvidedFields?: boolean
 }
 
 export const CopyLinkDialog = (props: TProps) => {
-  const { idReference, mode, destination, open, setOpen, hideProvidedFields } =
-    props
+  const {
+    idReference,
+    mode,
+    destination,
+    open,
+    setOpen,
+    hideProvidedFields,
+    title,
+    buttonText,
+  } = props
   const [selectedDestination, setSelectedDestination] =
     useState<TEntityPickerReturn>({
       address: destination || '',
@@ -35,7 +45,6 @@ export const CopyLinkDialog = (props: TProps) => {
   const [selectedMode, setSelectedMode] = useState<'copy' | 'link'>(
     mode || 'copy'
   )
-  // const [showCopyDialog, setShowCopyDialog] = useState<boolean>(open)
   const [showDestinationDialog, setShowDestinationDialog] =
     useState<boolean>(false)
   const { document, isLoading: documentIsLoading } = useDocument<TValidEntity>(
@@ -92,9 +101,9 @@ export const CopyLinkDialog = (props: TProps) => {
   }
 
   return (
-    <Dialog open={open} width={'100%'} height={'300px'}>
+    <Dialog open={open} width={'100%'}>
       <Dialog.Header>
-        <Dialog.Title>Copy or link entity</Dialog.Title>
+        <Dialog.Title>{title || 'Copy or link entity'}</Dialog.Title>
       </Dialog.Header>
       <Dialog.CustomContent>
         <EntityPickerDialog
@@ -105,20 +114,26 @@ export const CopyLinkDialog = (props: TProps) => {
             setSelectedDestination(v)
           }}
         />
-        <div className={'flex justify-between align-center'}>
-          <div className={'flex items-center'}>
-            <Label label='Destination:' />
-            <p>{selectedDestination.path || '-'}</p>
+        {(!destination || !hideProvidedFields) && (
+          <div className={'flex justify-between align-center'}>
+            <div className={'flex items-center'}>
+              <Label label='Destination:' />
+              <p>{selectedDestination.path || '-'}</p>
+            </div>
+            <Button onClick={() => setShowDestinationDialog(true)}>
+              Browse
+            </Button>
           </div>
-          <Button onClick={() => setShowDestinationDialog(true)}>Browse</Button>
-        </div>
-        <Checkbox
-          label='Copy as link'
-          checked={selectedMode === 'link'}
-          onChange={(e: ChangeEvent<HTMLInputElement>) =>
-            setSelectedMode(e.target.checked ? 'link' : 'copy')
-          }
-        />
+        )}
+        {(!mode || !hideProvidedFields) && (
+          <Checkbox
+            label='Copy as link'
+            checked={selectedMode === 'link'}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              setSelectedMode(e.target.checked ? 'link' : 'copy')
+            }
+          />
+        )}
       </Dialog.CustomContent>
       <Dialog.Actions>
         <div className={'flex justify-around w-full'}>
@@ -139,13 +154,14 @@ export const CopyLinkDialog = (props: TProps) => {
               }
             }}
           >
-            {isLoading ? (
-              <Progress.Dots />
-            ) : selectedMode === 'copy' ? (
-              'Copy'
-            ) : (
-              'Insert link'
-            )}
+            {buttonText ||
+              (isLoading ? (
+                <Progress.Dots />
+              ) : selectedMode === 'copy' ? (
+                'Copy'
+              ) : (
+                'Insert link'
+              ))}
           </Button>
         </div>
       </Dialog.Actions>

--- a/packages/dm-core/src/types.ts
+++ b/packages/dm-core/src/types.ts
@@ -1,3 +1,4 @@
+import { EBlueprint } from './Enums'
 import { JobStatus } from './services/api/configs/gen-job'
 
 export type TDataSource = {
@@ -100,6 +101,16 @@ export type TContainerJobHandler = {
   environmentVariables?: string[]
 }
 
+export type TMeta = {
+  type: EBlueprint.META
+  version: string
+  dependencies: any[]
+  createdBy?: string
+  createdTimestamp?: string
+  lastModifiedBy?: string
+  lastModifiedTimestamp?: string
+}
+
 export type TJob = {
   _id?: string
   label?: string
@@ -135,6 +146,7 @@ export type TJobWithRunner = TJob & {
 }
 
 type TValidAttribute =
+  | undefined
   | string
   | number
   | boolean
@@ -143,6 +155,7 @@ type TValidAttribute =
 
 export type TValidEntity = {
   type: string
+  _meta_?: TMeta
   [key: string]: TValidAttribute
 }
 

--- a/packages/dm-core/src/utils/setMetaInDocument.ts
+++ b/packages/dm-core/src/utils/setMetaInDocument.ts
@@ -1,0 +1,21 @@
+import { EBlueprint } from '../Enums'
+import { TMeta, TValidEntity } from '../types'
+
+export function setMetaInDocument(
+  document: TValidEntity,
+  user: string
+): TValidEntity {
+  const meta: TMeta = document._meta_ || {
+    type: EBlueprint.META,
+    version: '0.0.1',
+    dependencies: [],
+    createdBy: user,
+    createdTimestamp: new Date().toISOString(),
+  }
+  document._meta_ = {
+    ...meta,
+    lastModifiedBy: user,
+    lastModifiedTimestamp: new Date().toISOString(),
+  }
+  return document
+}


### PR DESCRIPTION
## What does this pull request change?
- Override text in copy/link popup (so it can be used for "publishing")
- On copy, update entities _meta_
- Option to hide config of values that are provided


## Issues related to this change
closes #1148 
