### PR TITLE
fix: popovers always on top

### DIFF
--- a/packages/dm-core/src/components/MediaContent.tsx
+++ b/packages/dm-core/src/components/MediaContent.tsx
@@ -4,6 +4,7 @@ import { ReactElement, useRef, useState } from 'react'
 import styled from 'styled-components'
 
 import { DateTime } from 'luxon'
+import { createPortal } from 'react-dom'
 import { imageFiletypes, videoFiletypes } from '../utils/filetypes'
 import { mimeTypes } from '../utils/mime-types'
 import { formatBytes } from '../utils/stringUtilities'
@@ -128,67 +129,70 @@ export const MediaContent = (props: MediaContentProps): ReactElement => {
         )}
         {renderMediaElement(meta.filetype)}
       </MediaWrapper>
-      <Popover
-        open={showMeta}
-        anchorEl={referenceElement.current}
-        onClose={() => setShowMeta(false)}
-        role='dialog'
-        style={{
-          overflow: 'auto',
-          maxWidth: '100vw',
-        }}
-      >
-        <Popover.Header>
-          <Popover.Title>{config.caption ?? 'Meta'}</Popover.Title>
-        </Popover.Header>
-        <Popover.Content>
-          <div className='mb-5'>
-            <label className='font-bold text-sm'>Description</label>
-            <p>{config.description}</p>
-          </div>
-          {config.showMeta && (
-            <div className='grid grid-cols-2 font-normal text-xs'>
-              <label className='font-bold'>File name:</label>
-              <span> {meta.title}</span>
-              <label className='font-bold'>Author:</label>
-              <span> {meta.author}</span>
-              <label className='font-bold'>Filetype:</label>
-              <span> {meta.filetype}</span>
-              <label className='font-bold'>Filesize:</label>
-              <span> {formatBytes(meta.fileSize)}</span>
-              <label className='font-bold'>Date:</label>
-              <span>
-                {DateTime.fromISO(meta.date.replace(' ', 'T')).toFormat(
-                  'dd/MM/yyyy HH:mm'
-                )}
-              </span>
+      {createPortal(
+        <Popover
+          open={showMeta}
+          anchorEl={referenceElement.current}
+          onClose={() => setShowMeta(false)}
+          role='dialog'
+          style={{
+            overflow: 'auto',
+            maxWidth: '100vw',
+          }}
+        >
+          <Popover.Header>
+            <Popover.Title>{config.caption ?? 'Meta'}</Popover.Title>
+          </Popover.Header>
+          <Popover.Content>
+            <div className='mb-5'>
+              <label className='font-bold text-sm'>Description</label>
+              <p>{config.description}</p>
             </div>
-          )}
-        </Popover.Content>
-        <Popover.Actions>
-          <div className='flex justify-start w-full'>
-            <Button
-              variant='ghost'
-              as='a'
-              className='transition-all'
-              href={blobUrl}
-              target='_blank'
-              rel='noopener noreferrer'
-            >
-              <Icon size={16} data={external_link} />
-              New tab
-            </Button>
-            <Button
-              download={`${meta.title}.${meta.filetype}`}
-              href={blobUrl}
-              variant='ghost'
-            >
-              <Icon size={16} data={download} />
-              Download
-            </Button>
-          </div>
-        </Popover.Actions>
-      </Popover>
+            {config.showMeta && (
+              <div className='grid grid-cols-2 font-normal text-xs'>
+                <label className='font-bold'>File name:</label>
+                <span> {meta.title}</span>
+                <label className='font-bold'>Author:</label>
+                <span> {meta.author}</span>
+                <label className='font-bold'>Filetype:</label>
+                <span> {meta.filetype}</span>
+                <label className='font-bold'>Filesize:</label>
+                <span> {formatBytes(meta.fileSize)}</span>
+                <label className='font-bold'>Date:</label>
+                <span>
+                  {DateTime.fromISO(meta.date.replace(' ', 'T')).toFormat(
+                    'dd/MM/yyyy HH:mm'
+                  )}
+                </span>
+              </div>
+            )}
+          </Popover.Content>
+          <Popover.Actions>
+            <div className='flex justify-start w-full'>
+              <Button
+                variant='ghost'
+                as='a'
+                className='transition-all'
+                href={blobUrl}
+                target='_blank'
+                rel='noopener noreferrer'
+              >
+                <Icon size={16} data={external_link} />
+                New tab
+              </Button>
+              <Button
+                download={`${meta.title}.${meta.filetype}`}
+                href={blobUrl}
+                variant='ghost'
+              >
+                <Icon size={16} data={download} />
+                Download
+              </Button>
+            </div>
+          </Popover.Actions>
+        </Popover>,
+        document.body
+      )}
     </>
   )
 }

--- a/packages/dm-core/src/components/Pickers/Datepicker/Datepicker.tsx
+++ b/packages/dm-core/src/components/Pickers/Datepicker/Datepicker.tsx
@@ -3,6 +3,7 @@ import {
   EdsProvider,
   Icon,
   InputWrapper,
+  Popover,
 } from '@equinor/eds-core-react'
 import { calendar } from '@equinor/eds-icons'
 import { DateTime } from 'luxon'
@@ -52,8 +53,6 @@ export const Datepicker = (props: DatepickerProps): ReactElement => {
     datetime?.toFormat('HH:mm') ?? '--:--'
   )
   const inputWrapperRef = useRef<HTMLDivElement | null>(null)
-  // This is kind of a hack. The state is only used to trigger a recalculation of the popover position when scrolling
-  const [scrollChange, setScrollChange] = useState<number>(0)
 
   useEffect(() => {
     if (!useMinutes && datetime) {
@@ -82,22 +81,6 @@ export const Datepicker = (props: DatepickerProps): ReactElement => {
       document.removeEventListener('mousedown', handleClickOutside)
     }
   }, [datepickerRef])
-
-  useEffect(() => {
-    document.addEventListener(
-      'scroll',
-      () => setScrollChange((v) => v + 1),
-      true
-    )
-
-    return () => {
-      document.removeEventListener(
-        'mousedown',
-        () => setScrollChange((v) => v + 1),
-        true
-      )
-    }
-  }, [])
 
   function handleDateInput(dateInput: string): void {
     if (dateInput) {
@@ -163,12 +146,6 @@ export const Datepicker = (props: DatepickerProps): ReactElement => {
     }
   }
 
-  function getInputRect() {
-    const inputElement = inputWrapperRef.current
-    if (!inputElement) return new DOMRect()
-    return inputElement.getBoundingClientRect()
-  }
-
   return (
     <div>
       <InputWrapper
@@ -219,17 +196,12 @@ export const Datepicker = (props: DatepickerProps): ReactElement => {
           </EdsProvider>
         </div>
       </InputWrapper>
-
-      {open &&
-        createPortal(
+      {createPortal(
+        <Popover open={open} anchorEl={inputWrapperRef.current}>
           <div
             id={`date-picker-popover-container`}
             ref={datepickerRef}
-            className={`absolute p-4 gap-3 bg-white shadow border border-gray-300 flex flex-col rounded-sm mt-1`}
-            style={{
-              top: `${getInputRect().top + 38}px`,
-              left: `${getInputRect().left + 10}px`,
-            }}
+            className={`p-4 gap-3 bg-white shadow border border-gray-300 flex flex-col rounded-sm mt-1`}
           >
             <Calendar
               dateTime={datetime}
@@ -256,9 +228,10 @@ export const Datepicker = (props: DatepickerProps): ReactElement => {
                 </span>
               </>
             )}
-          </div>,
-          document.body
-        )}
+          </div>
+        </Popover>,
+        document.body
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## What does this pull request change?
- Uses `react portal` along with EDS's Popover to make sure popovers are always on top and behave nicely with scroll and parent components


## Issues related to this change
closes #1263 
