### PR TITLE
feat(publish): copy and link mode

### DIFF
--- a/e2e/tests/plugin-form-relative_reference.spec.ts
+++ b/e2e/tests/plugin-form-relative_reference.spec.ts
@@ -113,7 +113,7 @@ test('Relative reference', async ({ page }) => {
     await expect(page.getByTestId('form-number-widget-A Number')).toHaveValue(
       '3'
     )
-    await page.getByTestId('expandListItem-0').click()
+    // await page.getByTestId('expandListItem-0').click()
   })
 
   await test.step('Nested root reference', async () => {
@@ -127,7 +127,7 @@ test('Relative reference', async ({ page }) => {
       page.getByTestId('form-number-widget-A Number').last()
     ).toHaveValue('400')
     await page.getByTestId('form-number-widget-A Number').last().fill('4')
-    await page.getByRole('button', { name: 'Submit' }).click()
+    await page.getByRole('button', { name: 'Submit' }).last().click()
     await expect(page.getByRole('alert')).toHaveText(['Document updated'])
     await page
       .getByRole('button', { name: 'close', exact: true })
@@ -144,7 +144,7 @@ test('Relative reference', async ({ page }) => {
     await expect(
       page.getByTestId('form-number-widget-A Number').last()
     ).toHaveValue('10')
-    await page.getByRole('button', { name: 'Close job' }).click()
+    await page.getByRole('button', { name: 'Close job' }).last().click()
 
     await page.getByText('Data', { exact: true }).nth(2).click()
     await expect(page.getByRole('code')).toBeVisible()

--- a/example/app/data/DemoDataSource/plugins/publish/Archive.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/publish/Archive.blueprint.json
@@ -1,0 +1,13 @@
+{
+  "name": "Archive",
+  "type": "CORE:Blueprint",
+  "extends": ["CORE:NamedEntity"],
+  "attributes": [
+    {
+      "name": "publishedReports",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "PLUGINS:dm-core-plugins/common/Meta",
+      "dimensions": "*"
+    }
+  ]
+}

--- a/example/app/data/DemoDataSource/plugins/publish/PublishWrapper.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/publish/PublishWrapper.blueprint.json
@@ -1,0 +1,12 @@
+{
+  "name": "PublishWrapper",
+  "type": "CORE:Blueprint",
+  "extends": ["CORE:Entity"],
+  "attributes": [
+    {
+      "name": "report",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "./Report"
+    }
+  ]
+}

--- a/example/app/data/DemoDataSource/plugins/publish/Report.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/publish/Report.blueprint.json
@@ -1,0 +1,5 @@
+{
+  "name": "Report",
+  "type": "CORE:Blueprint",
+  "extends": ["CORE:NamedEntity"]
+}

--- a/example/app/data/DemoDataSource/plugins/publish/archive.entity.json
+++ b/example/app/data/DemoDataSource/plugins/publish/archive.entity.json
@@ -1,0 +1,6 @@
+{
+  "_id": "45dcc280-8350-4bef-bf75-ff09db23732c",
+  "type": "dmss://DemoDataSource/plugins/publish/Archive",
+  "name": "archive",
+  "publishedReports": []
+}

--- a/example/app/data/DemoDataSource/plugins/publish/report.entity.json
+++ b/example/app/data/DemoDataSource/plugins/publish/report.entity.json
@@ -1,0 +1,9 @@
+{
+  "type": "./PublishWrapper",
+  "name": "publishWrapper",
+  "report": {
+    "type": "./Report",
+    "name": "Minority",
+    "description": "This is a report that might get published"
+  }
+}

--- a/example/app/data/DemoDataSource/recipes/meta.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/meta.recipe.json
@@ -1,0 +1,9 @@
+{
+  "type": "CORE:RecipeLink",
+  "_blueprintPath_": "PLUGINS:dm-core-plugins/common/Meta",
+  "initialUiRecipe": {
+    "name": "Meta",
+    "plugin": "@development-framework/dm-core-plugins/meta",
+    "type": "CORE:UiRecipe"
+  }
+}

--- a/example/app/data/DemoDataSource/recipes/plugins/publish/publishWrapper.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/publish/publishWrapper.recipe.json
@@ -1,0 +1,25 @@
+{
+  "type": "CORE:RecipeLink",
+  "_blueprintPath_": "/plugins/publish/PublishWrapper",
+  "initialUiRecipe": {
+    "name": "SingleView",
+    "type": "CORE:UiRecipe",
+    "plugin": "@development-framework/dm-core-plugins/single_view",
+    "config": {
+      "type": "CORE:InlineRecipeViewConfig",
+      "scope": "report",
+      "recipe": {
+        "name": "Publish",
+        "plugin": "@development-framework/dm-core-plugins/publish",
+        "type": "CORE:UiRecipe",
+        "config": {
+          "type": "PLUGINS:dm-core-plugins/publish/PublishConfig",
+          "destination": "dmss://DemoDataSource/plugins/publish",
+          "linkDestination": "dmss://DemoDataSource/plugins/publish/archive.publishedReports",
+          "mode": "copy&link",
+          "description": "Create a copy of the report, and a link in the list of official reports."
+        }
+      }
+    }
+  }
+}

--- a/packages/dm-core-plugins/blueprints/publish/PublishConfig.json
+++ b/packages/dm-core-plugins/blueprints/publish/PublishConfig.json
@@ -8,20 +8,41 @@
       "attributeType": "string"
     },
     {
-      "name": "publishDestination",
+      "name": "destination",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
       "attributeType": "string",
       "description": "A reference/Id to where the published copy should be added."
     },
     {
-      "name": "publishWrapper",
+      "name": "linkDestination",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "description": "A reference/Id to where a link to the published document should be added."
+    },
+    {
+      "name": "wrapper",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
       "description": "A blueprint for which an entity of will serve as a wrapper for the published document",
       "attributeType": "string",
       "optional": true
     },
     {
-      "name": "publishWrapperAttribute",
+      "name": "description",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "A text to inform the user what the publish action does",
+      "attributeType": "string",
+      "optional": true
+    },
+    {
+      "name": "mode",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "Which mode the publish plugin should operate in. One of 'copy' | 'link'| 'copy&link'",
+      "attributeType": "string",
+      "default": "copy&link",
+      "optional": true
+    },
+    {
+      "name": "wrapperAttribute",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
       "description": "Name of attribute in the 'publishWrapper'-blueprint of which the document will be placed.",
       "attributeType": "string",

--- a/packages/dm-core-plugins/src/list/ListPlugin.tsx
+++ b/packages/dm-core-plugins/src/list/ListPlugin.tsx
@@ -320,24 +320,22 @@ export const ListPlugin = (props: IUIPlugin & { config?: TListConfig }) => {
                 </Stack>
               </Stack>
               <LazyLoad visible={expanded[item.key]}>
-                  <div className='m-2 border-b border-[#ccc] pb-4'>
-                    <ViewCreator
-                      onSubmit={
-                        config.saveExpanded
-                          ? undefined
-                          : (data: TGenericObject) =>
-                              handleItemUpdate(item, data)
-                      }
-                      onChange={
-                        config.saveExpanded
-                          ? (data: TGenericObject) =>
-                              handleItemUpdate(item, data)
-                          : undefined
-                      }
-                      idReference={item.idReference}
-                      viewConfig={internalConfig.expandViewConfig}
-                    />
-                  </div>
+                <div className='m-2 border-b border-[#ccc] pb-4'>
+                  <ViewCreator
+                    onSubmit={
+                      config.saveExpanded
+                        ? undefined
+                        : (data: TGenericObject) => handleItemUpdate(item, data)
+                    }
+                    onChange={
+                      config.saveExpanded
+                        ? (data: TGenericObject) => handleItemUpdate(item, data)
+                        : undefined
+                    }
+                    idReference={item.idReference}
+                    viewConfig={internalConfig.expandViewConfig}
+                  />
+                </div>
               </LazyLoad>
             </Stack>
           ))}

--- a/packages/dm-core-plugins/src/meta/MetaPlugin.tsx
+++ b/packages/dm-core-plugins/src/meta/MetaPlugin.tsx
@@ -12,7 +12,7 @@ import { DateTime } from 'luxon'
 export const MetaPlugin = (props: IUIPlugin) => {
   const { document, isLoading, error } = useDocument<TGenericObject>(
     props.idReference,
-    0
+    1
   )
 
   if (isLoading) return <Loading />
@@ -23,11 +23,6 @@ export const MetaPlugin = (props: IUIPlugin) => {
 
   const meta: TMeta = document._meta_
 
-  if (document.type !== 'dmss://system/Plugins/dm-core-plugins/common/Meta')
-    throw new Error(
-      'The meta plugin only supports entities of type "Meta" at this stage'
-    )
-
   return (
     <>
       <Table className={'w-full'}>
@@ -37,6 +32,7 @@ export const MetaPlugin = (props: IUIPlugin) => {
             <Table.Cell>Created time</Table.Cell>
             <Table.Cell>Last modified by</Table.Cell>
             <Table.Cell>Last modified time</Table.Cell>
+            <Table.Cell>Note</Table.Cell>
           </Table.Row>
         </Table.Head>
         <Table.Body>
@@ -73,16 +69,26 @@ export const MetaPlugin = (props: IUIPlugin) => {
                   )
                 : '-'}
             </Table.Cell>
+            <Table.Cell>{meta?.versionNote}</Table.Cell>
           </Table.Row>
         </Table.Body>
       </Table>
       {/*This empty div wrapper is kind of a hack to avoid EntityView take the same height as the entire plugin*/}
       <div>
-        <EntityView
-          {...props}
-          type={document.content.type}
-          idReference={`${props.idReference}.content`}
-        />
+        {document.type ===
+        'dmss://system/Plugins/dm-core-plugins/common/Meta' ? (
+          <EntityView
+            {...props}
+            type={document.content.type}
+            idReference={`${props.idReference}.content`}
+          />
+        ) : (
+          <EntityView
+            {...props}
+            type={document.type}
+            idReference={props.idReference}
+          />
+        )}
       </div>
     </>
   )

--- a/packages/dm-core-plugins/src/publish/PublishPlugin.tsx
+++ b/packages/dm-core-plugins/src/publish/PublishPlugin.tsx
@@ -10,13 +10,15 @@ import { useState } from 'react'
 export const PublishPlugin = (
   props: IUIPlugin & {
     config: {
-      publishDestination: string
-      publishWrapper?: string
-      publishWrapperAttribute?: string
+      destination: string
+      linkDestination?: string
+      description?: string
+      wrapper?: string
+      wrapperAttribute?: string
+      mode?: 'copy' | 'link' | 'copy&link'
     }
   }
 ) => {
-  const { idReference } = props
   const [showPublishDialog, setShowPublishDialog] = useState<boolean>(false)
 
   return (
@@ -31,18 +33,16 @@ export const PublishPlugin = (
           <Icon data={approve} />
         </Button>
         <CopyLinkDialog
-          title={'Publish report?'}
+          title={'Publish report'}
+          description={props.config.description}
           buttonText={'Publish'}
-          destination={props.config.publishDestination}
-          mode={'copy'}
-          // Defaults to using a "Meta"-entity as a wrapper. Can be overridden with config
-          wrapper={
-            props.config.publishWrapper ||
-            'dmss://system/Plugins/dm-core-plugins/common/Meta'
-          }
-          wrapperAttribute={props.config.publishWrapperAttribute || 'content'}
+          destination={props.config.destination}
+          linkTarget={props.config.linkDestination}
+          mode={props.config.mode || 'copy&link'}
+          wrapper={props.config.wrapper}
+          wrapperAttribute={props.config.wrapperAttribute || 'content'}
           hideProvidedFields={true}
-          idReference={idReference}
+          idReference={props.idReference}
           open={showPublishDialog}
           setOpen={setShowPublishDialog}
         />

--- a/packages/dm-core/src/components/CopyLinkDialog.tsx
+++ b/packages/dm-core/src/components/CopyLinkDialog.tsx
@@ -1,4 +1,13 @@
-import { Button, Checkbox, Label, Progress } from '@equinor/eds-core-react'
+import {
+  Button,
+  Icon,
+  Label,
+  Progress,
+  Radio,
+  TextField,
+  Tooltip,
+} from '@equinor/eds-core-react'
+import { folder_open } from '@equinor/eds-icons'
 import { AxiosError } from 'axios'
 import { ChangeEvent, useContext, useState } from 'react'
 import { toast } from 'react-toastify'
@@ -11,6 +20,7 @@ import {
   TEntityPickerReturn,
   TLinkReference,
   TValidEntity,
+  truncatePathString,
   useDMSS,
   useDocument,
 } from '../index'
@@ -20,10 +30,12 @@ type TPropsBase = {
   idReference: string
   open: boolean
   setOpen: (v: boolean) => void
-  mode?: 'copy' | 'link'
+  mode?: 'copy' | 'link' | 'copy&link'
   title?: string
   buttonText?: string
   destination?: string
+  description?: string
+  linkTarget?: string
   hideProvidedFields?: boolean
 }
 
@@ -39,6 +51,8 @@ export const CopyLinkDialog = (props: TProps) => {
     idReference,
     mode,
     destination,
+    description,
+    linkTarget,
     open,
     setOpen,
     hideProvidedFields,
@@ -58,29 +72,38 @@ export const CopyLinkDialog = (props: TProps) => {
       path: destination || '',
       entity: { type: '' },
     })
-  const [selectedMode, setSelectedMode] = useState<'copy' | 'link'>(
-    mode || 'copy'
-  )
+  const [selectedLinkTarget, setLinkTarget] = useState<TEntityPickerReturn>({
+    address: linkTarget || '',
+    path: linkTarget || '',
+    entity: { type: '' },
+  })
+  const [selectedMode, setSelectedMode] = useState<
+    'copy' | 'link' | 'copy&link'
+  >(mode || 'copy')
+  const [note, setNote] = useState<string>('')
   const [showDestinationDialog, setShowDestinationDialog] =
+    useState<boolean>(false)
+  const [showLinkTargetDialog, setShowLinkTargetDialog] =
     useState<boolean>(false)
   const { document, isLoading: documentIsLoading } = useDocument<TValidEntity>(
     idReference,
     9
   )
-
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const dmss = useDMSS()
 
-  const copyEntityToDestination = async () => {
-    if (!selectedDestination) return
+  const copyEntityToDestination = async (): Promise<
+    Promise<TEntityPickerReturn> | Promise<void>
+  > => {
     setIsLoading(true)
     let newDocument = window.structuredClone(document) as TValidEntity
-    // @ts-ignore
-    newDocument['_id'] = undefined // Remove any old ID, or we will get into trouble
+
+    delete newDocument['_id'] // Remove any old ID, or we will get into trouble
 
     newDocument._meta_ = newDocument?._meta_ || {
       type: EBlueprint.META,
       version: '0.0.1',
+      versionNote: note,
       dependencies: [],
       createdBy: username,
       createdTimestamp: new Date().toISOString(),
@@ -98,13 +121,19 @@ export const CopyLinkDialog = (props: TProps) => {
       newDocument = wrapperEntity
     }
 
-    dmss
+    return dmss
       .documentAdd({
         address: selectedDestination.address,
         document: JSON.stringify(newDocument),
       })
-      .then(() => {
+      .then((response) => {
         toast.success(`Entity copied to '${selectedDestination.path}'`)
+        const newCopyAddress = (response.data as { uid: string }).uid
+        return {
+          address: newCopyAddress,
+          path: newCopyAddress,
+          entity: { type: '' },
+        } as TEntityPickerReturn
       })
       .catch((error: AxiosError<ErrorResponse>) => {
         console.error(error)
@@ -116,21 +145,20 @@ export const CopyLinkDialog = (props: TProps) => {
       })
   }
 
-  const insertLinkAtDestination = () => {
-    if (!selectedDestination) return
+  const insertLinkAtDestination = (target: TEntityPickerReturn) => {
     setIsLoading(true)
     const linkReference: TLinkReference = {
-      address: idReference,
+      address: target.address,
       referenceType: 'link',
       type: EBlueprint.REFERENCE,
     }
     dmss
       .documentAdd({
-        address: selectedDestination.address,
+        address: selectedLinkTarget.address,
         document: JSON.stringify(linkReference),
       })
       .then(() => {
-        toast.success(`Entity linked to '${selectedDestination.path}'`)
+        toast.success(`Entity linked to '${selectedLinkTarget.path}'`)
         setOpen(false)
       })
       .catch((error: AxiosError<ErrorResponse>) => {
@@ -140,40 +168,110 @@ export const CopyLinkDialog = (props: TProps) => {
       .finally(() => setIsLoading(false))
   }
 
+  const copyAndLink = async () => {
+    const newCopy = (await copyEntityToDestination()) || null
+    if (!newCopy) return
+    insertLinkAtDestination(newCopy)
+  }
+
   return (
-    <Dialog open={open} style={{ minWidth: '230px' }}>
+    <Dialog
+      open={open}
+      style={{ minWidth: '450px', width: '40vw', maxWidth: '600px' }}
+    >
       <Dialog.Header>
         <Dialog.Title>{title || 'Copy or link entity'}</Dialog.Title>
       </Dialog.Header>
       <Dialog.CustomContent>
+        {description && <p className='mb-4'>{description}</p>}
+        <TextField
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            setNote(e.target.value)
+          }
+          id='textfield-normal'
+          placeholder='Note on published version'
+          label='Note'
+          autoComplete='off'
+        />
+        {(!destination || !hideProvidedFields) && (
+          <div className={'flex justify-between align-center py-2'}>
+            <div className={'flex items-center'}>
+              <Label label='Destination:' />
+              <p>{truncatePathString(selectedDestination.path || '-')}</p>
+            </div>
+            <Button
+              variant='ghost_icon'
+              aria-label='browse destination action'
+              onClick={() => setShowDestinationDialog(true)}
+            >
+              <Icon data={folder_open}></Icon>
+            </Button>
+          </div>
+        )}
+        {(!linkTarget || !hideProvidedFields) &&
+          selectedMode === 'copy&link' && (
+            <div className={'flex justify-between align-center py-2'}>
+              <div className={'flex items-center'}>
+                <Label label='Link target:' />
+                <p>{truncatePathString(selectedLinkTarget.path || '-')}</p>
+              </div>
+              <Button
+                variant='ghost_icon'
+                aria-label='browse link action'
+                onClick={() => setShowLinkTargetDialog(true)}
+              >
+                <Icon data={folder_open}></Icon>
+              </Button>
+            </div>
+          )}
+        {(!mode || !hideProvidedFields) && (
+          <fieldset>
+            <legend>Publish mode</legend>
+            <Tooltip title='Make a copy at the destination'>
+              <Radio
+                label='Copy'
+                name='group'
+                value='copy'
+                checked={selectedMode === 'copy'}
+                onChange={() => setSelectedMode('copy')}
+              />
+            </Tooltip>
+            <Tooltip title='Insert a link at destination'>
+              <Radio
+                label='Link'
+                name='group'
+                value='link'
+                checked={selectedMode === 'link'}
+                onChange={() => setSelectedMode('link')}
+              />
+            </Tooltip>
+            <Tooltip title='Make a copy at destination, and insert a link at link target'>
+              <Radio
+                label='Copy & Link'
+                name='group'
+                value='copy&link'
+                checked={selectedMode === 'copy&link'}
+                onChange={() => setSelectedMode('copy&link')}
+              />
+            </Tooltip>
+          </fieldset>
+        )}
         <EntityPickerDialog
-          title={`Select destination for ${selectedMode}`}
+          title={`Select destination for the copy`}
           showModal={showDestinationDialog}
           setShowModal={setShowDestinationDialog}
           onChange={(v: TEntityPickerReturn) => {
             setSelectedDestination(v)
           }}
         />
-        {(!destination || !hideProvidedFields) && (
-          <div className={'flex justify-between align-center'}>
-            <div className={'flex items-center'}>
-              <Label label='Destination:' />
-              <p>{selectedDestination.path || '-'}</p>
-            </div>
-            <Button onClick={() => setShowDestinationDialog(true)}>
-              Browse
-            </Button>
-          </div>
-        )}
-        {(!mode || !hideProvidedFields) && (
-          <Checkbox
-            label='Copy as link'
-            checked={selectedMode === 'link'}
-            onChange={(e: ChangeEvent<HTMLInputElement>) =>
-              setSelectedMode(e.target.checked ? 'link' : 'copy')
-            }
-          />
-        )}
+        <EntityPickerDialog
+          title={`Select target to insert link`}
+          showModal={showLinkTargetDialog}
+          setShowModal={setShowLinkTargetDialog}
+          onChange={(v: TEntityPickerReturn) => {
+            setLinkTarget(v)
+          }}
+        />
       </Dialog.CustomContent>
       <Dialog.Actions>
         <div className={'flex justify-around w-full'}>
@@ -189,8 +287,11 @@ export const CopyLinkDialog = (props: TProps) => {
             onClick={() => {
               if (selectedMode === 'copy') {
                 copyEntityToDestination()
+              }
+              if (selectedMode === 'link') {
+                insertLinkAtDestination(selectedDestination)
               } else {
-                insertLinkAtDestination()
+                copyAndLink()
               }
             }}
           >

--- a/packages/dm-core/src/components/Pickers/EntityPickerDialog.tsx
+++ b/packages/dm-core/src/components/Pickers/EntityPickerDialog.tsx
@@ -17,17 +17,16 @@ import { TREE_DIALOG_HEIGHT, TREE_DIALOG_WIDTH } from '../../utils/variables'
 import { Dialog } from '../Dialog'
 import { TNodeWrapperProps, TreeView } from '../TreeView'
 
-const Wrapper = styled.div`
+const Wrapper = styled.div<{ cursor?: string }>`
     display: flex;
     border-radius: 5px;
     justify-content: space-between;
     align-items: center;
-    cursor: pointer;
+    cursor: ${(props) => props.cursor ?? ''};
     border-bottom: 1px solid transparent;
 
     &:hover {
-        border-bottom: 1px solid rgba(179, 178, 178, 0.5);
-        border-radius: 0;
+        background-color: rgba(229, 231, 235, 0.43);
     }
 `
 const CheckSelectNode = (
@@ -42,7 +41,7 @@ const CheckSelectNode = (
 
   if (node.isArray()) return <>{children}</>
   return (
-    <Wrapper onClick={() => onSelect(node, !nodeIsSelected)}>
+    <Wrapper cursor='pointer' onClick={() => onSelect(node, !nodeIsSelected)}>
       {children}
       {node.type === typeFilter && (
         <EdsProvider density={'compact'}>

--- a/packages/dm-core/src/hooks/useRecipe.tsx
+++ b/packages/dm-core/src/hooks/useRecipe.tsx
@@ -102,8 +102,11 @@ export const useRecipe = (
 
   const dmssAPI = useDMSS()
   const { name } = useContext(ApplicationContext)
+
   useEffect(() => {
     setLoading(true)
+    setError(null)
+    setFindRecipeError(null)
     dmssAPI
       .blueprintGet({ typeRef: typeRef, context: name })
       .then((response: any) => {

--- a/packages/dm-core/src/types.ts
+++ b/packages/dm-core/src/types.ts
@@ -105,6 +105,7 @@ export type TContainerJobHandler = {
 export type TMeta = {
   type: EBlueprint.META
   version: string
+  versionNote?: string
   dependencies: any[]
   createdBy?: string
   createdTimestamp?: string

--- a/packages/dm-core/src/utils/truncatePathString.ts
+++ b/packages/dm-core/src/utils/truncatePathString.ts
@@ -19,7 +19,7 @@ export function truncatePathString(
     previousPath = truncatedPath
     truncatedPath = truncatedPath.replace(
       '...',
-      `${splitTextOnFolders[counter]}/...`
+      `.../${splitTextOnFolders[splitTextOnFolders.length - counter - 2]}`
     )
     if (truncatedPath.length >= maxLength) {
       truncatedPath = previousPath


### PR DESCRIPTION
## What does this pull request change?
- Added "copy&link" mode to "CopyLinkDialog"
- Fixed a bug in "useRecipe", where error where not reset when changing type
- Changed "truncatePathString" to truncate start of path instead of end
- Meta plugin can now show meta for any type, not just the "Meta" type
- Updated "PublishPlugin" to support "copy&link"

depends on:
- https://github.com/equinor/data-modelling-storage-service/pull/807
- https://github.com/equinor/data-modelling-storage-service/pull/808

## Issues related to this change
closes #1330 
