### PR TITLE
add meta and publish plugins

### DIFF
--- a/packages/dm-core-plugins/blueprints/common/Meta.json
+++ b/packages/dm-core-plugins/blueprints/common/Meta.json
@@ -1,0 +1,19 @@
+{
+  "name": "Meta",
+  "type": "CORE:Blueprint",
+  "extends": ["CORE:Entity"],
+  "description": "Purely for convenience. A wrapper that contains any entity. Used to render the 'meta' plugin around entities.",
+  "attributes": [
+    {
+      "name": "type",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "content",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "object",
+      "optional": true
+    }
+  ]
+}

--- a/packages/dm-core-plugins/blueprints/publish/PublishConfig.json
+++ b/packages/dm-core-plugins/blueprints/publish/PublishConfig.json
@@ -1,0 +1,31 @@
+{
+  "name": "PublishConfig",
+  "type": "CORE:Blueprint",
+  "attributes": [
+    {
+      "name": "type",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "publishDestination",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "description": "A reference/Id to where the published copy should be added."
+    },
+    {
+      "name": "publishWrapper",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "A blueprint for which an entity of will serve as a wrapper for the published document",
+      "attributeType": "string",
+      "optional": true
+    },
+    {
+      "name": "publishWrapperAttribute",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "Name of attribute in the 'publishWrapper'-blueprint of which the document will be placed.",
+      "attributeType": "string",
+      "optional": true
+    }
+  ]
+}

--- a/packages/dm-core-plugins/blueprints/publish/package.json
+++ b/packages/dm-core-plugins/blueprints/publish/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "publish",
+  "type": "CORE:Package",
+  "isRoot": false,
+  "_meta_": {
+    "type": "CORE:Meta",
+    "version": "0.0.1",
+    "dependencies": [
+      {
+        "type": "CORE:Dependency",
+        "alias": "CORE",
+        "address": "system/SIMOS",
+        "version": "0.0.1",
+        "protocol": "dmss"
+      },
+      {
+        "type": "CORE:Dependency",
+        "alias": "PLUGINS",
+        "address": "system/Plugins",
+        "version": "0.0.1",
+        "protocol": "dmss"
+      }
+    ]
+  }
+}

--- a/packages/dm-core-plugins/src/index.tsx
+++ b/packages/dm-core-plugins/src/index.tsx
@@ -151,4 +151,18 @@ export default ({
       }))
     ),
   },
+  '@development-framework/dm-core-plugins/meta': {
+    component: lazy(() =>
+      import('./meta/MetaPlugin').then((module) => ({
+        default: module.MetaPlugin,
+      }))
+    ),
+  },
+  '@development-framework/dm-core-plugins/publish': {
+    component: lazy(() =>
+      import('./publish/PublishPlugin').then((module) => ({
+        default: module.PublishPlugin,
+      }))
+    ),
+  },
 } as TUiPluginMap)

--- a/packages/dm-core-plugins/src/meta/MetaPlugin.tsx
+++ b/packages/dm-core-plugins/src/meta/MetaPlugin.tsx
@@ -1,0 +1,89 @@
+import {
+  EntityView,
+  IUIPlugin,
+  Loading,
+  TGenericObject,
+  TMeta,
+  useDocument,
+} from '@development-framework/dm-core'
+import { Table } from '@equinor/eds-core-react'
+import { DateTime } from 'luxon'
+
+export const MetaPlugin = (props: IUIPlugin) => {
+  const { document, isLoading, error } = useDocument<TGenericObject>(
+    props.idReference,
+    0
+  )
+
+  if (isLoading) return <Loading />
+
+  if (error) throw new Error(JSON.stringify(error, null, 2))
+
+  if (!document) return
+
+  const meta: TMeta = document._meta_
+
+  if (document.type !== 'dmss://system/Plugins/dm-core-plugins/common/Meta')
+    throw new Error(
+      'The meta plugin only supports entities of type "Meta" at this stage'
+    )
+
+  return (
+    <>
+      <Table className={'w-full'}>
+        <Table.Head>
+          <Table.Row>
+            <Table.Cell>Created by</Table.Cell>
+            <Table.Cell>Created time</Table.Cell>
+            <Table.Cell>Last modified by</Table.Cell>
+            <Table.Cell>Last modified time</Table.Cell>
+          </Table.Row>
+        </Table.Head>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>{meta?.createdBy ?? '-'}</Table.Cell>
+            <Table.Cell>
+              {meta?.createdTimestamp
+                ? DateTime.fromISO(meta.createdTimestamp).toLocaleString(
+                    {
+                      day: '2-digit',
+                      month: '2-digit',
+                      year: '2-digit',
+                      hour: '2-digit',
+                      minute: '2-digit',
+                      hourCycle: 'h23',
+                    },
+                    { locale: 'nb' }
+                  )
+                : '-'}
+            </Table.Cell>
+            <Table.Cell>{meta?.lastModifiedBy ?? '-'}</Table.Cell>
+            <Table.Cell>
+              {meta?.lastModifiedTimestamp
+                ? DateTime.fromISO(meta.lastModifiedTimestamp).toLocaleString(
+                    {
+                      day: '2-digit',
+                      month: '2-digit',
+                      year: '2-digit',
+                      hour: '2-digit',
+                      minute: '2-digit',
+                      hourCycle: 'h23',
+                    },
+                    { locale: 'nb' }
+                  )
+                : '-'}
+            </Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>
+      {/*This empty div wrapper is kind of a hack to avoid EntityView take the same height as the entire plugin*/}
+      <div>
+        <EntityView
+          {...props}
+          type={document.content.type}
+          idReference={`${props.idReference}.content`}
+        />
+      </div>
+    </>
+  )
+}

--- a/packages/dm-core-plugins/src/publish/PublishPlugin.tsx
+++ b/packages/dm-core-plugins/src/publish/PublishPlugin.tsx
@@ -1,0 +1,53 @@
+import {
+  CopyLinkDialog,
+  EntityView,
+  IUIPlugin,
+} from '@development-framework/dm-core'
+import { Button, Icon } from '@equinor/eds-core-react'
+import { approve } from '@equinor/eds-icons'
+import { useState } from 'react'
+
+export const PublishPlugin = (
+  props: IUIPlugin & {
+    config: {
+      publishDestination: string
+      publishWrapper?: string
+      publishWrapperAttribute?: string
+    }
+  }
+) => {
+  const { idReference } = props
+  const [showPublishDialog, setShowPublishDialog] = useState<boolean>(false)
+
+  return (
+    <div className={'flex flex-col'}>
+      <div className={'justify-end flex'}>
+        <Button
+          variant='outlined'
+          color='secondary'
+          onClick={() => setShowPublishDialog(true)}
+        >
+          Publish
+          <Icon data={approve} />
+        </Button>
+        <CopyLinkDialog
+          title={'Publish report?'}
+          buttonText={'Publish'}
+          destination={props.config.publishDestination}
+          mode={'copy'}
+          // Defaults to using a "Meta"-entity as a wrapper. Can be overridden with config
+          wrapper={
+            props.config.publishWrapper ||
+            'dmss://system/Plugins/dm-core-plugins/common/Meta'
+          }
+          wrapperAttribute={props.config.publishWrapperAttribute || 'content'}
+          hideProvidedFields={true}
+          idReference={idReference}
+          open={showPublishDialog}
+          setOpen={setShowPublishDialog}
+        />
+      </div>
+      <EntityView {...props} />
+    </div>
+  )
+}


### PR DESCRIPTION
## What does this pull request change?
Adds plugins for "Publish" and "Meta".
They are both wrappers, that just show a "publish button", and "meta info" before the main entity's plugin.
![Screenshot_20240214_124130](https://github.com/equinor/dm-core-packages/assets/11062560/c8c89897-73e8-42e2-b12c-e1f2169eed2b)
![Screenshot_20240214_133534](https://github.com/equinor/dm-core-packages/assets/11062560/0a4e8dec-82b5-462b-bf03-f8afbd79b7ae)


## Issues related to this change
Closes #1148 

