### PR TITLE
fix(datagrid): pagination should be high enough for numbers to fit

### DIFF
--- a/packages/dm-core-plugins/src/data-grid/DataGridPagination/DataGridPagination.tsx
+++ b/packages/dm-core-plugins/src/data-grid/DataGridPagination/DataGridPagination.tsx
@@ -32,6 +32,7 @@ export function DataGridPagination(props: DataGridPaginationProps) {
         <Styled.Select
           id='rowsPerPage'
           value={rowsPerPage}
+          style={{ height: '100%' }}
           onChange={(event) => setRowsPerPage(Number(event.target.value))}
         >
           {[5, 10, 25, 50, 100, 500].map((amount) => (


### PR DESCRIPTION


# Now looks like this: 
<img width="1473" alt="image" src="https://github.com/equinor/dm-core-packages/assets/37016135/31322946-d91a-44c1-baee-59a28ca0a42f">


#  Before it looked like this: 
<img width="1016" alt="image" src="https://github.com/equinor/dm-core-packages/assets/37016135/6fd0ae4c-59f7-463e-ae56-faaead8c2258">


