### PR TITLE
fix: add missing wrapper to sidebar content

### DIFF
--- a/packages/dm-core-plugins/src/view_selector/SidebarPlugin.tsx
+++ b/packages/dm-core-plugins/src/view_selector/SidebarPlugin.tsx
@@ -44,27 +44,29 @@ export const SidebarPlugin = (
         setSelectedViewId={setSelectedViewId}
         addView={addView}
       />
-      {viewItem.viewConfig ? (
-        <ViewCreator
-          key={`${viewItem.rootEntityId}-${viewItem.viewConfig.scope}`}
-          idReference={viewItem.rootEntityId}
-          viewConfig={viewItem.viewConfig}
-          onOpen={addView}
-          onSubmit={(data: TGenericObject) => {
-            if (viewItem?.onSubmit) viewItem?.onSubmit(data)
-            setFormData({
-              ...formData,
-              [viewItem.viewId]: data,
-            })
-          }}
-          onChange={viewItem?.onChange}
-        />
-      ) : (
-        <p>
-          {viewItem.label ?? viewItem.viewId} was selected, but has no view
-          defined
-        </p>
-      )}
+      <div className='flex-layout-container scroll'>
+        {viewItem.viewConfig ? (
+          <ViewCreator
+            key={`${viewItem.rootEntityId}-${viewItem.viewConfig.scope}`}
+            idReference={viewItem.rootEntityId}
+            viewConfig={viewItem.viewConfig}
+            onOpen={addView}
+            onSubmit={(data: TGenericObject) => {
+              if (viewItem?.onSubmit) viewItem?.onSubmit(data)
+              setFormData({
+                ...formData,
+                [viewItem.viewId]: data,
+              })
+            }}
+            onChange={viewItem?.onChange}
+          />
+        ) : (
+          <p>
+            {viewItem.label ?? viewItem.viewId} was selected, but has no view
+            defined
+          </p>
+        )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## What does this pull request change?
Add missing wrapper around content in SidebarPlugin

## Why is this pull request needed?
Not using Content (TabsContent) in Sidebar anymore, but a wrapper is still necessary to make the layout work

