### PR TITLE
fix(data-grid): disable clear button when rows are not editable

### DIFF
--- a/packages/dm-core-plugins/src/data-grid/DataGridActions/DataGridActions.tsx
+++ b/packages/dm-core-plugins/src/data-grid/DataGridActions/DataGridActions.tsx
@@ -156,16 +156,18 @@ export function DataGridActions(props: DataGridActionsProps) {
           <Icon size={16} data={settings} />
         </Styled.ActionRowButton>
       </Tooltip>
-      <Tooltip title='Clear table content'>
-        <Styled.ActionRowButton
-          aria-haspopup
-          aria-expanded={isMenuOpen}
-          onClick={() => clearTable()}
-          ref={setMenuButtonAnchor}
-        >
-          <Icon size={16} data={delete_to_trash} />
-        </Styled.ActionRowButton>
-      </Tooltip>
+      {functionality.rowsAreEditable && functionality.addButtonIsEnabled && (
+        <Tooltip title='Clear table content'>
+          <Styled.ActionRowButton
+            aria-haspopup
+            aria-expanded={isMenuOpen}
+            onClick={() => clearTable()}
+            ref={setMenuButtonAnchor}
+          >
+            <Icon size={16} data={delete_to_trash} />
+          </Styled.ActionRowButton>
+        </Tooltip>
+      )}
       <Menu
         anchorEl={menuButtonAnchor}
         id='table-setting-menu'

--- a/packages/dm-core-plugins/src/data-grid/DataGridPlugin.tsx
+++ b/packages/dm-core-plugins/src/data-grid/DataGridPlugin.tsx
@@ -123,7 +123,11 @@ export function DataGridPlugin(props: IUIPlugin) {
   }
 
   return !data ? null : (
-    <Stack className='dm-plugin-padding' alignItems='flex-start' spacing={1}>
+    <Stack
+      className='dm-plugin-padding w-full'
+      alignItems='flex-start'
+      spacing={1}
+    >
       <DataGrid
         attributeType={attribute?.attributeType || 'string'}
         config={userConfig}


### PR DESCRIPTION
## What does this pull request change?

Only show clear button when rows are editable

## Why is this pull request needed?

## Issues related to this change

