### PR TITLE
fix: URL type can be used with hyperlinkwidget

### DIFF
--- a/example/app/data/DemoDataSource/plugins/form/hyperlinks/LinkForm.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/form/hyperlinks/LinkForm.blueprint.json
@@ -12,6 +12,16 @@
       "name": "stringLink2",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "string"
+    },
+    {
+      "name": "urlLink1",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "CORE:Url"
+    },
+    {
+      "name": "urlLink2",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "CORE:Url"
     }
   ]
 }

--- a/example/app/data/DemoDataSource/plugins/form/hyperlinks/LinkForm.entity.json
+++ b/example/app/data/DemoDataSource/plugins/form/hyperlinks/LinkForm.entity.json
@@ -3,5 +3,15 @@
   "type": "./LinkForm",
   "_id": "linkForm",
   "stringLink1": "https://google.com",
-  "stringLink2": "http://localhost:3000/view/?documentId=dmss://DemoDataSource/$linkForm"
+  "stringLink2": "http://localhost:3000/view/?documentId=dmss://DemoDataSource/$linkForm",
+  "urlLink1": {
+    "type": "CORE:Url",
+    "value": "http://example.com",
+    "label": "Url Complex Link"
+  },
+  "urlLink2": {
+    "type": "CORE:Url",
+    "value": "http://localhost:3000/view/?documentId=dmss://DemoDataSource/$linkForm",
+    "label": "Core:Url"
+  }
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/form/hyperlinks/LinkForm.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/hyperlinks/LinkForm.recipe.json
@@ -23,9 +23,19 @@
             "type": "PLUGINS:dm-core-plugins/form/widgets/HyperlinkWidgetConfig",
             "label": "Go To This Page"
           }
+        },
+        {
+          "name": "urlLink1",
+          "type": "PLUGINS:dm-core-plugins/form/fields/ObjectField",
+          "widget": "HyperlinkWidget"
+        },
+        {
+          "name": "urlLink2",
+          "type": "PLUGINS:dm-core-plugins/form/fields/ObjectField",
+          "widget": "HyperlinkWidget"
         }
       ],
-      "fields": ["stringLink1", "stringLink2"]
+      "fields": ["stringLink1", "stringLink2", "urlLink1", "urlLink2"]
     }
   }
 }

--- a/example/app/data/DemoDataSource/recipes/plugins/form/hyperlinks/LinkForm.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/hyperlinks/LinkForm.recipe.json
@@ -27,7 +27,11 @@
         {
           "name": "urlLink1",
           "type": "PLUGINS:dm-core-plugins/form/fields/ObjectField",
-          "widget": "HyperlinkWidget"
+          "widget": "HyperlinkWidget",
+          "config": {
+            "type": "PLUGINS:dm-core-plugins/form/widgets/HyperlinkWidgetConfig",
+            "label": "Overwritten from Config"
+          }
         },
         {
           "name": "urlLink2",

--- a/example/docker-compose.yaml
+++ b/example/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   dmss:
-    image: datamodelingtool.azurecr.io/dmss:v1.16.2
+    image: datamodelingtool.azurecr.io/dmss:v1.18.0
     platform: linux/amd64
     restart: unless-stopped
     environment:

--- a/packages/dm-core-plugins/src/form/widgets/HyperlinkWidget.tsx
+++ b/packages/dm-core-plugins/src/form/widgets/HyperlinkWidget.tsx
@@ -9,10 +9,38 @@ function ensureProtocol(url: string): string {
   return url
 }
 
+function isComplex(value: string | object) {
+  if (typeof value === 'object') return true
+  if (typeof value === 'string') return false
+  throw new Error('Invalid data type of value')
+}
+
+function isUrl(value: any): value is Url {
+  return (
+    value &&
+    typeof (value.value === 'string') &&
+    (typeof (value.label === 'string') || typeof value.label === 'undefined')
+  )
+}
+
+type Url = {
+  value: string
+  label?: string
+}
+
 const HyperlinkWidget = (props: TWidget) => {
   const { value, config } = props
 
-  const url = ensureProtocol(value)
+  let url
+  let label
+  if (isComplex(value) && isUrl(value)) {
+    url = value.value
+    label = config?.label || value.label
+  } else {
+    url = value
+    label = config?.label
+  }
+  url = ensureProtocol(url)
   return (
     <div
       style={{
@@ -30,7 +58,7 @@ const HyperlinkWidget = (props: TWidget) => {
               style={{ transform: 'rotate(315deg)' }}
               className='me-1'
             />
-            {config?.label ?? url}
+            {label ?? url}
           </Typography>
         </a>
       </Tooltip>


### PR DESCRIPTION
## What does this pull request change?

Url type can now be used with HyperlinkWidget, as well as with simple strings. 

## Why is this pull request needed?

## Issues related to this change

