### PR TITLE
fix: added testid to refresh button and jobStatus

### DIFF
--- a/packages/dm-core-plugins/src/job/JobControl.tsx
+++ b/packages/dm-core-plugins/src/job/JobControl.tsx
@@ -188,7 +188,9 @@ export const JobControl = (props: IUIPlugin) => {
       <JobButtonWrapper>
         {getControlButton(status, remove, start, false, jobIsLoading)}
         {!internalConfig.hideLogs && <JobLog logs={logs} error={error} />}
-        <Chip variant={getVariant(status)}>{status ?? 'Not registered'}</Chip>
+        <Chip variant={getVariant(status)} data-testid={'jobStatus'}>
+          {status ?? 'Not registered'}
+        </Chip>
         {internalConfig.runnerTemplates &&
           internalConfig.runnerTemplates.length > 0 && (
             <div className={'flex flex-row items-center'}>

--- a/packages/dm-core/src/components/RefreshButton.tsx
+++ b/packages/dm-core/src/components/RefreshButton.tsx
@@ -52,6 +52,7 @@ const RefreshButton = ({
   return (
     <Tooltip title={`Refresh ${tooltip}`}>
       <StyledRefreshButton
+        data-testid={'refreshButton'}
         style={hidden || wait ? { opacity: 0 } : {}}
         onClick={() => onClick()}
         onMouseLeave={() => onMouseLeave()}


### PR DESCRIPTION
## What does this pull request change?
Added testid to refresh button and jobstatus.

## Why is this pull request needed?
There were no suitable element to use with e2e-tests.

## Issues related to this change

