### PR TITLE
feat: stack plugin

### DIFF
--- a/packages/dm-core-plugins/blueprints/stack/StackPluginConfig.json
+++ b/packages/dm-core-plugins/blueprints/stack/StackPluginConfig.json
@@ -24,7 +24,7 @@
     {
       "name": "horizontalPlacement",
       "type": "CORE:BlueprintAttribute",
-      "description": "left, center, right or spaceItems",
+      "description": "left, center, right or spaceEvenly",
       "attributeType": "string",
       "optional": true,
       "default": "left"

--- a/packages/dm-core-plugins/blueprints/stack/StackPluginConfig.json
+++ b/packages/dm-core-plugins/blueprints/stack/StackPluginConfig.json
@@ -55,7 +55,7 @@
     {
       "name": "wrapItems",
       "type": "CORE:BlueprintAttribute",
-      "description": "When using vertical direction, make items wrap under eachother when width is getting too small to fit all items",
+      "description": "When using horizontal direction, make items wrap under eachother when width is getting too small to fit all items",
       "attributeType": "boolean",
       "optional": true,
       "default": false

--- a/packages/dm-core-plugins/blueprints/stack/StackPluginConfig.json
+++ b/packages/dm-core-plugins/blueprints/stack/StackPluginConfig.json
@@ -1,0 +1,72 @@
+{
+  "name": "StackPluginConfig",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "attributes": [
+    {
+      "name": "type",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "items",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "CORE:ViewConfig",
+      "dimensions": "*"
+    },
+    {
+      "name": "direction",
+      "type": "CORE:BlueprintAttribute",
+      "description": "horizontal or vertical",
+      "attributeType": "string",
+      "optional": true,
+      "default": "horizontal"
+    },
+    {
+      "name": "verticalPlacement",
+      "type": "CORE:BlueprintAttribute",
+      "description": "left, center, right or spaceItems",
+      "attributeType": "string",
+      "optional": true,
+      "default": "left"
+    },
+    {
+      "name": "horizontalPlacement",
+      "type": "CORE:BlueprintAttribute",
+      "description": "top, center or bottom",
+      "attributeType": "string",
+      "optional": true,
+      "default": "top"
+    },
+    {
+      "name": "spacing",
+      "type": "CORE:BlueprintAttribute",
+      "description": "REM value. Default is 2 = 32px",
+      "attributeType": "number",
+      "optional": true,
+      "default": 2
+    },
+    {
+      "name": "maxWidth",
+      "type": "CORE:BlueprintAttribute",
+      "description": "Set max-width of wrapper if you want to use less than 100% width.",
+      "attributeType": "string",
+      "optional": true
+    },
+    {
+      "name": "wrapItems",
+      "type": "CORE:BlueprintAttribute",
+      "description": "When using vertical direction, make items wrap under eachother when width is getting too small to fit all items",
+      "attributeType": "boolean",
+      "optional": true,
+      "default": false
+    },
+    {
+      "name": "classNames",
+      "type": "CORE:BlueprintAttribute",
+      "description": "Add tailwind classNames to wrapper",
+      "attributeType": "string",
+      "dimensions": "*",
+      "optional": true
+    }
+  ]
+}

--- a/packages/dm-core-plugins/blueprints/stack/StackPluginConfig.json
+++ b/packages/dm-core-plugins/blueprints/stack/StackPluginConfig.json
@@ -19,10 +19,10 @@
       "description": "horizontal or vertical",
       "attributeType": "string",
       "optional": true,
-      "default": "horizontal"
+      "default": "vertical"
     },
     {
-      "name": "verticalPlacement",
+      "name": "horizontalPlacement",
       "type": "CORE:BlueprintAttribute",
       "description": "left, center, right or spaceItems",
       "attributeType": "string",
@@ -30,7 +30,7 @@
       "default": "left"
     },
     {
-      "name": "horizontalPlacement",
+      "name": "verticalPlacement",
       "type": "CORE:BlueprintAttribute",
       "description": "top, center or bottom",
       "attributeType": "string",

--- a/packages/dm-core-plugins/blueprints/stack/package.json
+++ b/packages/dm-core-plugins/blueprints/stack/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "stack",
+  "type": "CORE:Package",
+  "isRoot": false,
+  "_meta_": {
+    "type": "CORE:Meta",
+    "version": "0.0.1",
+    "dependencies": [
+      {
+        "type": "CORE:Dependency",
+        "alias": "CORE",
+        "address": "system/SIMOS",
+        "version": "0.0.1",
+        "protocol": "dmss"
+      },
+      {
+        "type": "CORE:Dependency",
+        "alias": "PLUGINS",
+        "address": "system/Plugins",
+        "version": "0.0.1",
+        "protocol": "dmss"
+      }
+    ]
+  }
+}

--- a/packages/dm-core-plugins/src/index.tsx
+++ b/packages/dm-core-plugins/src/index.tsx
@@ -22,6 +22,13 @@ export default ({
       }))
     ),
   },
+  '@development-framework/dm-core-plugins/stack': {
+    component: lazy(() =>
+      import('./stack/StackPlugin').then((module) => ({
+        default: module.StackPlugin,
+      }))
+    ),
+  },
   '@development-framework/dm-core-plugins/data_grid': {
     component: lazy(() =>
       import('./data-grid/DataGridPlugin').then((module) => ({

--- a/packages/dm-core-plugins/src/stack/StackPlugin.tsx
+++ b/packages/dm-core-plugins/src/stack/StackPlugin.tsx
@@ -32,6 +32,7 @@ export const StackPlugin = (props: IUIPlugin) => {
     className: config.classNames?.join(' '),
     spacing: config.spacing !== undefined ? config.spacing : 1.5,
     wrap: config.wrap ? 'wrap' : 'no-wrap',
+    style: { maxWidth: config.maxWidth },
   }
 
   return (

--- a/packages/dm-core-plugins/src/stack/StackPlugin.tsx
+++ b/packages/dm-core-plugins/src/stack/StackPlugin.tsx
@@ -1,0 +1,50 @@
+import { IUIPlugin, Stack, ViewCreator } from '@development-framework/dm-core'
+import {
+  DirectionTypes,
+  StackProps,
+} from '@development-framework/dm-core/dist/components/common/Stack/types'
+import { StackPluginConfig, defaultConfig } from './types'
+
+export const StackPlugin = (props: IUIPlugin) => {
+  const { idReference } = props
+  const config: StackPluginConfig = { ...defaultConfig, ...props.config }
+
+  // map plugin language to stack props/css language
+  const configMap: { [name: string]: string } = {
+    horizontal: 'column',
+    vertical: 'row',
+    verticalPlacement:
+      config.direction === 'horizontal' ? 'alignItems' : 'justifyContent',
+    horizontalPlacement:
+      config.direction === 'horizontal' ? 'justifyContent' : 'alignItems',
+    left: 'flex-start',
+    center: 'center',
+    right: 'flex-end',
+    top: 'flex-start',
+    bottom: 'flex-end',
+    spaceItems: 'space-between',
+  }
+
+  const stackProps: StackProps = {
+    direction: configMap[config.direction] as DirectionTypes,
+    [configMap.verticalPlacement]: configMap[config.verticalPlacement],
+    [configMap.horizontalPlacement]: configMap[config.horizontalPlacement],
+    className: config.classNames?.join(' '),
+    spacing: config.spacing !== undefined ? config.spacing : 1.5,
+    wrap: config.wrap ? 'wrap' : 'no-wrap',
+  }
+
+  return (
+    <Stack {...stackProps}>
+      {config.items?.map((item, index) => (
+        <ViewCreator
+          key={`${item.recipe}_${index}`}
+          idReference={idReference}
+          viewConfig={item}
+          onSubmit={props.onSubmit}
+          onChange={props.onChange}
+        />
+      ))}
+    </Stack>
+  )
+}

--- a/packages/dm-core-plugins/src/stack/StackPlugin.tsx
+++ b/packages/dm-core-plugins/src/stack/StackPlugin.tsx
@@ -22,7 +22,7 @@ export const StackPlugin = (props: IUIPlugin) => {
     right: 'flex-end',
     top: 'flex-start',
     bottom: 'flex-end',
-    spaceItems: 'space-between',
+    spaceEvenly: 'space-between',
   }
 
   const stackProps: StackProps = {

--- a/packages/dm-core-plugins/src/stack/StackPlugin.tsx
+++ b/packages/dm-core-plugins/src/stack/StackPlugin.tsx
@@ -11,11 +11,11 @@ export const StackPlugin = (props: IUIPlugin) => {
 
   // map plugin language to stack props/css language
   const configMap: { [name: string]: string } = {
-    horizontal: 'column',
-    vertical: 'row',
-    verticalPlacement:
-      config.direction === 'horizontal' ? 'alignItems' : 'justifyContent',
+    vertical: 'column',
+    horizontal: 'row',
     horizontalPlacement:
+      config.direction === 'horizontal' ? 'alignItems' : 'justifyContent',
+    verticalPlacement:
       config.direction === 'horizontal' ? 'justifyContent' : 'alignItems',
     left: 'flex-start',
     center: 'center',
@@ -30,7 +30,7 @@ export const StackPlugin = (props: IUIPlugin) => {
     [configMap.verticalPlacement]: configMap[config.verticalPlacement],
     [configMap.horizontalPlacement]: configMap[config.horizontalPlacement],
     className: config.classNames?.join(' '),
-    spacing: config.spacing !== undefined ? config.spacing : 1.5,
+    spacing: config.spacing,
     wrap: config.wrap ? 'wrap' : 'no-wrap',
     style: { maxWidth: config.maxWidth },
   }

--- a/packages/dm-core-plugins/src/stack/types.ts
+++ b/packages/dm-core-plugins/src/stack/types.ts
@@ -3,8 +3,8 @@ import { TViewConfig } from '@development-framework/dm-core'
 export type StackPluginConfig = {
   items: TViewConfig[]
   direction: 'horizontal' | 'vertical'
-  verticalPlacement: 'left' | 'center' | 'right' | 'spaceItems'
-  horizontalPlacement: 'top' | 'center' | 'bottom'
+  horizontalPlacement: 'left' | 'center' | 'right' | 'spaceItems'
+  verticalPlacement: 'top' | 'center' | 'bottom'
   spacing: number
   maxWidth: string
   wrap: boolean
@@ -13,9 +13,9 @@ export type StackPluginConfig = {
 
 export const defaultConfig: StackPluginConfig = {
   items: [],
-  direction: 'horizontal',
-  verticalPlacement: 'left',
-  horizontalPlacement: 'top',
+  direction: 'vertical',
+  horizontalPlacement: 'left',
+  verticalPlacement: 'top',
   spacing: 2,
   maxWidth: 'none',
   wrap: false,

--- a/packages/dm-core-plugins/src/stack/types.ts
+++ b/packages/dm-core-plugins/src/stack/types.ts
@@ -3,7 +3,7 @@ import { TViewConfig } from '@development-framework/dm-core'
 export type StackPluginConfig = {
   items: TViewConfig[]
   direction: 'horizontal' | 'vertical'
-  horizontalPlacement: 'left' | 'center' | 'right' | 'spaceItems'
+  horizontalPlacement: 'left' | 'center' | 'right' | 'spaceEvenly'
   verticalPlacement: 'top' | 'center' | 'bottom'
   spacing: number
   maxWidth: string

--- a/packages/dm-core-plugins/src/stack/types.ts
+++ b/packages/dm-core-plugins/src/stack/types.ts
@@ -1,0 +1,23 @@
+import { TViewConfig } from '@development-framework/dm-core'
+
+export type StackPluginConfig = {
+  items: TViewConfig[]
+  direction: 'horizontal' | 'vertical'
+  verticalPlacement: 'left' | 'center' | 'right' | 'spaceItems'
+  horizontalPlacement: 'top' | 'center' | 'bottom'
+  spacing: number
+  maxWidth: string
+  wrap: boolean
+  classNames: string[]
+}
+
+export const defaultConfig: StackPluginConfig = {
+  items: [],
+  direction: 'horizontal',
+  verticalPlacement: 'left',
+  horizontalPlacement: 'top',
+  spacing: 2,
+  maxWidth: '100%',
+  wrap: false,
+  classNames: [],
+}

--- a/packages/dm-core-plugins/src/stack/types.ts
+++ b/packages/dm-core-plugins/src/stack/types.ts
@@ -17,7 +17,7 @@ export const defaultConfig: StackPluginConfig = {
   verticalPlacement: 'left',
   horizontalPlacement: 'top',
   spacing: 2,
-  maxWidth: '100%',
+  maxWidth: 'none',
   wrap: false,
   classNames: [],
 }

--- a/packages/dm-core/src/components/common/Stack/types.ts
+++ b/packages/dm-core/src/components/common/Stack/types.ts
@@ -42,7 +42,7 @@ export interface StackProps extends React.ComponentPropsWithoutRef<'div'> {
     | 'max-content'
   grow?: number
   shrink?: number
-  direction?: 'row' | 'column' | 'row-reverse' | 'column-reverse'
+  direction?: DirectionTypes
   wrap?: 'initial' | 'no-wrap' | 'wrap' | 'wrap-reverse'
   order?: number
   className?: string

--- a/packages/dm-core/src/types.ts
+++ b/packages/dm-core/src/types.ts
@@ -225,6 +225,7 @@ export type TViewConfig = {
   eds_icon?: string
   roles?: string[]
   showRefreshButton?: boolean
+  recipe?: string
 }
 
 export type TReferenceViewConfig = TViewConfig & {

--- a/packages/dm-core/src/types.ts
+++ b/packages/dm-core/src/types.ts
@@ -225,7 +225,7 @@ export type TViewConfig = {
   eds_icon?: string
   roles?: string[]
   showRefreshButton?: boolean
-  recipe?: string
+  recipe?: string | TUiRecipe
 }
 
 export type TReferenceViewConfig = TViewConfig & {


### PR DESCRIPTION
## What does this pull request change?
Add StackPlugin to dm-core-plugins. Allows user to stack views on top or next to each other.
In items array, just pass viewConfig objects

Example of config:
```json
{
      "name": "Dashboard",
      "type": "CORE:UiRecipe",
      "description": "ESS Plot",
      "plugin": "@development-framework/dm-core-plugins/stack",
      "config": {
        "type": "PLUGINS:dm-core-plugins/stack/StackPluginConfig",
        "items": [
          {
            "type": "CORE:ReferenceViewConfig",
            "scope": "sce",
            "recipe": "Date"
          },
          {
            "type": "CORE:ReferenceViewConfig",
            "scope": "job",
            "recipe": "Fetch_Signals_OmniaTS"
          },
          {
            "type": "CORE:ReferenceViewConfig",
            "scope": "sce.signals",
            "recipe": "List"
          }
        ]
      }
    },
```

Open to discussing naming. "MultiView" to me seems like you can switch between multiple views of the same content. "Flexbox" is more css language. If we describe this as user being able to **stack** views on top of or next to each other - I feel like it's pretty self-explanatory. 

## Why is this pull request needed?
Help with some layout use-cases that are a bit over-complicated.

## Issues related to this change
#1258
