### PR TITLE
Fix/actuall fix scroll bar always there

### DIFF
--- a/packages/dm-core/src/components/Pagination/Pagination.tsx
+++ b/packages/dm-core/src/components/Pagination/Pagination.tsx
@@ -78,6 +78,7 @@ export function Pagination(props: PaginationProps) {
             disabled={page + 1 === availablePages}
             variant='ghost_icon'
             onClick={() => setPage(page + 1)}
+            style={{ marginInlineEnd: '1px' }} // when disabled causes a scroll bar, so 1px margin fixes this.
           >
             <Icon data={chevron_right} title='Next page' />
           </Button>

--- a/packages/dm-core/src/components/Pagination/Pagination.tsx
+++ b/packages/dm-core/src/components/Pagination/Pagination.tsx
@@ -44,12 +44,7 @@ export function Pagination(props: PaginationProps) {
 
   return (
     <EdsProvider density='compact'>
-      <Stack
-        direction='row'
-        spacing={1}
-        alignItems='center'
-        justifyContent='flex-end'
-      >
+      <Stack direction='row' spacing={1} alignItems='center'>
         <Stack spacing={0.5} direction='row' alignItems='center'>
           <Typography variant='label' group='input'>
             Rows per page:{' '}

--- a/packages/dm-core/src/components/Table/Table.tsx
+++ b/packages/dm-core/src/components/Table/Table.tsx
@@ -248,7 +248,7 @@ export function Table(props: TableProps) {
         direction='row'
         spacing={1}
         justifyContent='flex-end'
-        style={{ width: '100%', marginInlineEnd: '1px' }}
+        style={{ width: '100%' }}
       >
         <Pagination
           count={items?.length || 0}

--- a/packages/dm-core/src/components/Table/Table.tsx
+++ b/packages/dm-core/src/components/Table/Table.tsx
@@ -248,7 +248,7 @@ export function Table(props: TableProps) {
         direction='row'
         spacing={1}
         justifyContent='flex-end'
-        style={{ width: '100%' }}
+        style={{ width: '100%', marginInlineEnd: '1px' }}
       >
         <Pagination
           count={items?.length || 0}


### PR DESCRIPTION
## What does this pull request change?

So it seems that disabled button in eds is 1 px bigger or something? 
When we enabled scroll on the table, when the right most button was disabled, then it caused the whole table to scroll. 

Didn't quite figure out why, but 1px margin seems to fix it

## Why is this pull request needed?

## Issues related to this change

