### PR TITLE
fix: flaky table test

### DIFF
--- a/e2e/tests/plugin-table-car_list.spec.ts
+++ b/e2e/tests/plugin-table-car_list.spec.ts
@@ -52,11 +52,11 @@ test('Table car list example', async ({ page }) => {
   await test.step('Delete a car from the table', async () => {
     await page.getByRole('button', { name: 'Row actions' }).last().click()
     await page.getByRole('menuitem', { name: 'Delete' }).click()
+    await expect(page.getByText('1 - 1 of 1')).toBeVisible()
+    await page.reload()
     await expect(
       page.getByRole('button', { name: 'Open expandable row' })
     ).toHaveCount(1)
-    await page.reload()
-    await expect(page.getByText('1 - 1 of 1')).toBeVisible()
   })
 
   await test.step('Add car using multiple template', async () => {


### PR DESCRIPTION
## What does this pull request change?
Changed the order of a few asserts.

## Why is this pull request needed?
Test was flaky due to reloading happening before deleting is complete. Try to fix by using another assert to verify frontend before reloading.

## Issues related to this change
Closes #1305 
