### PR TITLE
fix: add flex-row class after custom layout class

### DIFF
--- a/packages/dm-core-plugins/src/styles/main.css
+++ b/packages/dm-core-plugins/src/styles/main.css
@@ -36,6 +36,10 @@ body {
   overflow-y: auto;
 }
 
+.flex-row {
+  flex-direction: row;
+}
+
 /* Add padding to plugins */
 .dm-plugin-padding {
   padding: 1rem;


### PR DESCRIPTION
## What does this pull request change?
Add flex-row class after custom layout class

## Why is this pull request needed?
tailwind classes are bundled after custom css so it doesn't overwrite custom css which is flex-direction column

