### PR TITLE
fix: call form onChange instead of save in DataGridPlugin if passed

### DIFF
--- a/packages/dm-core-plugins/src/data-grid/DataGridPlugin.tsx
+++ b/packages/dm-core-plugins/src/data-grid/DataGridPlugin.tsx
@@ -78,16 +78,16 @@ export function DataGridPlugin(props: IUIPlugin) {
 
   function parseDataBeforeSave() {
     let modifiedData = data
-      if (config.printDirection === 'vertical') {
-        modifiedData = reverseData(data || [], getColumnsLength(data || []))
-      }
-      let dataToSave = { [fieldNames[0]]: modifiedData }
-      if (multiplePrimitives) {
-        dataToSave = Object.fromEntries(
-          (modifiedData || []).map((value, index) => [fieldNames[index], value])
-        )
-      }
-      return dataToSave
+    if (config.printDirection === 'vertical') {
+      modifiedData = reverseData(data || [], getColumnsLength(data || []))
+    }
+    let dataToSave = { [fieldNames[0]]: modifiedData }
+    if (multiplePrimitives) {
+      dataToSave = Object.fromEntries(
+        (modifiedData || []).map((value, index) => [fieldNames[index], value])
+      )
+    }
+    return dataToSave
   }
 
   function updateForm() {
@@ -162,7 +162,7 @@ export function DataGridPlugin(props: IUIPlugin) {
             disabled={!isDirty || loading}
             className='w-max h-max overflow-hidden'
           >
-            {onChange ? "Update" : "Save"}
+            {onChange ? 'Update' : 'Save'}
           </Button>
         </Stack>
       )}

--- a/packages/dm-core-plugins/src/form/templates/ObjectModelContainedTemplate.tsx
+++ b/packages/dm-core-plugins/src/form/templates/ObjectModelContainedTemplate.tsx
@@ -99,7 +99,7 @@ export const ObjectModelContainedTemplate = (
           onOpen={onOpen}
           viewConfig={getExpandViewConfig(uiAttribute)}
           onChange={(data: Record<string, unknown>) =>
-            setValue(namePath, data, {
+            setValue(namePath, {...value, ...data}, {
               shouldValidate: true,
               shouldDirty: true,
             })

--- a/packages/dm-core-plugins/src/form/templates/ObjectModelContainedTemplate.tsx
+++ b/packages/dm-core-plugins/src/form/templates/ObjectModelContainedTemplate.tsx
@@ -99,10 +99,14 @@ export const ObjectModelContainedTemplate = (
           onOpen={onOpen}
           viewConfig={getExpandViewConfig(uiAttribute)}
           onChange={(data: Record<string, unknown>) =>
-            setValue(namePath, {...value, ...data}, {
-              shouldValidate: true,
-              shouldDirty: true,
-            })
+            setValue(
+              namePath,
+              { ...value, ...data },
+              {
+                shouldValidate: true,
+                shouldDirty: true,
+              }
+            )
           }
         />
       </FormTemplate.Content>


### PR DESCRIPTION
## What does this pull request change?
When DataGridPlugin is a part of form/onChange function is passed to plugin, call onChange function instead of save

## Why is this pull request needed?
Form overwrites changes in DataGradPlugin if it's nested more than one time.

## Issues related to this change
#1294 
