### PR TITLE
fix: set depth to template to 1

### DIFF
--- a/packages/dm-core/src/hooks/useList/useList.test.tsx
+++ b/packages/dm-core/src/hooks/useList/useList.test.tsx
@@ -451,6 +451,18 @@ const setupNonContained = () => {
       ],
       '1': [
         {
+          referenceType: 'link',
+          address: '$1',
+          type: 'dmss://system/SIMOS/Reference',
+        },
+        {
+          referenceType: 'link',
+          address: '$2',
+          type: 'dmss://system/SIMOS/Reference',
+        },
+      ],
+      '2': [
+        {
           name: 'document1',
           description: 'Description1',
         },

--- a/packages/dm-core/src/hooks/useList/useList.tsx
+++ b/packages/dm-core/src/hooks/useList/useList.tsx
@@ -104,7 +104,7 @@ export function useList<T extends object>(
         newEntity = (
           await dmssAPI.documentGet({
             address: resolveRelativeAddressSimplified(template, idReference),
-            depth: 99,
+            depth: 1,
           })
         ).data
       } else {


### PR DESCRIPTION
## What does this pull request change?

* Set depth to 1 to keep the references when create entities from templates

## Why is this pull request needed?

## Issues related to this change

