### PR TITLE
feat: don't use index for address of item when 'ensureUID'

### DIFF
--- a/example/app/data/DemoDataSource/plugins/list/task_list/blueprints/TaskList.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/list/task_list/blueprints/TaskList.blueprint.json
@@ -17,7 +17,8 @@
       "type": "CORE:BlueprintAttribute",
       "attributeType": "./Task",
       "contained": true,
-      "dimensions": "*"
+      "dimensions": "*",
+      "ensureUID": true
     },
     {
       "name": "_template_",

--- a/example/app/data/DemoDataSource/plugins/list/task_list/taskList.entity.json
+++ b/example/app/data/DemoDataSource/plugins/list/task_list/taskList.entity.json
@@ -9,6 +9,7 @@
   },
   "task_list": [
     {
+      "_id": "wash",
       "name": "Wash the car",
       "type": "./blueprints/Task",
       "description": "Car needs a thorough wash inside and outside.",
@@ -16,6 +17,7 @@
       "complete": false
     },
     {
+      "_id": "mow",
       "name": "Mow the lawn",
       "type": "./blueprints/Task",
       "description": "",
@@ -23,6 +25,7 @@
       "complete": false
     },
     {
+      "_id": "paint",
       "name": "Paint the living room",
       "type": "./blueprints/Task",
       "description": "",

--- a/example/app/data/DemoDataSource/plugins/table/car_list/blueprints/CarList.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/table/car_list/blueprints/CarList.blueprint.json
@@ -19,7 +19,8 @@
       "name": "cars",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "./Car",
-      "dimensions": "*"
+      "dimensions": "*",
+      "ensureUID": true
     },
     {
       "name": "_templates_",

--- a/example/app/data/DemoDataSource/plugins/table/car_list/carList.entity.json
+++ b/example/app/data/DemoDataSource/plugins/table/car_list/carList.entity.json
@@ -39,6 +39,7 @@
   ],
   "cars": [
     {
+      "_id": "volvo-in-car-list",
       "name": "Volvo",
       "type": "./blueprints/Car",
       "color": "White",

--- a/packages/dm-core-plugins/src/list/ListPlugin.tsx
+++ b/packages/dm-core-plugins/src/list/ListPlugin.tsx
@@ -14,7 +14,6 @@ import {
   TViewConfig,
   TemplateMenu,
   ViewCreator,
-  resolveRelativeAddress,
   resolveRelativeAddressSimplified,
   splitAddress,
   useList,
@@ -150,7 +149,7 @@ export const ListPlugin = (props: IUIPlugin & { config?: TListConfig }) => {
     onOpen(
       item.key,
       view,
-      `${idReference}[${item.index}]`,
+      item.idReference,
       false,
       config.saveExpanded
         ? undefined
@@ -160,6 +159,7 @@ export const ListPlugin = (props: IUIPlugin & { config?: TListConfig }) => {
         : undefined
     )
   }
+
   if (error) throw new Error(JSON.stringify(error, null, 2))
   if (isLoading) return <Loading />
 
@@ -320,30 +320,24 @@ export const ListPlugin = (props: IUIPlugin & { config?: TListConfig }) => {
                 </Stack>
               </Stack>
               <LazyLoad visible={expanded[item.key]}>
-                <div className='m-2 border-b border-[#ccc] pb-4'>
-                  <ViewCreator
-                    onSubmit={
-                      config.saveExpanded
-                        ? undefined
-                        : (data: TGenericObject) => handleItemUpdate(item, data)
-                    }
-                    onChange={
-                      config.saveExpanded
-                        ? (data: TGenericObject) => handleItemUpdate(item, data)
-                        : undefined
-                    }
-                    idReference={
-                      attribute && !attribute.contained
-                        ? resolveRelativeAddress(
-                            item?.reference?.address || '',
-                            documentPath,
-                            dataSource
-                          )
-                        : `${idReference}[${item.index}]`
-                    }
-                    viewConfig={internalConfig.expandViewConfig}
-                  />
-                </div>
+                  <div className='m-2 border-b border-[#ccc] pb-4'>
+                    <ViewCreator
+                      onSubmit={
+                        config.saveExpanded
+                          ? undefined
+                          : (data: TGenericObject) =>
+                              handleItemUpdate(item, data)
+                      }
+                      onChange={
+                        config.saveExpanded
+                          ? (data: TGenericObject) =>
+                              handleItemUpdate(item, data)
+                          : undefined
+                      }
+                      idReference={item.idReference}
+                      viewConfig={internalConfig.expandViewConfig}
+                    />
+                  </div>
               </LazyLoad>
             </Stack>
           ))}

--- a/packages/dm-core/src/components/Table/TableRow/TableRow.tsx
+++ b/packages/dm-core/src/components/Table/TableRow/TableRow.tsx
@@ -66,7 +66,7 @@ export function TableRow(props: TableRowProps) {
         label: config.labelByIndex ? `${label} #${index + 1}` : label,
         type: 'ViewConfig',
       },
-      `${idReference}[${index}]`,
+      item.idReference,
       false,
       (data: any) => handleItemUpdate(item, data)
     )
@@ -175,7 +175,7 @@ export function TableRow(props: TableRowProps) {
           style={{ maxWidth: config.width || 'none' }}
         >
           <ViewCreator
-            idReference={`${idReference}[${item.index}]`}
+            idReference={item.idReference}
             onSubmit={(data: TGenericObject) => handleItemUpdate(item, data)}
             viewConfig={
               config.expandableRecipeViewConfig

--- a/packages/dm-core/src/hooks/useList/types.ts
+++ b/packages/dm-core/src/hooks/useList/types.ts
@@ -4,6 +4,7 @@ import { TAttribute, TLinkReference } from '../../types'
 export type TItem<T> = {
   key: string
   index: number
+  idReference: string
   data: T | null
   reference?: TLinkReference | null
   isSaved?: boolean

--- a/packages/dm-core/src/hooks/useList/useList.test.tsx
+++ b/packages/dm-core/src/hooks/useList/useList.test.tsx
@@ -58,11 +58,13 @@ describe('contained list', () => {
           index: 0,
           isSaved: true,
           reference: null,
+          idReference: "testDS/1[0]",
           key: expect.any(String),
           data: mockList[0],
         },
         {
           index: 1,
+          idReference: "testDS/1[1]",
           isSaved: true,
           reference: null,
           key: expect.any(String),
@@ -110,9 +112,11 @@ describe('contained list', () => {
           isSaved: true,
           reference: null,
           key: expect.any(String),
+          idReference: "testDS/1[0]",
           data: mockList[0],
         },
         {
+          idReference: "testDS/1[1]",
           index: 1,
           isSaved: true,
           reference: null,
@@ -121,6 +125,7 @@ describe('contained list', () => {
         },
         {
           index: 2,
+          idReference: "testDS/1[2]",
           isSaved: false,
           reference: null,
           key: expect.any(String),
@@ -151,6 +156,7 @@ describe('contained list', () => {
           index: 0,
           isSaved: true,
           reference: null,
+          idReference: "testDS/1[0]",
           key: expect.any(String),
           data: mockList[0],
         },
@@ -160,9 +166,11 @@ describe('contained list', () => {
           reference: null,
           key: expect.any(String),
           data: mockList[1],
+          idReference: "testDS/1[1]",
         },
         {
           index: 2,
+          idReference: "testDS/1[2]",
           isSaved: true,
           reference: null,
           key: expect.any(String),
@@ -184,6 +192,7 @@ describe('contained list', () => {
       expect(result.current.items).toEqual([
         {
           index: 0,
+          idReference: "testDS/1[0]",
           isSaved: true,
           reference: null,
           key: expect.any(String),
@@ -191,6 +200,7 @@ describe('contained list', () => {
         },
         {
           index: 1,
+          idReference: "testDS/1[1]",
           isSaved: true,
           reference: null,
           key: expect.any(String),
@@ -208,6 +218,7 @@ describe('contained list', () => {
       expect(result.current.items).toEqual([
         {
           index: 1,
+          idReference: "testDS/1[1]",
           isSaved: true,
           reference: null,
           key: expect.any(String),
@@ -225,6 +236,7 @@ describe('contained list', () => {
       expect(result.current.items).toEqual([
         {
           index: 0,
+          idReference: "testDS/1[0]",
           isSaved: true,
           reference: null,
           key: expect.any(String),
@@ -233,6 +245,7 @@ describe('contained list', () => {
         {
           index: 1,
           isSaved: true,
+          idReference: "testDS/1[1]",
           reference: null,
           key: expect.any(String),
           data: mockList[1],
@@ -249,6 +262,7 @@ describe('contained list', () => {
       expect(result.current.items).toEqual([
         {
           index: 1,
+          idReference: "testDS/1[1]",
           isSaved: true,
           reference: null,
           key: expect.any(String),
@@ -265,6 +279,7 @@ describe('contained list', () => {
       expect(result.current.items).toEqual([
         {
           index: 0,
+          idReference: "testDS/1[0]",
           isSaved: true,
           reference: null,
           key: expect.any(String),
@@ -272,6 +287,7 @@ describe('contained list', () => {
         },
         {
           index: 1,
+          idReference: "testDS/1[1]",
           isSaved: true,
           reference: null,
           key: expect.any(String),
@@ -291,6 +307,7 @@ describe('contained list', () => {
       expect(result.current.items).toEqual([
         {
           index: 0,
+          idReference: "testDS/1[0]",
           isSaved: true,
           reference: null,
           key: expect.any(String),
@@ -298,6 +315,7 @@ describe('contained list', () => {
         },
         {
           index: 1,
+          idReference: "testDS/1[1]",
           isSaved: true,
           reference: null,
           key: expect.any(String),
@@ -315,12 +333,14 @@ describe('contained list', () => {
         {
           index: 0,
           isSaved: true,
+          idReference: "testDS/1[0]",
           reference: null,
           key: expect.any(String),
           data: mockList[0],
         },
         {
           index: 1,
+          idReference: "testDS/1[1]",
           isSaved: true,
           reference: null,
           key: expect.any(String),
@@ -340,6 +360,7 @@ describe('contained list', () => {
       expect(result.current.items).toEqual([
         {
           index: 0,
+          idReference: "testDS/1[0]",
           isSaved: true,
           reference: null,
           key: expect.any(String),
@@ -347,6 +368,7 @@ describe('contained list', () => {
         },
         {
           index: 1,
+          idReference: "testDS/1[1]",
           isSaved: true,
           reference: null,
           key: expect.any(String),
@@ -364,6 +386,7 @@ describe('contained list', () => {
       expect(result.current.items).toEqual([
         {
           index: 0,
+          idReference: "testDS/1[0]",
           isSaved: true,
           reference: null,
           key: expect.any(String),
@@ -371,6 +394,7 @@ describe('contained list', () => {
         },
         {
           index: 1,
+          idReference: "testDS/1[1]",
           isSaved: true,
           reference: null,
           key: expect.any(String),
@@ -394,6 +418,7 @@ describe('contained list', () => {
       expect(result.current.items).toEqual([
         {
           index: 0,
+          idReference: "testDS/1[0]",
           isSaved: true,
           reference: null,
           key: expect.any(String),
@@ -401,6 +426,7 @@ describe('contained list', () => {
         },
         {
           index: 1,
+          idReference: "testDS/1[1]",
           isSaved: false,
           reference: null,
           key: expect.any(String),
@@ -413,6 +439,7 @@ describe('contained list', () => {
       expect(result.current.items).toEqual([
         {
           index: 0,
+          idReference: "testDS/1[0]",
           isSaved: true,
           reference: null,
           key: expect.any(String),
@@ -420,6 +447,7 @@ describe('contained list', () => {
         },
         {
           index: 1,
+          idReference: "testDS/1[1]",
           isSaved: true,
           reference: null,
           key: expect.any(String),
@@ -491,6 +519,7 @@ describe('non contained list with resolve references enabled', () => {
       expect(result.current.items).toEqual([
         {
           index: 0,
+          idReference: "$1",
           isSaved: true,
           reference: referenceList[0],
           key: expect.any(String),
@@ -498,6 +527,7 @@ describe('non contained list with resolve references enabled', () => {
         },
         {
           index: 1,
+          idReference: "$2",
           isSaved: true,
           reference: referenceList[1],
           key: expect.any(String),
@@ -532,6 +562,7 @@ describe('non contained list with resolve references enabled', () => {
       expect(result.current.items).toEqual([
         {
           index: 0,
+          idReference: "$1",
           isSaved: true,
           reference: referenceList[0],
           key: expect.any(String),
@@ -539,6 +570,7 @@ describe('non contained list with resolve references enabled', () => {
         },
         {
           index: 1,
+          idReference: "$2",
           isSaved: true,
           reference: referenceList[1],
           key: expect.any(String),
@@ -546,6 +578,7 @@ describe('non contained list with resolve references enabled', () => {
         },
         {
           index: 2,
+          idReference: "$3",
           isSaved: false,
           reference: newReference,
           key: expect.any(String),
@@ -580,6 +613,7 @@ describe('non contained list with resolve references enabled', () => {
       expect(result.current.items).toEqual([
         {
           index: 0,
+          idReference: "$1",
           isSaved: true,
           reference: referenceList[0],
           key: expect.any(String),
@@ -587,6 +621,7 @@ describe('non contained list with resolve references enabled', () => {
         },
         {
           index: 1,
+          idReference: "$2",
           isSaved: true,
           reference: referenceList[1],
           key: expect.any(String),
@@ -594,6 +629,7 @@ describe('non contained list with resolve references enabled', () => {
         },
         {
           index: 2,
+          idReference: "$3",
           isSaved: true,
           reference: newReference,
           key: expect.any(String),
@@ -617,6 +653,7 @@ describe('non contained list with resolve references disabled', () => {
       expect(result.current.items).toEqual([
         {
           index: 0,
+          idReference: "$1",
           isSaved: true,
           reference: referenceList[0],
           key: expect.any(String),
@@ -624,6 +661,7 @@ describe('non contained list with resolve references disabled', () => {
         },
         {
           index: 1,
+          idReference: "$2",
           isSaved: true,
           reference: referenceList[1],
           key: expect.any(String),
@@ -656,11 +694,13 @@ describe('non contained list with resolve references disabled', () => {
           index: 0,
           isSaved: true,
           reference: referenceList[0],
+          idReference: "$1",
           key: expect.any(String),
           data: referenceList[0],
         },
         {
           index: 1,
+          idReference: "$2",
           isSaved: true,
           reference: referenceList[1],
           key: expect.any(String),
@@ -668,6 +708,7 @@ describe('non contained list with resolve references disabled', () => {
         },
         {
           index: 2,
+          idReference: "$3",
           isSaved: false,
           reference: newReference,
           key: expect.any(String),
@@ -702,15 +743,18 @@ describe('non contained list with resolve references disabled', () => {
           reference: referenceList[0],
           key: expect.any(String),
           data: referenceList[0],
+          idReference: "$1",
         },
         {
           index: 1,
           isSaved: true,
           reference: referenceList[1],
+          idReference: "$2",
           key: expect.any(String),
           data: referenceList[1],
         },
         {
+          idReference: "$3",
           index: 2,
           isSaved: true,
           reference: newReference,

--- a/packages/dm-core/src/hooks/useList/utils.ts
+++ b/packages/dm-core/src/hooks/useList/utils.ts
@@ -1,3 +1,5 @@
+import { TItem } from './types'
+
 export function arrayMove(arr: any[], fromIndex: number, toIndex: number) {
   const arrayCopy = [...arr]
   const element = arrayCopy[fromIndex]
@@ -6,17 +8,16 @@ export function arrayMove(arr: any[], fromIndex: number, toIndex: number) {
   return arrayCopy
 }
 
-export function createNewItemObject(
+export const createNewItemObject = (
   data: any,
   newItemIndex: number,
-  isSaved: boolean
-) {
-  const id: string = crypto.randomUUID()
-  return {
-    key: id,
-    data,
-    index: newItemIndex,
-    reference: null,
-    isSaved,
-  }
-}
+  isSaved: boolean,
+  idReference: string
+): TItem<any> => ({
+  key: crypto.randomUUID(),
+  idReference: idReference,
+  data,
+  index: newItemIndex,
+  reference: null,
+  isSaved,
+})

--- a/packages/dm-core/src/types.ts
+++ b/packages/dm-core/src/types.ts
@@ -27,6 +27,7 @@ export type TAttribute = {
   name: string
   type: string
   attributeType: string
+  ensureUID?: boolean
   dimensions?: string
   optional?: boolean
   contained?: boolean


### PR DESCRIPTION
## What does this pull request change?
- Items in lists (useList hook), now has an `idReference`. 
  - Will be set to `_id=...` if "ensureUID", else use index


depends on:
- https://github.com/equinor/data-modelling-storage-service/pull/807

## Issues related to this change
closes #1308 

