### PR TITLE
test: run integration tests with 4 workers

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -76,6 +76,8 @@ jobs:
         working-directory: example/
 
       - name: Run docker images
+        env:
+          ENVIRONMENT: CI
         run: docker-compose up -d
         working-directory: example/
 
@@ -112,6 +114,10 @@ jobs:
 
       - name: Run reset-app script
         run: ./reset-app.sh
+        working-directory: example/
+
+      - name: Warmup cache
+        run: ./heat-cache.sh
         working-directory: example/
 
       - name: Cache e2e dependencies

--- a/e2e/tests/plugin-form-model_uncontained-complex_attribute.spec.ts
+++ b/e2e/tests/plugin-form-model_uncontained-complex_attribute.spec.ts
@@ -15,7 +15,9 @@ test('Model uncontained complex attribute', async ({ page }) => {
     await expect(page.getByLabel('Name')).toHaveValue('TheBlackPearl')
     await page.getByLabel('Open in tab').click()
     await expect(page.getByRole('tab', { name: 'captain' })).toBeVisible()
-    await expect(page.getByRole('code')).toBeVisible()
+    await expect(
+      page.getByText('CaptainJackSparrow', { exact: true })
+    ).toBeVisible()
     await page.getByRole('button', { name: 'Edit' }).nth(1).click()
     await expect(page.getByRole('textbox')).toHaveValue('CaptainJackSparrow')
     await expect(

--- a/e2e/tests/plugin-list-task_list.spec.ts
+++ b/e2e/tests/plugin-list-task_list.spec.ts
@@ -39,10 +39,7 @@ test('task list', async ({ page }) => {
     await expect(page.getByLabel('Task description: (Optional)')).toHaveValue(
       'Review and submit the tax return.'
     )
-    await page
-      .getByRole('button', { name: 'Minimize item', exact: true })
-      .last()
-      .click()
+    await page.getByTestId('expandListItem-3').click()
   })
 
   await test.step('Mark task as complete', async () => {

--- a/example/.env.test
+++ b/example/.env.test
@@ -2,5 +2,6 @@
 VITE_REDIRECT_URI=http://localhost:3000/
 VITE_DMSS_URL=http://localhost:5000
 VITE_DM_JOB_URL=http://localhost:5001
+VITE_APPLICATION_ID=example-application-id
 VITE_AUTH_ENABLED=0
 VITE_TEST_ROLES='["dmss-admin","operator","developer"]'

--- a/example/docker-compose.yaml
+++ b/example/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
     restart: unless-stopped
     environment:
       AUTH_ENABLED: 0
-      ENVIRONMENT: local
+      ENVIRONMENT: ${ENVIRONMENT:-local}
 #      RESET_DATA_SOURCE: off
       MONGO_USERNAME: maf
       MONGO_PASSWORD: xd7wCEhEx4kszsecYFfC

--- a/example/heat-cache.sh
+++ b/example/heat-cache.sh
@@ -1,0 +1,30 @@
+#! /usr/bin/env bash
+
+set -euo pipefail
+
+pip install pip --quiet --upgrade
+pip install dm-cli --quiet --upgrade
+
+MODE=${1:-local}
+# Load environment (mode) specific environment values
+source .env.$MODE
+# Load token (not needed locally)
+TOKEN=${2:-""}
+
+# This should make sure all the workers(4) have loaded every blueprint in the system.
+
+dm --token "$TOKEN" --url $VITE_DMSS_URL entities validate DemoDataSource/plugins & \
+dm --token "$TOKEN" --url $VITE_DMSS_URL entities validate DemoDataSource/plugins & \
+dm --token "$TOKEN" --url $VITE_DMSS_URL entities validate DemoDataSource/plugins & \
+dm --token "$TOKEN" --url $VITE_DMSS_URL entities validate DemoDataSource/plugins
+
+dm --token "$TOKEN" --url $VITE_DMSS_URL entities validate DemoDataSource/apps & \
+dm --token "$TOKEN" --url $VITE_DMSS_URL entities validate DemoDataSource/apps & \
+dm --token "$TOKEN" --url $VITE_DMSS_URL entities validate DemoDataSource/apps & \
+dm --token "$TOKEN" --url $VITE_DMSS_URL entities validate DemoDataSource/apps
+
+dm --token "$TOKEN" --url $VITE_DMSS_URL entities validate DemoDataSource/recipes & \
+dm --token "$TOKEN" --url $VITE_DMSS_URL entities validate DemoDataSource/recipes & \
+dm --token "$TOKEN" --url $VITE_DMSS_URL entities validate DemoDataSource/recipes & \
+dm --token "$TOKEN" --url $VITE_DMSS_URL entities validate DemoDataSource/recipes
+


### PR DESCRIPTION
Depends on https://github.com/equinor/data-modelling-storage-service/pull/791

## What does this pull request change?
- Run dmss in "prod"-mode for better performance
- Warm cache before running tests

## Why is this pull request needed?
flaky tests. Seems to be caused by performance issues

## Issues related to this change
should help on #1307 
