### PR TITLE
fix: correct cells based on enabled functionality + pagination styling

### DIFF
--- a/packages/dm-core/src/components/Table/Table.tsx
+++ b/packages/dm-core/src/components/Table/Table.tsx
@@ -67,6 +67,9 @@ export function Table(props: TableProps) {
           (variant: TTableVariant) => variant.name === tableVariant
         ).functionality
 
+  const showAdditionalCell =
+    config.variant?.length === 2 || functionalityConfig.delete
+
   /**
    * Start with ascending order if sorting on new column, switch to descending if already sorted, turn off sorting and reset to initial data if sorting was descending
    */
@@ -97,11 +100,12 @@ export function Table(props: TableProps) {
   return (
     <Stack
       style={{
-        display: 'flex',
         width: config?.width || '100%',
         overflow: 'scroll',
         height: '100%',
       }}
+      spacing={0.5}
+      alignItems='flex-end'
     >
       <Stack
         style={{
@@ -118,6 +122,7 @@ export function Table(props: TableProps) {
             <TableHead
               config={config}
               tableVariant={tableVariant}
+              showAdditionalCell={showAdditionalCell}
               setTableVariant={setTableVariant}
               sortColumn={sortColumn}
               sortDirection={sortDirection}
@@ -151,6 +156,7 @@ export function Table(props: TableProps) {
                       items={items}
                       onOpen={props.onOpen}
                       rowsPerPage={itemsPerPage}
+                      showAdditionalCell={showAdditionalCell}
                       setDirtyState={setDirtyState}
                       setItems={setItems}
                       tableVariant={tableVariant}
@@ -199,7 +205,7 @@ export function Table(props: TableProps) {
         direction='row'
         spacing={1}
         justifyContent='space-between'
-        style={{ height: '40px', width: 'max-content' }}
+        style={{ width: 'max-content' }}
       >
         <Pagination
           count={items?.length || 0}

--- a/packages/dm-core/src/components/Table/TableHead/TableHead.tsx
+++ b/packages/dm-core/src/components/Table/TableHead/TableHead.tsx
@@ -72,42 +72,46 @@ export function TableHead(props: TableHeadProps) {
             </SortCell>
           )
         })}
-        <Table.Cell width='40'>
-          <>
-            <Button
-              aria-label='Table actions'
-              aria-haspopup='true'
-              aria-expanded={isMenuOpen}
-              aria-controls={`tablehead-menu`}
-              onClick={() => setIsMenuOpen(true)}
-              ref={setMenuButtonAnchor}
-              variant='ghost_icon'
-            >
-              <Icon data={more_vertical} aria-hidden />
-            </Button>
-            <Menu
-              anchorEl={menuButtonAnchor}
-              aria-labelledby='anchor-default'
-              id={`tablehead-menu`}
-              onClose={() => setIsMenuOpen(false)}
-              open={isMenuOpen}
-            >
-              {config.variant?.length === 2 && (
-                <Menu.Item
-                  onClick={() =>
-                    setTableVariant(
-                      tableVariant === TableVariantNameEnum.View
-                        ? TableVariantNameEnum.Edit
-                        : TableVariantNameEnum.View
-                    )
-                  }
-                >
-                  {tableVariant === TableVariantNameEnum.View ? 'Edit' : 'View'}
-                </Menu.Item>
-              )}
-            </Menu>
-          </>
-        </Table.Cell>
+        {props.showAdditionalCell && (
+          <Table.Cell width='40'>
+            <>
+              <Button
+                aria-label='Table actions'
+                aria-haspopup='true'
+                aria-expanded={isMenuOpen}
+                aria-controls={`tablehead-menu`}
+                onClick={() => setIsMenuOpen(true)}
+                ref={setMenuButtonAnchor}
+                variant='ghost_icon'
+              >
+                <Icon data={more_vertical} aria-hidden />
+              </Button>
+              <Menu
+                anchorEl={menuButtonAnchor}
+                aria-labelledby='anchor-default'
+                id={`tablehead-menu`}
+                onClose={() => setIsMenuOpen(false)}
+                open={isMenuOpen}
+              >
+                {config.variant?.length === 2 && (
+                  <Menu.Item
+                    onClick={() =>
+                      setTableVariant(
+                        tableVariant === TableVariantNameEnum.View
+                          ? TableVariantNameEnum.Edit
+                          : TableVariantNameEnum.View
+                      )
+                    }
+                  >
+                    {tableVariant === TableVariantNameEnum.View
+                      ? 'Edit'
+                      : 'View'}
+                  </Menu.Item>
+                )}
+              </Menu>
+            </>
+          </Table.Cell>
+        )}
       </Table.Row>
     </Table.Head>
   )

--- a/packages/dm-core/src/components/Table/TableRow/TableRow.tsx
+++ b/packages/dm-core/src/components/Table/TableRow/TableRow.tsx
@@ -159,11 +159,12 @@ export function TableRow(props: TableRowProps) {
               updateItem={updateCell}
             ></TableCell>
           ))}
-          {functionalityConfig?.delete && (
+          {props.showAdditionalCell && (
             <TableRowActions
               editMode={editMode}
               item={item}
               removeItem={props.removeItem}
+              functionalityConfig={functionalityConfig}
             />
           )}
         </Table.Row>

--- a/packages/dm-core/src/components/Table/TableRow/TableRowActions/TableRowActions.tsx
+++ b/packages/dm-core/src/components/Table/TableRow/TableRowActions/TableRowActions.tsx
@@ -12,36 +12,39 @@ export function TableRowActions(props: TableRowActionsProps) {
 
   return (
     <Table.Cell style={{ textAlign: 'center' }}>
-      {editMode ? (
-        <DeleteSoftButton
-          onClick={() => removeItem(item, false)}
-          title={'Remove row'}
-          ariaLabel={'Remove row'}
-        />
-      ) : (
-        <>
-          <Button
-            aria-label='Row actions'
-            aria-haspopup='true'
-            aria-expanded={isMenuOpen}
-            aria-controls={`row-object-menu-${item.key}`}
-            variant='ghost_icon'
-            onClick={() => setIsMenuOpen(true)}
-            ref={setMenuButtonAnchor}
-          >
-            <Icon data={more_vertical} aria-hidden />
-          </Button>
-          <Menu
-            anchorEl={menuButtonAnchor}
-            aria-labelledby='anchor-default'
-            id={`row-object-menu-${item.key}`}
-            onClose={() => setIsMenuOpen(false)}
-            open={isMenuOpen}
-          >
-            <Menu.Item onClick={() => removeItem(item, true)}>Delete</Menu.Item>
-          </Menu>
-        </>
-      )}
+      {props.functionalityConfig.delete &&
+        (editMode ? (
+          <DeleteSoftButton
+            onClick={() => removeItem(item, false)}
+            title={'Remove row'}
+            ariaLabel={'Remove row'}
+          />
+        ) : (
+          <>
+            <Button
+              aria-label='Row actions'
+              aria-haspopup='true'
+              aria-expanded={isMenuOpen}
+              aria-controls={`row-object-menu-${item.key}`}
+              variant='ghost_icon'
+              onClick={() => setIsMenuOpen(true)}
+              ref={setMenuButtonAnchor}
+            >
+              <Icon data={more_vertical} aria-hidden />
+            </Button>
+            <Menu
+              anchorEl={menuButtonAnchor}
+              aria-labelledby='anchor-default'
+              id={`row-object-menu-${item.key}`}
+              onClose={() => setIsMenuOpen(false)}
+              open={isMenuOpen}
+            >
+              <Menu.Item onClick={() => removeItem(item, true)}>
+                Delete
+              </Menu.Item>
+            </Menu>
+          </>
+        ))}
     </Table.Cell>
   )
 }

--- a/packages/dm-core/src/components/Table/types.ts
+++ b/packages/dm-core/src/components/Table/types.ts
@@ -84,6 +84,7 @@ export type TableProps = {
 export type TableHeadProps = {
   config: TTableConfig
   setTableVariant: React.Dispatch<React.SetStateAction<TableVariantNameEnum>>
+  showAdditionalCell: boolean
   sortColumn: string | undefined
   sortDirection: TTableSortDirection
   sortByColumn: (column: string) => void
@@ -111,6 +112,7 @@ export type TableRowProps = {
   rowsPerPage: number
   setDirtyState: React.Dispatch<React.SetStateAction<boolean>>
   setItems: React.Dispatch<React.SetStateAction<TItem<TGenericObject>[]>>
+  showAdditionalCell: boolean
   updateItem: (
     itemToUpdate: TItem<TGenericObject>,
     newDocument: TGenericObject,
@@ -126,6 +128,7 @@ export type TableRowActionsProps = {
     itemToDelete: TItem<TGenericObject>,
     saveOnRemove?: boolean
   ) => Promise<void>
+  functionalityConfig: TTableFunctionalityConfig
 }
 
 export type TableCellProps = {

--- a/packages/dm-core/src/components/common/Stack/Stack.tsx
+++ b/packages/dm-core/src/components/common/Stack/Stack.tsx
@@ -23,5 +23,5 @@ Stack.defaultProps = {
   wrap: 'initial',
   padding: 0,
   grow: 0,
-  shrink: 1,
+  shrink: 0,
 }


### PR DESCRIPTION
## What does this pull request change?
- Show correct amount of cells for functionality based on config passed so that cell amount in header matches amount in rows
- Hide additional cells if there is no use (only 1 variant, delete is also disabled)
- Fixes pagination styling bug in pic below
![Skjermbilde 2024-02-05 kl  14 49 02](https://github.com/equinor/dm-core-packages/assets/25383299/adf221d9-0af1-48a4-a8b3-fb33bf8d7316)

## Why is this pull request needed?
There are discrepancies in amount of header-cells and row-cells because we add based on functionality config. They should always be the same amount, and the content should vary based on config.

## Issues related to this change
#1268 
