### PR TITLE
fix: hide meta when disabled

### DIFF
--- a/e2e/tests/plugin-form-Media_viewer.spec.ts
+++ b/e2e/tests/plugin-form-Media_viewer.spec.ts
@@ -12,35 +12,12 @@ test('Media viewer', async ({ page }) => {
   await test.step('video', async () => {
     await page.getByRole('button', { name: 'mediaViewerMOV' }).click()
     await expect(page.locator('video')).toBeVisible()
-    await page.getByRole('button', { name: 'view meta info' }).click()
-
-    await expect(dialog.getByText('mov')).toBeVisible()
-    //await dialog.getByRole('link', { name: 'New tab' }).click() #802 BUG in Chrome (downloads instead of open new tab). Works in Firefox.
-    //const newTab = await page1Promise
-    //await expect(newTab.getByRole('video')).toBeVisible() //Not sure if "video" is accepted as role
-    //await newTab.close()
-
-    const downloadPromise = page.waitForEvent('download')
-    await dialog.getByRole('link', { name: 'Download' }).click()
-    const download = await downloadPromise
-    await download.createReadStream()
   })
   await test.step('gif', async () => {
     await page.getByRole('button', { name: 'mediaViewerGIF' }).click()
     await expect(page.locator('img')).toHaveJSProperty('complete', true)
     await expect(page.locator('img')).not.toHaveJSProperty('naturalWidth', 0)
     await expect(page.getByRole('img', { name: 'fast' })).toBeVisible()
-    await page.getByRole('button', { name: 'view meta info' }).click()
-    const page1Promise = page.waitForEvent('popup')
-    await expect(dialog.getByText('gif')).toBeVisible()
-    await dialog.getByRole('link', { name: 'New tab' }).click()
-    const newTab = await page1Promise
-    await expect(newTab.getByRole('img')).toBeVisible()
-    await newTab.close()
-    const downloadPromise = page.waitForEvent('download')
-    await page.getByRole('link', { name: 'Download' }).click()
-    const download = await downloadPromise
-    await download.createReadStream()
   })
 
   await test.step('image', async () => {
@@ -48,19 +25,6 @@ test('Media viewer', async ({ page }) => {
     await expect(page.locator('img')).toHaveJSProperty('complete', true)
     await expect(page.locator('img')).not.toHaveJSProperty('naturalWidth', 0)
     await expect(page.getByRole('img', { name: 'beauty' })).toBeVisible()
-    await page.getByRole('button', { name: 'view meta info' }).click()
-
-    const page1Promise = page.waitForEvent('popup')
-    await expect(dialog.getByText('jpeg')).toBeVisible()
-    await dialog.getByRole('link', { name: 'New tab' }).click()
-    const newTab = await page1Promise
-    await expect(newTab.getByRole('img')).toBeVisible()
-    await newTab.close()
-
-    const downloadPromise = page.waitForEvent('download')
-    await page.getByRole('link', { name: 'Download' }).click()
-    const download = await downloadPromise
-    await download.createReadStream()
   })
 
   await test.step('pdf', async () => {

--- a/packages/dm-core-plugins/blueprints/media_viewer/MediaViewerConfig.json
+++ b/packages/dm-core-plugins/blueprints/media_viewer/MediaViewerConfig.json
@@ -27,6 +27,13 @@
       "optional": true
     },
     {
+      "name": "showDescription",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "boolean",
+      "default": false,
+      "optional": true
+    },
+    {
       "name": "caption",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "string",

--- a/packages/dm-core/src/components/MediaContent/MediaContent.tsx
+++ b/packages/dm-core/src/components/MediaContent/MediaContent.tsx
@@ -13,7 +13,7 @@ export { imageFiletypes, videoFiletypes }
 
 export const MediaContent = (props: MediaContentProps): ReactElement => {
   const { blobUrl, getBlobUrl, meta, config } = props
-  const [showMeta, setShowMeta] = useState(false)
+  const [showInfoPopover, setShowInfoPopover] = useState(false)
   const referenceElement = useRef()
 
   async function downloadFile() {
@@ -89,42 +89,43 @@ export const MediaContent = (props: MediaContentProps): ReactElement => {
   return (
     <>
       <MediaWrapper $height={config.height} $width={config.width}>
-        {meta.filetype === 'pfd' && config.showMeta && (
-          <MetaPopoverButton
-            onClick={() => setShowMeta(!showMeta)}
-            variant='ghost_icon'
-            aria-haspopup
-            aria-expanded={showMeta}
-            ref={referenceElement}
-          >
-            <Icon data={info_circle} title='view meta info' />
-          </MetaPopoverButton>
-        )}
+        {!(meta.filetype === 'pfd') &&
+          (config.showMeta || config.showDescription) && (
+            <MetaPopoverButton
+              onClick={() => setShowInfoPopover(!showInfoPopover)}
+              variant='ghost_icon'
+              aria-haspopup
+              aria-expanded={showInfoPopover}
+              ref={referenceElement}
+            >
+              <Icon data={info_circle} title='view meta info' />
+            </MetaPopoverButton>
+          )}
         {renderMediaElement(meta.filetype)}
       </MediaWrapper>
-      {config.showMeta && (
-        <>
-          {createPortal(
-            <Popover
-              open={showMeta}
-              anchorEl={referenceElement.current}
-              onClose={() => setShowMeta(false)}
-              role='dialog'
-              style={{
-                overflow: 'auto',
-                maxWidth: '100vw',
-              }}
-            >
-              <Popover.Header>
-                <Popover.Title>{config.caption ?? meta?.title}</Popover.Title>
-              </Popover.Header>
-              <Popover.Content>
-                {config.description && (
-                  <div className='mb-5'>
-                    <label className='font-bold text-sm'>Description</label>
-                    <p>{config.description}</p>
-                  </div>
-                )}
+      {(config.showMeta || config.showDescription) &&
+        createPortal(
+          <Popover
+            open={showInfoPopover}
+            anchorEl={referenceElement.current}
+            onClose={() => setShowInfoPopover(false)}
+            role='dialog'
+            style={{
+              overflow: 'auto',
+              maxWidth: '100vw',
+            }}
+          >
+            <Popover.Header>
+              <Popover.Title>{config.caption ?? meta?.title}</Popover.Title>
+            </Popover.Header>
+            <Popover.Content>
+              {config.showDescription && config.description && (
+                <div className='mb-5'>
+                  <label className='font-bold text-sm'>Description</label>
+                  <p>{config.description}</p>
+                </div>
+              )}
+              {config.showMeta && (
                 <div className='grid grid-cols-2 font-normal text-xs'>
                   <label className='font-bold'>File name:</label>
                   <span>
@@ -144,35 +145,34 @@ export const MediaContent = (props: MediaContentProps): ReactElement => {
                     )}
                   </span>
                 </div>
-              </Popover.Content>
-              <Popover.Actions>
-                <div className='flex justify-start w-full'>
-                  <Button
-                    variant='ghost'
-                    as='a'
-                    className='transition-all'
-                    href={blobUrl}
-                    target='_blank'
-                    rel='noopener noreferrer'
-                  >
-                    <Icon size={16} data={external_link} />
-                    New tab
-                  </Button>
-                  <Button
-                    download={`${meta.title}.${meta.filetype}`}
-                    href={blobUrl}
-                    variant='ghost'
-                  >
-                    <Icon size={16} data={download} />
-                    Download
-                  </Button>
-                </div>
-              </Popover.Actions>
-            </Popover>,
-            document.body
-          )}
-        </>
-      )}
+              )}
+            </Popover.Content>
+            <Popover.Actions>
+              <div className='flex justify-start w-full'>
+                <Button
+                  variant='ghost'
+                  as='a'
+                  className='transition-all'
+                  href={blobUrl}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                >
+                  <Icon size={16} data={external_link} />
+                  New tab
+                </Button>
+                <Button
+                  download={`${meta.title}.${meta.filetype}`}
+                  href={blobUrl}
+                  variant='ghost'
+                >
+                  <Icon size={16} data={download} />
+                  Download
+                </Button>
+              </div>
+            </Popover.Actions>
+          </Popover>,
+          document.body
+        )}
     </>
   )
 }

--- a/packages/dm-core/src/components/MediaContent/MediaContent.tsx
+++ b/packages/dm-core/src/components/MediaContent/MediaContent.tsx
@@ -119,6 +119,12 @@ export const MediaContent = (props: MediaContentProps): ReactElement => {
                 <Popover.Title>{config.caption ?? meta?.title}</Popover.Title>
               </Popover.Header>
               <Popover.Content>
+                {config.description && (
+                  <div className='mb-5'>
+                    <label className='font-bold text-sm'>Description</label>
+                    <p>{config.description}</p>
+                  </div>
+                )}
                 <div className='grid grid-cols-2 font-normal text-xs'>
                   <label className='font-bold'>File name:</label>
                   <span>

--- a/packages/dm-core/src/components/MediaContent/MediaContent.tsx
+++ b/packages/dm-core/src/components/MediaContent/MediaContent.tsx
@@ -89,7 +89,7 @@ export const MediaContent = (props: MediaContentProps): ReactElement => {
   return (
     <>
       <MediaWrapper $height={config.height} $width={config.width}>
-        {!['pdf'].includes(meta.filetype) && (
+        {meta.filetype === 'pfd' && config.showMeta && (
           <MetaPopoverButton
             onClick={() => setShowMeta(!showMeta)}
             variant='ghost_icon'
@@ -102,69 +102,70 @@ export const MediaContent = (props: MediaContentProps): ReactElement => {
         )}
         {renderMediaElement(meta.filetype)}
       </MediaWrapper>
-      {createPortal(
-        <Popover
-          open={showMeta}
-          anchorEl={referenceElement.current}
-          onClose={() => setShowMeta(false)}
-          role='dialog'
-          style={{
-            overflow: 'auto',
-            maxWidth: '100vw',
-          }}
-        >
-          <Popover.Header>
-            <Popover.Title>{config.caption ?? 'Meta'}</Popover.Title>
-          </Popover.Header>
-          <Popover.Content>
-            <div className='mb-5'>
-              <label className='font-bold text-sm'>Description</label>
-              <p>{config.description}</p>
-            </div>
-            {config.showMeta && (
-              <div className='grid grid-cols-2 font-normal text-xs'>
-                <label className='font-bold'>File name:</label>
-                <span> {meta.title}</span>
-                <label className='font-bold'>Author:</label>
-                <span> {meta.author}</span>
-                <label className='font-bold'>Filetype:</label>
-                <span> {meta.filetype}</span>
-                <label className='font-bold'>Filesize:</label>
-                <span> {formatBytes(meta.fileSize)}</span>
-                <label className='font-bold'>Date:</label>
-                <span>
-                  {DateTime.fromISO(meta.date.replace(' ', 'T')).toFormat(
-                    'dd/MM/yyyy HH:mm'
-                  )}
-                </span>
-              </div>
-            )}
-          </Popover.Content>
-          <Popover.Actions>
-            <div className='flex justify-start w-full'>
-              <Button
-                variant='ghost'
-                as='a'
-                className='transition-all'
-                href={blobUrl}
-                target='_blank'
-                rel='noopener noreferrer'
-              >
-                <Icon size={16} data={external_link} />
-                New tab
-              </Button>
-              <Button
-                download={`${meta.title}.${meta.filetype}`}
-                href={blobUrl}
-                variant='ghost'
-              >
-                <Icon size={16} data={download} />
-                Download
-              </Button>
-            </div>
-          </Popover.Actions>
-        </Popover>,
-        document.body
+      {config.showMeta && (
+        <>
+          {createPortal(
+            <Popover
+              open={showMeta}
+              anchorEl={referenceElement.current}
+              onClose={() => setShowMeta(false)}
+              role='dialog'
+              style={{
+                overflow: 'auto',
+                maxWidth: '100vw',
+              }}
+            >
+              <Popover.Header>
+                <Popover.Title>{config.caption ?? meta?.title}</Popover.Title>
+              </Popover.Header>
+              <Popover.Content>
+                <div className='grid grid-cols-2 font-normal text-xs'>
+                  <label className='font-bold'>File name:</label>
+                  <span>
+                    {' '}
+                    {meta.title}.{meta.filetype}
+                  </span>
+                  <label className='font-bold'>Author:</label>
+                  <span> {meta.author}</span>
+                  <label className='font-bold'>Filetype:</label>
+                  <span> {meta.filetype}</span>
+                  <label className='font-bold'>Filesize:</label>
+                  <span> {formatBytes(meta.fileSize)}</span>
+                  <label className='font-bold'>Date:</label>
+                  <span>
+                    {DateTime.fromISO(meta.date.replace(' ', 'T')).toFormat(
+                      'dd/MM/yyyy HH:mm'
+                    )}
+                  </span>
+                </div>
+              </Popover.Content>
+              <Popover.Actions>
+                <div className='flex justify-start w-full'>
+                  <Button
+                    variant='ghost'
+                    as='a'
+                    className='transition-all'
+                    href={blobUrl}
+                    target='_blank'
+                    rel='noopener noreferrer'
+                  >
+                    <Icon size={16} data={external_link} />
+                    New tab
+                  </Button>
+                  <Button
+                    download={`${meta.title}.${meta.filetype}`}
+                    href={blobUrl}
+                    variant='ghost'
+                  >
+                    <Icon size={16} data={download} />
+                    Download
+                  </Button>
+                </div>
+              </Popover.Actions>
+            </Popover>,
+            document.body
+          )}
+        </>
       )}
     </>
   )

--- a/packages/dm-core/src/components/MediaContent/types.ts
+++ b/packages/dm-core/src/components/MediaContent/types.ts
@@ -2,6 +2,7 @@ export interface MediaContentConfig {
   height?: number
   width?: number
   showMeta?: boolean
+  showDescription?: boolean
   caption?: string
   description?: string
 }


### PR DESCRIPTION
## What does this pull request change?
- New config: showDescription
- Show info-popover when showMeta OR showDescription is enabled
- Use filename as title if label is not provided 
- Hide description label if description is not provided

## Why is this pull request needed?
Want to actually hide meta

## Issues related to this change
#1223 
