### PR TITLE
feat: pass up selected month

### DIFF
--- a/packages/dm-core/src/components/Pickers/Datepicker/Calendar.tsx
+++ b/packages/dm-core/src/components/Pickers/Datepicker/Calendar.tsx
@@ -170,7 +170,7 @@ export const Calendar = (props: CalendarProps): ReactElement => {
                   Object.keys(CALENDAR_MONTHS)[date.month - 1]
                 }`}
                 className={`
-                p-1.5 w-9 rounded-full justify-center hover:bg-equinor-lightgreen hover:text-equinor-green ${
+                p-1.5 w-9 rounded-full relative justify-center hover:bg-equinor-lightgreen hover:text-equinor-green ${
                   isSelected
                     ? 'bg-equinor-lightgreen text-equinor-green font-medium'
                     : isSameMonth(
@@ -184,16 +184,23 @@ export const Calendar = (props: CalendarProps): ReactElement => {
                       : 'text-slate-400'
                 }
               `}
-                style={
-                  isHighlighted && !isSelected
-                    ? { backgroundColor: '#ffe8d6', fontWeight: 'bold' }
-                    : isHighlighted
-                      ? { fontWeight: 'bold' }
-                      : {}
-                }
                 key={index}
               >
                 {date.day}
+                {isHighlighted && (
+                  <span
+                    style={{
+                      color: '#0b5d65',
+                      position: 'absolute',
+                      bottom: '-1px',
+                      left: 'calc(50% - 5px)',
+                      width: '10px',
+                      fontSize: '0.6rem',
+                    }}
+                  >
+                    &#9679;
+                  </span>
+                )}
               </button>
             )
           })}

--- a/packages/dm-core/src/components/Pickers/Datepicker/Calendar.tsx
+++ b/packages/dm-core/src/components/Pickers/Datepicker/Calendar.tsx
@@ -6,7 +6,7 @@ import {
   chevron_right,
 } from '@equinor/eds-icons'
 import { DateTime } from 'luxon'
-import { ReactElement, useState } from 'react'
+import { ReactElement, useEffect, useState } from 'react'
 import {
   CALENDAR_MONTHS,
   DateSelection,
@@ -24,6 +24,7 @@ interface CalendarProps {
   dateTime: DateTime | null
   handleDateSelection: (selection: DateSelection) => void
   highlightedDates?: Date[]
+  onChangeMonthView?: (year: number, month: number) => void
 }
 
 export const Calendar = (props: CalendarProps): ReactElement => {
@@ -38,6 +39,10 @@ export const Calendar = (props: CalendarProps): ReactElement => {
   const cal = calendar(activeMonth, activeYear)
 
   const currentMonthName = Object.keys(CALENDAR_MONTHS)[activeMonth - 1]
+
+  useEffect(() => {
+    props.onChangeMonthView?.(activeYear, activeMonth)
+  }, [activeMonth, activeYear])
 
   function incrementMonth(): void {
     const nextMonth = getNextMonth(activeMonth, activeYear)
@@ -153,7 +158,10 @@ export const Calendar = (props: CalendarProps): ReactElement => {
               DateTime.fromObject(date).toJSDate(),
               props.highlightedDates
             )
-
+            const isSelected = isSameDay(
+              DateTime.fromObject(date).toJSDate(),
+              dateTime ? dateTime.toJSDate() : DateTime.now().toJSDate()
+            )
             return (
               <button
                 type='button'
@@ -163,10 +171,7 @@ export const Calendar = (props: CalendarProps): ReactElement => {
                 }`}
                 className={`
                 p-1.5 w-9 rounded-full justify-center hover:bg-equinor-lightgreen hover:text-equinor-green ${
-                  isSameDay(
-                    DateTime.fromObject(date).toJSDate(),
-                    dateTime ? dateTime.toJSDate() : DateTime.now().toJSDate()
-                  )
+                  isSelected
                     ? 'bg-equinor-lightgreen text-equinor-green font-medium'
                     : isSameMonth(
                           DateTime.fromObject(date).toJSDate(),
@@ -178,8 +183,14 @@ export const Calendar = (props: CalendarProps): ReactElement => {
                       ? ''
                       : 'text-slate-400'
                 }
-                ${isHighlighted ? 'font-bold underline' : ''}
               `}
+                style={
+                  isHighlighted && !isSelected
+                    ? { backgroundColor: '#ffe8d6', fontWeight: 'bold' }
+                    : isHighlighted
+                      ? { fontWeight: 'bold' }
+                      : {}
+                }
                 key={index}
               >
                 {date.day}

--- a/packages/dm-core/src/components/Pickers/Datepicker/Datepicker.tsx
+++ b/packages/dm-core/src/components/Pickers/Datepicker/Datepicker.tsx
@@ -18,6 +18,7 @@ interface DatepickerProps {
   helperText?: string
   isDirty?: boolean
   hightlightedDates?: string[]
+  onChangeMonthView?: (year: number, month: number) => void
 }
 
 export const Datepicker = (props: DatepickerProps): ReactElement => {
@@ -31,6 +32,7 @@ export const Datepicker = (props: DatepickerProps): ReactElement => {
     label,
     helperText,
     isDirty,
+    onChangeMonthView,
   } = props
   const [open, setOpen] = useState(false)
   const [openTop, setOpenTop] = useState(false)
@@ -206,6 +208,7 @@ export const Datepicker = (props: DatepickerProps): ReactElement => {
             dateTime={datetime}
             handleDateSelection={handleDateSelection}
             highlightedDates={props.hightlightedDates?.map((d) => new Date(d))}
+            onChangeMonthView={onChangeMonthView}
           />
           {variant === 'datetime' && (
             <>


### PR DESCRIPTION
## What does this pull request change?

Welcome to my pr. 

This changes 2️⃣ things: 


1. Slight different view for the highlighted dates that have data. 

<img width="948" alt="image" src="https://github.com/equinor/dm-core-packages/assets/37016135/a114717c-50cc-4229-8e7c-bad2ac4afdc5">




3. Pass up which year/month that is currently in the view. 

Earlier the only thing the Calendar/Datepicker told the parent about was which date is currently selected. 
But we need also to know what month is currently in the View. 

This is used in SIMPOS to fetch the dates for this month that have any data. 
We use this to highlight the dates with data, without having to fetch all dates for the whole platform that might have data. So we scope only down to the current view for performance reasons. 

## Why is this pull request needed?

## Issues related to this change

