### PR TITLE
fix(form): bad idRef concat for 2-nd-child

### DIFF
--- a/packages/dm-core-plugins/src/form/templates/ObjectModelContainedTemplate.tsx
+++ b/packages/dm-core-plugins/src/form/templates/ObjectModelContainedTemplate.tsx
@@ -95,7 +95,7 @@ export const ObjectModelContainedTemplate = (
       </FormTemplate.Header>
       <FormTemplate.Content expanded={!!isExpanded} canExpand={!!canExpand}>
         <ViewCreator
-          idReference={`${idReference}.${namePath}`}
+          idReference={`${idReference}.${attribute.name}`}
           onOpen={onOpen}
           viewConfig={getExpandViewConfig(uiAttribute)}
           onChange={(data: Record<string, unknown>) =>


### PR DESCRIPTION
## What does this pull request change?
- When constructing the idReference to children in "Form/ObjectField", append attributeName, not namePath since namePath can have multiple "levels"

![Screenshot_20240125_122442](https://github.com/equinor/dm-core-packages/assets/11062560/290307f1-6b78-4389-a5c7-5514791a0b94)
Profile is back

## Why is this pull request needed?
- seconds level form contained object could not be found because of a badly constructed "idReference"
