### PR TITLE
feat: add responsive grid plugin

### DIFF
--- a/example/app/data/DemoDataSource/plugins/responsive_grid/example/blueprints/Dashboard.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/responsive_grid/example/blueprints/Dashboard.blueprint.json
@@ -1,0 +1,33 @@
+{
+  "name": "Dashboard",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "attributes": [
+    {
+      "name": "type",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "name",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "orders",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "./OrderItem",
+      "dimensions": "*"
+    },
+    {
+      "name": "order",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "./OrderItem"
+    },
+    {
+      "name": "aNestedObjectWithCustomUI",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "./Nested",
+      "label": "A nested object with custom ui"
+    }
+  ]
+}

--- a/example/app/data/DemoDataSource/plugins/responsive_grid/example/blueprints/Nested.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/responsive_grid/example/blueprints/Nested.blueprint.json
@@ -1,0 +1,32 @@
+{
+  "name": "Nested",
+  "type": "CORE:Blueprint",
+  "attributes": [
+    {
+      "name": "type",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "foo",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "number",
+      "label": "Foo",
+      "optional": true
+    },
+    {
+      "name": "bar",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string",
+      "label": "Bar",
+      "optional": false
+    },
+    {
+      "name": "baz",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string",
+      "label": "Baz",
+      "optional": true
+    }
+  ]
+}

--- a/example/app/data/DemoDataSource/plugins/responsive_grid/example/blueprints/Order.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/responsive_grid/example/blueprints/Order.blueprint.json
@@ -1,0 +1,17 @@
+{
+  "name": "Order",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "attributes": [
+    {
+      "name": "type",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "items",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "./OrderItem",
+      "dimensions": "*"
+    }
+  ]
+}

--- a/example/app/data/DemoDataSource/plugins/responsive_grid/example/blueprints/OrderItem.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/responsive_grid/example/blueprints/OrderItem.blueprint.json
@@ -1,0 +1,21 @@
+{
+  "name": "OrderItem",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "attributes": [
+    {
+      "name": "type",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "quantity",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "number"
+    },
+    {
+      "name": "product",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "./Product"
+    }
+  ]
+}

--- a/example/app/data/DemoDataSource/plugins/responsive_grid/example/blueprints/Product.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/responsive_grid/example/blueprints/Product.blueprint.json
@@ -1,0 +1,28 @@
+{
+  "name": "Product",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "attributes": [
+    {
+      "name": "type",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "name",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "something",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true
+    },
+    {
+      "name": "price",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "number",
+      "optional": true
+    }
+  ]
+}

--- a/example/app/data/DemoDataSource/plugins/responsive_grid/example/dashboardExample.entity.json
+++ b/example/app/data/DemoDataSource/plugins/responsive_grid/example/dashboardExample.entity.json
@@ -1,0 +1,32 @@
+{
+  "_id": "responsiveDashboardExample",
+  "name": "DashboardExample",
+  "type": "./blueprints/Dashboard",
+  "aNestedObjectWithCustomUI": {
+    "type": "./blueprints/Nested",
+    "bar": "hello",
+    "baz": "testing",
+    "foo": 1337
+  },
+  "order": {
+    "type": "./blueprints/OrderItem",
+    "product": {
+      "name": "Product 1",
+      "type": "./blueprints/Product",
+      "something": "Asdf"
+    },
+    "quantity": 1
+  },
+  "orders": [
+    {
+      "type": "./blueprints/OrderItem",
+      "product": {
+        "_id": "product1",
+        "name": "Product 1",
+        "type": "./blueprints/Product",
+        "something": "Asdf"
+      },
+      "quantity": 1
+    }
+  ]
+}

--- a/example/app/data/DemoDataSource/plugins/responsive_grid/example/productExample.entity.json
+++ b/example/app/data/DemoDataSource/plugins/responsive_grid/example/productExample.entity.json
@@ -1,0 +1,5 @@
+{
+  "_id": "responsiveProduct1",
+  "name": "ProductExample",
+  "type": "./blueprints/Product"
+}

--- a/example/app/data/DemoDataSource/recipes/plugins/responsive_grid/example/dashboard.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/responsive_grid/example/dashboard.recipe.json
@@ -1,0 +1,75 @@
+{
+  "type": "CORE:RecipeLink",
+  "_blueprintPath_": "/plugins/responsive_grid/example/blueprints/Dashboard",
+  "initialUiRecipe": {
+    "name": "Dashboard",
+    "type": "CORE:UiRecipe",
+    "config": {
+      "type": "PLUGINS:dm-core-plugins/responsive_grid/ResponsiveGridPluginConfig",
+      "rows": [
+        {
+          "type": "PLUGINS:dm-core-plugins/responsive_grid/RowItem",
+          "columns": [
+            {
+              "type": "PLUGINS:dm-core-plugins/responsive_grid/ColumnItem",
+              "viewConfig": {
+                "type": "CORE:ReferenceViewConfig",
+                "recipe": "aRecipeName",
+                "scope": "aNestedObjectWithCustomUI"
+              },
+              "size": {
+                "type": "PLUGINS:dm-core-plugins/responsive_grid/ColumnSize",
+                "sm": 12,
+                "md": 4
+              }
+            },
+            {
+              "type": "PLUGINS:dm-core-plugins/responsive_grid/ColumnItem",
+              "viewConfig": {
+                "type": "CORE:ReferenceViewConfig",
+                "recipe": "aRecipeName",
+                "scope": "aNestedObjectWithCustomUI"
+              },
+              "size": {
+                "type": "PLUGINS:dm-core-plugins/responsive_grid/ColumnSize",
+                "sm": 12,
+                "md": 4
+              }
+            }
+          ]
+        },
+        {
+          "type": "PLUGINS:dm-core-plugins/responsive_grid/RowItem",
+          "columns": [
+            {
+              "type": "PLUGINS:dm-core-plugins/responsive_grid/ColumnItem",
+              "viewConfig": {
+                "type": "CORE:ReferenceViewConfig",
+                "recipe": "aRecipeName",
+                "scope": "aNestedObjectWithCustomUI"
+              },
+              "size": {
+                "type": "PLUGINS:dm-core-plugins/responsive_grid/ColumnSize",
+                "sm": 12,
+                "md": 4
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "plugin": "@development-framework/dm-core-plugins/responsive_grid"
+  },
+  "uiRecipes": [
+    {
+      "name": "Yaml",
+      "type": "CORE:UiRecipe",
+      "plugin": "@development-framework/dm-core-plugins/yaml"
+    },
+    {
+      "name": "Edit",
+      "type": "CORE:UiRecipe",
+      "plugin": "@development-framework/dm-core-plugins/form"
+    }
+  ]
+}

--- a/example/app/data/DemoDataSource/recipes/plugins/responsive_grid/example/nested.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/responsive_grid/example/nested.recipe.json
@@ -1,0 +1,40 @@
+{
+  "type": "CORE:RecipeLink",
+  "_blueprintPath_": "/plugins/responsive_grid/example/blueprints/Nested",
+  "initialUiRecipe": {
+    "name": "ViewSelector",
+    "type": "CORE:UiRecipe",
+    "config": {},
+    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
+  },
+  "uiRecipes": [
+    {
+      "name": "custom",
+      "type": "CORE:UiRecipe",
+      "category": "view",
+      "plugin": "@development-framework/dm-core-plugins/yaml"
+    },
+    {
+      "name": "Form",
+      "type": "CORE:UiRecipe",
+      "category": "edit",
+      "plugin": "@development-framework/dm-core-plugins/form"
+    },
+    {
+      "name": "aRecipeName",
+      "type": "CORE:UiRecipe",
+      "category": "edit",
+      "config": {
+        "type": "PLUGINS:dm-core-plugins/form/FormInput",
+        "attributes": [
+          {
+            "name": "bar",
+            "type": "PLUGINS:dm-core-plugins/form/fields/StringField",
+            "widget": "TextareaWidget"
+          }
+        ]
+      },
+      "plugin": "@development-framework/dm-core-plugins/form"
+    }
+  ]
+}

--- a/example/app/data/DemoDataSource/recipes/plugins/responsive_grid/example/order.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/responsive_grid/example/order.recipe.json
@@ -1,0 +1,39 @@
+{
+  "type": "CORE:RecipeLink",
+  "_blueprintPath_": "/plugins/responsive_grid/example/blueprints/Order",
+  "initialUiRecipe": {
+    "name": "ViewSelector",
+    "type": "CORE:UiRecipe",
+    "config": {
+      "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
+      "childTabsOnRender": true
+    },
+    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
+  },
+  "uiRecipes": [
+    {
+      "name": "Form",
+      "type": "CORE:UiRecipe",
+      "plugin": "@development-framework/dm-core-plugins/form"
+    },
+    {
+      "name": "Yaml",
+      "type": "CORE:UiRecipe",
+      "plugin": "@development-framework/dm-core-plugins/yaml"
+    },
+    {
+      "name": "List",
+      "type": "CORE:UiRecipe",
+      "config": {
+        "type": "PLUGINS:dm-core-plugins/list/ListPluginConfig",
+        "functionality": {
+          "type": "PLUGINS:dm-core-plugins/list/FunctionalityConfig",
+          "delete": true
+        },
+        "headers": ["name", "description"]
+      },
+      "dimensions": "*",
+      "plugin": "@development-framework/dm-core-plugins/list"
+    }
+  ]
+}

--- a/example/app/data/DemoDataSource/recipes/plugins/responsive_grid/example/orderItem.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/responsive_grid/example/orderItem.recipe.json
@@ -1,0 +1,55 @@
+{
+  "type": "CORE:RecipeLink",
+  "_blueprintPath_": "/plugins/responsive_grid/example/blueprints/OrderItem",
+  "initialUiRecipe": {
+    "name": "UiRecipesSelector",
+    "type": "CORE:UiRecipe",
+    "config": {
+      "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorConfig",
+      "items": [
+        {
+          "type": "PLUGINS:dm-core-plugins/view_selector/ViewSelectorItem",
+          "label": "Edit",
+          "viewConfig": {
+            "type": "CORE:InlineRecipeViewConfig",
+            "recipe": {
+              "name": "Edit",
+              "type": "CORE:UiRecipe",
+              "description": "Default edit",
+              "plugin": "@development-framework/dm-core-plugins/form"
+            },
+            "scope": "self"
+          }
+        }
+      ]
+    },
+    "plugin": "@development-framework/dm-core-plugins/view_selector/tabs"
+  },
+  "uiRecipes": [
+    {
+      "name": "Yaml",
+      "type": "CORE:UiRecipe",
+      "plugin": "@development-framework/dm-core-plugins/yaml"
+    },
+    {
+      "name": "Form",
+      "type": "CORE:UiRecipe",
+      "plugin": "@development-framework/dm-core-plugins/form"
+    },
+    {
+      "name": "List",
+      "type": "CORE:UiRecipe",
+      "config": {
+        "type": "PLUGINS:dm-core-plugins/list/ListPluginConfig",
+        "functionality": {
+          "type": "PLUGINS:dm-core-plugins/list/FunctionalityConfig",
+          "delete": true,
+          "expand": true
+        },
+        "headers": ["name", "quantity", "type"]
+      },
+      "dimensions": "*",
+      "plugin": "@development-framework/dm-core-plugins/list"
+    }
+  ]
+}

--- a/example/app/data/DemoDataSource/recipes/plugins/responsive_grid/example/product.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/responsive_grid/example/product.recipe.json
@@ -1,0 +1,16 @@
+{
+  "type": "CORE:RecipeLink",
+  "_blueprintPath_": "/plugins/responsive_grid/example/blueprints/Product",
+  "uiRecipes": [
+    {
+      "name": "Yaml",
+      "type": "CORE:UiRecipe",
+      "plugin": "@development-framework/dm-core-plugins/yaml"
+    },
+    {
+      "name": "Form",
+      "type": "CORE:UiRecipe",
+      "plugin": "@development-framework/dm-core-plugins/form"
+    }
+  ]
+}

--- a/packages/dm-core-plugins/blueprints/responsive_grid/ColumnItem.json
+++ b/packages/dm-core-plugins/blueprints/responsive_grid/ColumnItem.json
@@ -1,0 +1,28 @@
+{
+  "name": "ColumnItem",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "attributes": [
+    {
+      "name": "type",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "viewConfig",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "CORE:ViewConfig"
+    },
+    {
+      "name": "title",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true
+    },
+    {
+      "name": "size",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "./ColumnSize",
+      "optional": true
+    }
+  ]
+}

--- a/packages/dm-core-plugins/blueprints/responsive_grid/ColumnSize.json
+++ b/packages/dm-core-plugins/blueprints/responsive_grid/ColumnSize.json
@@ -1,0 +1,47 @@
+{
+  "name": "ColumnSize",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "attributes": [
+    {
+      "name": "type",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "xs",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "number",
+      "optional": true
+    },
+    {
+      "name": "sm",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "number",
+      "optional": true
+    },
+    {
+      "name": "md",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "number",
+      "optional": true
+    },
+    {
+      "name": "lg",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "number",
+      "optional": true
+    },
+    {
+      "name": "xl",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "number",
+      "optional": true
+    },
+    {
+      "name": "xxl",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "number",
+      "optional": true
+    }
+  ]
+}

--- a/packages/dm-core-plugins/blueprints/responsive_grid/ResponsiveGridPluginConfig.json
+++ b/packages/dm-core-plugins/blueprints/responsive_grid/ResponsiveGridPluginConfig.json
@@ -1,0 +1,24 @@
+{
+  "name": "ResponsiveGridPluginConfig",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "attributes": [
+    {
+      "name": "type",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "showItemBorders",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "boolean",
+      "default": false,
+      "optional": true
+    },
+    {
+      "name": "rows",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "PLUGINS:dm-core-plugins/responsive_grid/RowItem",
+      "dimensions": "*"
+    }
+  ]
+}

--- a/packages/dm-core-plugins/blueprints/responsive_grid/RowItem.json
+++ b/packages/dm-core-plugins/blueprints/responsive_grid/RowItem.json
@@ -1,0 +1,18 @@
+{
+  "name": "RowItem",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "attributes": [
+    {
+      "name": "type",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "columns",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "./ColumnItem",
+      "optional": true,
+      "dimensions": "*"
+    }
+  ]
+}

--- a/packages/dm-core-plugins/blueprints/responsive_grid/package.json
+++ b/packages/dm-core-plugins/blueprints/responsive_grid/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "responsive_grid",
+  "type": "CORE:Package",
+  "isRoot": false,
+  "_meta_": {
+    "type": "CORE:Meta",
+    "version": "0.0.1",
+    "dependencies": [
+      {
+        "type": "CORE:Dependency",
+        "alias": "CORE",
+        "address": "system/SIMOS",
+        "version": "0.0.1",
+        "protocol": "dmss"
+      },
+      {
+        "type": "CORE:Dependency",
+        "alias": "PLUGINS",
+        "address": "system/Plugins",
+        "version": "0.0.1",
+        "protocol": "dmss"
+      }
+    ]
+  }
+}

--- a/packages/dm-core-plugins/package.json
+++ b/packages/dm-core-plugins/package.json
@@ -17,7 +17,8 @@
     "react-hook-form": "^7.48.2",
     "react-toastify": "^9.1.3",
     "ts-node": "^10.9.1",
-    "yaml": "^2.3.2"
+    "yaml": "^2.3.2",
+    "react-grid-system": "^8.1.9"
   },
   "devDependencies": {
     "@biomejs/biome": "1.4.1",

--- a/packages/dm-core-plugins/src/index.tsx
+++ b/packages/dm-core-plugins/src/index.tsx
@@ -50,6 +50,13 @@ export default ({
       }))
     ),
   },
+  '@development-framework/dm-core-plugins/responsive_grid': {
+    component: lazy(() =>
+      import('./responsive_grid/ResponsiveGridPlugin').then((module) => ({
+        default: module.ResponsiveGridPlugin,
+      }))
+    ),
+  },
   '@development-framework/dm-core-plugins/view_selector/sidebar': {
     component: lazy(() =>
       import('./view_selector/SidebarPlugin').then((module) => ({

--- a/packages/dm-core-plugins/src/responsive_grid/ResponsiveGridPlugin.tsx
+++ b/packages/dm-core-plugins/src/responsive_grid/ResponsiveGridPlugin.tsx
@@ -1,0 +1,54 @@
+import { IUIPlugin, Stack, ViewCreator } from '@development-framework/dm-core'
+import { Typography } from '@equinor/eds-core-react'
+import React from 'react'
+import { Col, Container, Row } from 'react-grid-system'
+import { TCol, TGridPluginConfig, TRow } from './types'
+
+const defaultConfig: TGridPluginConfig = {
+  rows: [],
+}
+
+export const ResponsiveGridPlugin = (
+  props: IUIPlugin & { config: TGridPluginConfig }
+): React.ReactElement => {
+  const { config, idReference, type, onSubmit, onChange } = props
+
+  const internalConfig: TGridPluginConfig = {
+    ...defaultConfig,
+    ...config,
+  }
+
+  return (
+    <Stack
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        maxWidth: 'max-content',
+      }}
+    >
+      <Container>
+        {internalConfig.rows.map((row: TRow) => {
+          const columns = row.columns.map((col: TCol) => {
+            return (
+              <Col {...col.size}>
+                <div style={{ marginBottom: '20px' }}>
+                  {col?.title && (
+                    <Typography variant='h4'>{col.title}</Typography>
+                  )}
+                  <ViewCreator
+                    idReference={idReference}
+                    viewConfig={col.viewConfig}
+                    onSubmit={onSubmit}
+                    onChange={onChange}
+                  />
+                </div>
+              </Col>
+            )
+          })
+          return <Row gutterWidth={row.gutterWidth || 30}>{columns}</Row>
+        })}
+      </Container>
+    </Stack>
+  )
+}

--- a/packages/dm-core-plugins/src/responsive_grid/types.ts
+++ b/packages/dm-core-plugins/src/responsive_grid/types.ts
@@ -1,0 +1,32 @@
+import { TViewConfig } from '@development-framework/dm-core'
+
+export type TColSize = {
+  xs: number
+  sm: number
+  md: number
+  lg: number
+  xl: number
+  xxl: number
+}
+
+export type TCol = {
+  viewConfig: TViewConfig
+  size: TColSize
+  title?: string
+}
+
+export type TRow = {
+  columns: TCol[]
+  gutterWidth: number
+}
+
+export type TGridPluginConfig = {
+  rows: TRow[]
+}
+
+export type TItemBorder = {
+  size: string
+  style: string
+  color: string
+  radius: string
+}

--- a/packages/dm-core-plugins/src/view_selector/Sidebar.tsx
+++ b/packages/dm-core-plugins/src/view_selector/Sidebar.tsx
@@ -2,6 +2,7 @@ import { TOnOpen } from '@development-framework/dm-core'
 import { SideBar } from '@equinor/eds-core-react'
 import * as EdsIcons from '@equinor/eds-icons'
 import * as React from 'react'
+import { useScreenClass } from 'react-grid-system'
 import { TItemData, TViewSelectorItem } from './types'
 
 export const Sidebar = (props: {
@@ -12,9 +13,13 @@ export const Sidebar = (props: {
 }): React.ReactElement => {
   const { selectedViewId, setSelectedViewId, viewSelectorItems, addView } =
     props
+  const screenClass = useScreenClass()
+
+  const isOpen = !['xs', 'sm', 'md'].includes(screenClass)
+
   return (
     <SideBar
-      open
+      open={isOpen}
       style={{
         display: 'flex',
         flexDirection: 'column',

--- a/packages/dm-core-plugins/src/yaml/YamlPlugin.tsx
+++ b/packages/dm-core-plugins/src/yaml/YamlPlugin.tsx
@@ -58,7 +58,7 @@ const YamlView = (props: {
 
   return (
     <div className='w-full h-full overflow-auto'>
-      <div className='flex flex-col items-end w-max'>
+      <div className='flex flex-col items-start w-max'>
         <div className='flex justify-end items-center my-2 gap-1 w-fit'>
           <Button variant='ghost' onClick={() => onClick(asYAML)}>
             Copy as YAML


### PR DESCRIPTION
 ## What does this pull request change?

* Add a responsive layout grid that adapts to screen size ensuring consistency across layouts
* Added logic that minimizes the sidebar on smaller screens.

https://github.com/equinor/dm-core-packages/assets/1190419/096294f4-268f-4fa9-8f75-2c07c765eda4

https://github.com/equinor/dm-core-packages/assets/1190419/0056b9c6-9b95-47fc-b94e-3a209c4e41cf

An example configuration can look like this:

```json
"initialUiRecipe": {
    "name": "Dashboard",      
    "type": "CORE:UiRecipe",
    "plugin": "@development-framework/dm-core-plugins/responsive_grid" 
    "config": {
      "type": "PLUGINS:dm-core-plugins/responsive_grid/ResponsiveGridPluginConfig",
      "rows": [
        {
          "type": "PLUGINS:dm-core-plugins/responsive_grid/RowItem",
          "columns": [
            {
              "type": "PLUGINS:dm-core-plugins/responsive_grid/ColumnItem",
              "viewConfig": {
                "type": "CORE:ReferenceViewConfig",
                "recipe": "aRecipeName",
                "scope": "...."
              },
              "size": {
                "type": "PLUGINS:dm-core-plugins/responsive_grid/ColumnSize",
                "sm": 12,
                "md": 4
              }
            },
            {
              "type": "PLUGINS:dm-core-plugins/responsive_grid/ColumnItem",
              "viewConfig": {
                "type": "CORE:ReferenceViewConfig",
                "recipe": "aRecipeName",
                "scope": "...."
              },
              "size": {
                "type": "PLUGINS:dm-core-plugins/responsive_grid/ColumnSize",
                "sm": 12,
                "md": 4
              }
            }
          ]
        },
        {
          "type": "PLUGINS:dm-core-plugins/responsive_grid/RowItem",
          "columns": [
            {
              "type": "PLUGINS:dm-core-plugins/responsive_grid/ColumnItem",
              "viewConfig": {
                "type": "CORE:ReferenceViewConfig",
                "recipe": "aRecipeName",
                "scope": "...."
              },
              "size": {
                "type": "PLUGINS:dm-core-plugins/responsive_grid/ColumnSize",
                "sm": 12,
                "md": 4
              }
            }
          ]
        }
      ]
    }
  },
```

The recipe above defines two rows, where the first row contains two columns, and the second row contains a single column.  The columns will expand on "sm" screens the whole grid (12), but on "md" screens the columns will only take up the space defined in the recipe above (4).  

Some properties of the grid.
* There are default 12 available columns to use, but we add an option to change that number of available columns through the ui recipe config if needed later on. 
* The default breakpoints for the grid are 
  * sm: 576px
  * md: 768px
  * lg:  992px
  * xl: 1200px
  * xxl: 1600px
  * xxxl: 1920px

To understand better the concept implemented take a look at these similar implementations:
- https://getbootstrap.com/docs/5.3/layout/grid/
- https://mui.com/material-ui/react-grid2/

> **NOTE**: This plugin uses https://www.npmjs.com/package/react-grid-system, but we replace it by some code that @awesthouse has later on. 

## Why is this pull request needed?

## Issues related to this change

