### PR TITLE
fix: ui job control 

### DIFF
--- a/packages/dm-core-plugins/src/job/JobControl/JobControl.tsx
+++ b/packages/dm-core-plugins/src/job/JobControl/JobControl.tsx
@@ -202,14 +202,22 @@ export const JobControl = (props: IUIPlugin) => {
             </div>
           )}
           <JobButtonWrapper>
-            <div className='flex items-center space-x-[1rem]'>
+            <div className='flex items-center space-x-2'>
               {getControlButton(status, remove, start, false, jobIsLoading)}
-              <div>
-                <p className='text-sm'>Status:</p>
+              <div
+                style={{
+                  width: '100px',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                }}
+              >
+                <p className='text-sm text-center'>Status:</p>
                 <Chip variant={getVariant(status)} data-testid={'jobStatus'}>
                   {status ?? 'Not registered'}
                 </Chip>
               </div>
+
               {!internalConfig.hideLogs && <JobLog logs={logs} error={error} />}
             </div>
 
@@ -256,7 +264,7 @@ export const JobControl = (props: IUIPlugin) => {
           </JobButtonWrapper>
 
           {status === JobStatus.Running && progress !== null && (
-            <div className='ps-2'>
+            <div className='px-4 pb-2'>
               <Progress progress={progress} />
             </div>
           )}

--- a/packages/dm-core-plugins/src/job/JobControl/JobControl.tsx
+++ b/packages/dm-core-plugins/src/job/JobControl/JobControl.tsx
@@ -205,7 +205,7 @@ export const JobControl = (props: IUIPlugin) => {
             <div className='flex items-center space-x-2'>
               {getControlButton(status, remove, start, false, jobIsLoading)}
               <div>
-                <p className='text-sm -mb-2'>Status:</p>
+                <p className='text-sm'>Status:</p>
                 <Chip variant={getVariant(status)} data-testid={'jobStatus'}>
                   {status ?? 'Not registered'}
                 </Chip>

--- a/packages/dm-core-plugins/src/job/JobControl/JobControl.tsx
+++ b/packages/dm-core-plugins/src/job/JobControl/JobControl.tsx
@@ -202,7 +202,7 @@ export const JobControl = (props: IUIPlugin) => {
             </div>
           )}
           <JobButtonWrapper>
-            <div className='flex items-center space-x-2'>
+            <div className='flex items-center space-x-[1rem]'>
               {getControlButton(status, remove, start, false, jobIsLoading)}
               <div>
                 <p className='text-sm'>Status:</p>
@@ -254,9 +254,11 @@ export const JobControl = (props: IUIPlugin) => {
                 </div>
               )}
           </JobButtonWrapper>
-          {status === JobStatus.Running && progress !== null && (
-            <Progress progress={progress} />
-          )}
+          <div className='p-2'>
+            {status === JobStatus.Running && progress !== null && (
+              <Progress progress={progress} />
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/packages/dm-core-plugins/src/job/JobControl/JobControl.tsx
+++ b/packages/dm-core-plugins/src/job/JobControl/JobControl.tsx
@@ -254,11 +254,12 @@ export const JobControl = (props: IUIPlugin) => {
                 </div>
               )}
           </JobButtonWrapper>
-          <div className='p-2'>
-            {status === JobStatus.Running && progress !== null && (
+
+          {status === JobStatus.Running && progress !== null && (
+            <div className='ps-2'>
               <Progress progress={progress} />
-            )}
-          </div>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/packages/dm-core-plugins/src/job/common.tsx
+++ b/packages/dm-core-plugins/src/job/common.tsx
@@ -166,7 +166,6 @@ export const Progress = (props: { progress: number }) => {
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'space-between',
-        width: '50%',
       }}
     >
       <LinearProgress

--- a/packages/dm-core/src/styles/main.css
+++ b/packages/dm-core/src/styles/main.css
@@ -47,7 +47,8 @@ body {
 }
 
 .dm-table-row .dm-plugin-padding {
-  padding: 0.5rem;
+  padding-block: 0.5rem;
+  padding-inline: 0;
 }
 
 Button,


### PR DESCRIPTION
## What does this pull request change?

Fixes some problems that were introduced in the job ui plugin feature. 

Progress bar now has padding and spans full width of the container. 
Not status and chip flows into each other. 
Also removed header, as it made the plugin less reusable. 
Fixes too much padding in the table row. 


<img width="1193" alt="image" src="https://github.com/equinor/dm-core-packages/assets/37016135/b3f88db2-2e19-4e62-b01b-b25e62ea182a">

Fixes this problem: 
<img width="471" alt="image" src="https://github.com/equinor/dm-core-packages/assets/37016135/194150db-9650-4798-8124-1acfe7d7efab">

## Why is this pull request needed?

## Issues related to this change

