### PR TITLE
fix: table-horitontal-scroll

### DIFF
--- a/packages/dm-core/src/components/Table/Table.tsx
+++ b/packages/dm-core/src/components/Table/Table.tsx
@@ -134,7 +134,7 @@ export function Table(props: TableProps) {
     <Stack
       style={{
         width: config?.width || '100%',
-        overflow: 'scroll',
+        overflow: 'auto',
         height: '100%',
       }}
       spacing={0.5}
@@ -247,8 +247,8 @@ export function Table(props: TableProps) {
       <Stack
         direction='row'
         spacing={1}
-        justifyContent='space-between'
-        style={{ width: 'max-content' }}
+        justifyContent='flex-end'
+        style={{ width: '100%' }}
       >
         <Pagination
           count={items?.length || 0}
@@ -261,9 +261,6 @@ export function Table(props: TableProps) {
           <Button
             disabled={isLoading || !props.dirtyState}
             onClick={() => saveTable(items)}
-            style={{
-              width: '100%',
-            }}
           >
             {isLoading ? <Progress.Dots color={'primary'} /> : 'Save'}
           </Button>


### PR DESCRIPTION
## What does this pull request change?

So there was an issue on table where horisontal scroll was always on. 

This PR fixes this. 



<img width="1456" alt="image" src="https://github.com/equinor/dm-core-packages/assets/37016135/30f3c5d3-fc94-4f7e-8c0e-5449e2f8932d">
<img width="1352" alt="image" src="https://github.com/equinor/dm-core-packages/assets/37016135/a071f07d-caf7-4a3c-8e4c-c61de03c56af">

## Why is this pull request needed?

## Issues related to this change

