### PR TITLE
fix: datepicker slight ui changes

### DIFF
--- a/packages/dm-core/src/components/Pickers/Datepicker/Calendar.tsx
+++ b/packages/dm-core/src/components/Pickers/Datepicker/Calendar.tsx
@@ -192,10 +192,10 @@ export const Calendar = (props: CalendarProps): ReactElement => {
                     style={{
                       color: '#0b5d65',
                       position: 'absolute',
-                      bottom: '-1px',
+                      bottom: '-3px',
                       left: 'calc(50% - 5px)',
                       width: '10px',
-                      fontSize: '0.6rem',
+                      fontSize: '0.7rem',
                     }}
                   >
                     &#9679;

--- a/packages/dm-core/src/components/Pickers/Datepicker/Datepicker.tsx
+++ b/packages/dm-core/src/components/Pickers/Datepicker/Datepicker.tsx
@@ -193,7 +193,7 @@ export const Datepicker = (props: DatepickerProps): ReactElement => {
               }
             />
           )}
-          <Icon data={calendar} size={18} className='w-6 mb-1' />
+          <Icon data={calendar} size={18} className='w-6' />
         </div>
       </InputWrapper>
       {open && (


### PR DESCRIPTION
## What does this pull request change?

1. Center calenar icon so it looks better.  Before it was offset by 0.25rem
<img width="696" alt="image" src="https://github.com/equinor/dm-core-packages/assets/37016135/552d71fb-22e1-4442-bb65-7924c3cb9704">

2. Data dots are now slightly larger to make them easier to see. 


<img width="422" alt="image" src="https://github.com/equinor/dm-core-packages/assets/37016135/35f98e4f-76b1-48d2-96ff-1748f470d0fd">


## Why is this pull request needed?

## Issues related to this change

