### PR TITLE
fix: loading ui improvements

### DIFF
--- a/packages/dm-core/src/components/Loading.tsx
+++ b/packages/dm-core/src/components/Loading.tsx
@@ -1,9 +1,18 @@
 import { CircularProgress } from '@equinor/eds-core-react'
+import { useEffect, useState } from 'react'
 
 export const Loading = () => {
+  const [visibility, setVisibility] = useState<'hidden' | 'visible'>('hidden')
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setVisibility('visible')
+    }, 300)
+    return () => clearInterval(interval)
+  }, [])
   return (
-    <div style={{ alignSelf: 'center', padding: '50px' }}>
-      <CircularProgress />
+    <div style={{ padding: '50px', visibility: visibility }}>
+      <CircularProgress size={24} />
     </div>
   )
 }


### PR DESCRIPTION
## What does this pull request change?

So the loading spinner was not so good. 
1. Loaded very 'quickly', making loading seem messy. 
2. Was centered, and made things seem to jump around when loading multiple plugins on the screen. 
3. Was very big, and caused a lot of attention. 


So I made the following changes. 
1. It does not appear immediately, only after loading for 300ms. This is so that components that do load very quickly will not jump around so much. 
2. Made it smaller. 
3. Made it align to top left, so less "jumping around". 

## Why is this pull request needed?

## Issues related to this change

