### PR TITLE
fix: minor changes to some e2e tests and config

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
     // baseURL: 'http://127.0.0.1:3000',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
+    trace: 'retain-on-failure',
     video: 'retain-on-failure',
   },
 

--- a/e2e/tests/plugin-default_recipe.spec.ts
+++ b/e2e/tests/plugin-default_recipe.spec.ts
@@ -4,8 +4,8 @@ test('Form default DMSS UI Recipe', async ({ page }) => {
   await page.goto(
     'http://localhost:3000/view/?documentId=dmss://DemoDataSource/$Form'
   )
+  await expect(page.getByRole('code')).toBeVisible()
   await page.getByRole('tab', { name: 'Edit' }).click()
-
   await expect(page.getByLabel('name')).toHaveValue('Form')
   await expect(page.getByLabel('A required string')).toHaveValue(
     'This form has no dedicated UI Recipe'
@@ -16,25 +16,19 @@ test('Form default DMSS UI Recipe', async ({ page }) => {
 })
 
 test('TableList default DMSS UI Recipe', async ({ page }) => {
-  await test.step('Open plugin', async () => {
-    await page.goto(
-      'http://localhost:3000/view/?documentId=dmss://DemoDataSource/$tableList'
-    )
-    await page.getByRole('tab', { name: 'Edit' }).click()
-  })
-
-  await test.step('Open item in tab', async () => {
-    await page.getByLabel('Open in tab').click()
-    await page
-      .getByRole('row', { name: 'Volvo' })
-      .getByRole('button', { name: 'Expand item', exact: true })
-      .click()
-    await expect(
-      page.getByRole('button', { name: 'Copy as YAML' })
-    ).toBeVisible()
-    await page.getByRole('tab', { name: 'Edit' }).last().click()
-    await expect(page.getByTestId('form-text-widget-Manufacturer')).toHaveValue(
-      'Volvo'
-    )
-  })
+  await page.goto(
+    'http://localhost:3000/view/?documentId=dmss://DemoDataSource/$tableList'
+  )
+  await expect(page.getByRole('code')).toBeVisible()
+  await page.getByRole('tab', { name: 'Edit' }).click()
+  await page.getByLabel('Open in tab').click()
+  await page
+    .getByRole('row', { name: 'Volvo' })
+    .getByRole('button', { name: 'Expand item', exact: true })
+    .click()
+  await expect(page.getByRole('button', { name: 'Copy as YAML' })).toBeVisible()
+  await page.getByRole('tab', { name: 'Edit' }).last().click()
+  await expect(page.getByTestId('form-text-widget-Manufacturer')).toHaveValue(
+    'Volvo'
+  )
 })

--- a/e2e/tests/plugin-explorer.spec.ts
+++ b/e2e/tests/plugin-explorer.spec.ts
@@ -98,4 +98,10 @@ test('Create entity with required name', async ({ page }) => {
   await expect(page.getByRole('alert')).toHaveText(['Entity is created'])
   await page.getByRole('button', { name: 'Jessica' }).click()
   await expect(page.getByTestId('form-text-widget-Name')).toHaveValue('Jessica')
+  await page.getByRole('button', { name: 'Jessica' }).click({
+    button: 'right',
+  })
+  await page.getByRole('menuitem', { name: 'Delete' }).click()
+  await dialog.getByRole('button', { name: 'Delete' }).click()
+  await expect(page.getByRole('button', { name: 'Jessica' })).not.toBeVisible()
 })

--- a/e2e/tests/plugin-form-model_uncontained-complex_attribute.spec.ts
+++ b/e2e/tests/plugin-form-model_uncontained-complex_attribute.spec.ts
@@ -46,5 +46,6 @@ test('Model uncontained complex attribute', async ({ page }) => {
     await expect(page.getByRole('tab', { name: 'captain' })).toBeVisible()
     await expect(page.getByRole('code')).toBeVisible()
     await page.getByRole('button', { name: 'Edit' }).nth(1).click()
+    await expect(page.getByRole('textbox')).toHaveValue('Barbossa')
   })
 })

--- a/e2e/tests/plugin-form-model_uncontained-complex_attribute.spec.ts
+++ b/e2e/tests/plugin-form-model_uncontained-complex_attribute.spec.ts
@@ -38,10 +38,20 @@ test('Model uncontained complex attribute', async ({ page }) => {
     await dialog.getByRole('button', { name: 'model_uncontained' }).click()
     await dialog.getByRole('button', { name: 'complex_attribute' }).click()
     await dialog.getByRole('button', { name: 'Barbossa' }).hover()
-    await page.getByTestId('select-single-entity-button').click()
+
+    await Promise.all([
+      page.waitForResponse(
+        (resp) =>
+          resp
+            .url()
+            .includes(
+              '/api/documents/dmss%3A%2F%2FDemoDataSource%2F%24TheBlackPearl.captain'
+            ) && resp.status() === 200
+      ),
+      await page.getByTestId('select-single-entity-button').click(),
+    ])
+
     await expect(dialog).not.toBeVisible()
-    await page.getByRole('button', { name: 'Submit', exact: true }).click()
-    await expect(page.getByRole('alert')).toHaveText(['Document updated'])
     await page.getByLabel('Open in tab').click()
     await expect(page.getByRole('tab', { name: 'captain' })).toBeVisible()
     await expect(page.getByRole('code')).toBeVisible()


### PR DESCRIPTION
## What does this pull request change?
- Default_recipe: Added a few extra asserts to make the test more robust. Removed test.step as it was unnecessary here.
- Plugin-explorer: Added testing of deleting a entity. This also makes it possible to rerun this test locally without needing to reset app.
- Model-uncontained: The last assert was previously removed because it often failed, but it then also removed checking that we actually could update the model. The assert should be there. Added waiting for api request before proceeding which hopefully solves the previous flakiness.
- Config: Changed tracing to retain on failure as we are not doing any retries in the pipeline. Hopefully this will make it easier to debug as the video often ends to early.

## Why is this pull request needed?

## Issues related to this change

