### PR TITLE
fix: make datagrid clear button 

### DIFF
--- a/packages/dm-core-plugins/src/data-grid/DataGrid.tsx
+++ b/packages/dm-core-plugins/src/data-grid/DataGrid.tsx
@@ -85,6 +85,13 @@ export function DataGrid(props: DataGridProps) {
     }
   }
 
+  function clearTable() {
+    setData([])
+    setSelectedRow(undefined)
+    setSelectedColumn(undefined)
+    setPaginationPage(0)
+  }
+
   function moveRow(direction: 'up' | 'down') {
     if (selectedRow !== undefined) {
       const toIndex = direction === 'up' ? selectedRow - 1 : selectedRow + 1
@@ -117,7 +124,7 @@ export function DataGrid(props: DataGridProps) {
   }
 
   return (
-    <Stack>
+    <Stack className='w-full'>
       <Stack>
         {config.title && <Typography variant='h5'>{config.title}</Typography>}
         {config.description && <Typography>{config.description}</Typography>}
@@ -213,6 +220,7 @@ export function DataGrid(props: DataGridProps) {
           setData={setData}
           updateColumnLabels={updateColumnLabels}
           updateRowLabels={updateRowLabels}
+          clearTable={clearTable}
         />
         <DataGridPagination
           count={data.length}

--- a/packages/dm-core-plugins/src/data-grid/DataGrid.tsx
+++ b/packages/dm-core-plugins/src/data-grid/DataGrid.tsx
@@ -63,7 +63,7 @@ export function DataGrid(props: DataGridProps) {
       : ['1']
     updateColumnLabels(columnsLength)
     updateRowLabels(data?.length)
-  }, [])
+  }, [data?.length])
 
   function addRow(newIndex?: number) {
     const newRow =

--- a/packages/dm-core-plugins/src/data-grid/DataGridActions/DataGridActions.tsx
+++ b/packages/dm-core-plugins/src/data-grid/DataGridActions/DataGridActions.tsx
@@ -8,6 +8,7 @@ import {
   Dialog,
   Icon,
   Menu,
+  Tooltip,
   Typography,
 } from '@equinor/eds-core-react'
 import {
@@ -16,6 +17,7 @@ import {
   chevron_down,
   chevron_up,
   copy,
+  delete_to_trash,
   download,
   minimize,
   settings,
@@ -42,6 +44,7 @@ type DataGridActionsProps = {
   setData: (data: any[]) => void
   updateColumnLabels: (length: number) => void
   updateRowLabels: (length: number) => void
+  clearTable: () => void
 }
 
 export function DataGridActions(props: DataGridActionsProps) {
@@ -53,6 +56,7 @@ export function DataGridActions(props: DataGridActionsProps) {
     moveRow,
     rowLabels,
     selectedRow,
+    clearTable,
   } = props
   const [includeColumnLabels, setIsIncludeColumnLabels] =
     useState<boolean>(false)
@@ -106,19 +110,23 @@ export function DataGridActions(props: DataGridActionsProps) {
   return (
     <Stack direction='row'>
       {functionality.addButtonIsEnabled && (
-        <Styled.ActionRowButton
-          aria-label='Add data row'
-          onClick={() => props.addRow()}
-        >
-          <Icon size={16} data={add} />
-        </Styled.ActionRowButton>
+        <Tooltip title='Add row'>
+          <Styled.ActionRowButton
+            aria-label='Add data row'
+            onClick={() => props.addRow()}
+          >
+            <Icon size={16} data={add} />
+          </Styled.ActionRowButton>
+        </Tooltip>
       )}
       {selectedRow !== undefined && (
         <>
           {functionality.rowsAreEditable && (
-            <Styled.ActionRowButton onClick={props.deleteRow}>
-              <Icon size={16} data={minimize} />
-            </Styled.ActionRowButton>
+            <Tooltip title='Delete selected row'>
+              <Styled.ActionRowButton onClick={props.deleteRow}>
+                <Icon size={16} data={minimize} />
+              </Styled.ActionRowButton>
+            </Tooltip>
           )}
           {functionality.isSortEnabled && (
             <>
@@ -146,6 +154,16 @@ export function DataGridActions(props: DataGridActionsProps) {
       >
         <Icon size={16} data={settings} />
       </Styled.ActionRowButton>
+      <Tooltip title='Clear table content'>
+        <Styled.ActionRowButton
+          aria-haspopup
+          aria-expanded={isMenuOpen}
+          onClick={() => clearTable()}
+          ref={setMenuButtonAnchor}
+        >
+          <Icon size={16} data={delete_to_trash} />
+        </Styled.ActionRowButton>
+      </Tooltip>
       <Menu
         anchorEl={menuButtonAnchor}
         id='table-setting-menu'

--- a/packages/dm-core-plugins/src/data-grid/DataGridPlugin.tsx
+++ b/packages/dm-core-plugins/src/data-grid/DataGridPlugin.tsx
@@ -23,17 +23,11 @@ export function DataGridPlugin(props: IUIPlugin) {
   const [loading, setLoading] = useState<boolean>(false)
   const [isDirty, setIsDirty] = useState<boolean>(false)
   const { blueprint } = useBlueprint(type)
-  const { document, isLoading, error } = useDocument<TGenericObject>(
-    idReference,
-    1
-  )
+  const { document, isLoading } = useDocument<TGenericObject>(idReference, 1)
   const { fieldNames, rowsPerPage } = config
   const multiplePrimitives = fieldNames?.length > 1
   const attribute = blueprint?.attributes?.find(
     (atts: TAttribute) => atts.name === fieldNames[0]
-  )
-  const attributes = fieldNames.map((field) =>
-    blueprint?.attributes.find((att: TAttribute) => att.name === field)
   )
 
   function getColumnsLength(data: any[]) {
@@ -82,7 +76,7 @@ export function DataGridPlugin(props: IUIPlugin) {
       modifiedData = reverseData(data || [], getColumnsLength(data || []))
     }
     let dataToSave = { [fieldNames[0]]: modifiedData }
-    if (multiplePrimitives) {
+    if (multiplePrimitives && data?.length) {
       dataToSave = Object.fromEntries(
         (modifiedData || []).map((value, index) => [fieldNames[index], value])
       )

--- a/packages/dm-core-plugins/src/data-grid/styles.ts
+++ b/packages/dm-core-plugins/src/data-grid/styles.ts
@@ -102,6 +102,7 @@ export const ActionRow = styled.div`
   display: flex;
   justify-content: space-between;
   border-bottom: 1px solid ${tokens.colors.ui.background__medium.rgba};
+  border-left: 1px solid ${tokens.colors.ui.background__medium.rgba};
   min-width: max-content;
 `
 

--- a/packages/dm-core/src/hooks/useJob.tsx
+++ b/packages/dm-core/src/hooks/useJob.tsx
@@ -132,6 +132,7 @@ export function useJob(entityId?: string, jobId?: string): IUseJob {
       return null
     }
     setIsLoading(true)
+    console.log(' --- Peter --- ')
     return dmJobApi
       .startJob({ jobDmssId: entityId })
       .then((response: AxiosResponse<StartJobResponse>) => {


### PR DESCRIPTION
## What does this pull request change?

1. added clear button, and clearing functionality
2. fixed a datagrid bug where one could not submit empty datagrid
3. added tooltips to the small buttons. 
4. made empty datagrid be full width 
5. made action row have border on the left side 

<img width="611" alt="image" src="https://github.com/equinor/dm-core-packages/assets/37016135/689cf4d3-865a-44b1-bcb2-7d9d5530cccf">

<img width="571" alt="image" src="https://github.com/equinor/dm-core-packages/assets/37016135/7f5490d7-5427-4c2c-802d-94b63b55a9ce">


## Why is this pull request needed?

## Issues related to this change

