### PR TITLE
fix: Dialog got height 0 on webkit(safari)

### DIFF
--- a/packages/dm-core/src/components/Dialog.tsx
+++ b/packages/dm-core/src/components/Dialog.tsx
@@ -2,7 +2,7 @@ import { Dialog as EdsDialog } from '@equinor/eds-core-react'
 import styled from 'styled-components'
 
 export const Dialog = styled(EdsDialog)<{ width?: string; height?: string }>`
-  height: ${(props) => props.height || '100%'};
+  height: ${(props) => props.height};
   overflow: auto;
   width: ${(props) => props.width || '100%'};
   display: flex;


### PR DESCRIPTION
## What does this pull request change?
Not sure why, but the height of the Dialog got set to "0" on safari with "height: 100%".
Seems to work fine without it. 

## Issues related to this change
closes #1331 

