### PR TITLE
chore: bump mongo from 3.4 to 3.6

### DIFF
--- a/example/docker-compose.yaml
+++ b/example/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
       - db
 
   db:
-    image: mongo:3.4
+    image: mongo:3.6
     environment:
       MONGO_INITDB_ROOT_USERNAME: maf
       MONGO_INITDB_ROOT_PASSWORD: xd7wCEhEx4kszsecYFfC


### PR DESCRIPTION
## What does this pull request change?
bump mongo from 3.4 to 3.6

