### PR TITLE
feature(explorer): menu item to 'view raw' (yaml and basic edit)

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -59,10 +59,16 @@ jobs:
         run: docker-compose pull
         working-directory: example/
 
+      - name: Run docker images
+        env:
+          ENVIRONMENT: CI
+        run: docker-compose up -d
+        working-directory: example/
+
       - name: Capture output DMSS version
         id: capture_dmss_version
         run: |
-          docker-compose run --rm dmss cat src/version.txt > dmss_version.txt
+          docker-compose exec -t dmss cat src/version.txt > dmss_version.txt
           dmss_version=$(tail -n 1 dmss_version.txt)
           echo "dmss_version=$dmss_version" >> "$GITHUB_OUTPUT"
         working-directory: example/
@@ -70,15 +76,9 @@ jobs:
       - name: Capture job-api version
         id: capture_job_version
         run: |
-          docker-compose run --rm job-api cat version.txt > job_version.txt
+          docker-compose exec -t job-api cat version.txt > job_version.txt
           job_version=$(tail -n 1 job_version.txt)
           echo "job_version=$job_version" >> "$GITHUB_OUTPUT"
-        working-directory: example/
-
-      - name: Run docker images
-        env:
-          ENVIRONMENT: CI
-        run: docker-compose up -d
         working-directory: example/
 
       - name: Pack core plugins
@@ -154,6 +154,10 @@ jobs:
           name: test-results
           path: e2e/test-results/
           retention-days: 30
+
+      - name: Output dmss logs on failure
+        if: failure()
+        run: docker logs example_dmss_1
 
       - uses: actions/upload-artifact@v3
         if: always()

--- a/example/app/data/WorkflowDS/Blueprints/AzureContainer.json
+++ b/example/app/data/WorkflowDS/Blueprints/AzureContainer.json
@@ -1,0 +1,7 @@
+{
+  "name": "AzureContainer",
+  "type": "CORE:Blueprint",
+  "description": "Description of a executable job running as an Azure Container Instance",
+  "extends": ["Container"],
+  "attributes": []
+}

--- a/example/app/data/WorkflowDS/Blueprints/Container.json
+++ b/example/app/data/WorkflowDS/Blueprints/Container.json
@@ -1,0 +1,31 @@
+{
+  "name": "Container",
+  "type": "CORE:Blueprint",
+  "description": "A container job",
+  "extends": ["JobHandler"],
+  "attributes": [
+    {
+      "name": "label",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true
+    },
+    {
+      "name": "image",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "ContainerImage"
+    },
+    {
+      "name": "customCommand",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true,
+      "dimensions": "*"
+    },
+    {
+      "name": "name",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string"
+    }
+  ]
+}

--- a/example/app/data/WorkflowDS/Blueprints/ContainerImage.json
+++ b/example/app/data/WorkflowDS/Blueprints/ContainerImage.json
@@ -1,0 +1,40 @@
+{
+  "name": "ContainerImage",
+  "type": "CORE:Blueprint",
+  "description": "Container image used as job runner for a task. Full container image name is name/subName",
+  "attributes": [
+    {
+      "name": "type",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string",
+      "label": "Type",
+      "default": "",
+      "optional": false
+    },
+    {
+      "name": "description",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string",
+      "default": "",
+      "optional": true,
+      "label": "Description"
+    },
+    {
+      "name": "imageName",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true
+    },
+    {
+      "name": "version",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string",
+      "default": "latest"
+    },
+    {
+      "name": "registryName",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string"
+    }
+  ]
+}

--- a/example/app/data/WorkflowDS/Blueprints/CronJob.json
+++ b/example/app/data/WorkflowDS/Blueprints/CronJob.json
@@ -1,0 +1,35 @@
+{
+  "name": "CronJob",
+  "type": "CORE:Blueprint",
+  "description": "Blueprint for a job triggered by a time schedule",
+  "attributes": [
+    {
+      "name": "type",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "cron",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "startDate",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true
+    },
+    {
+      "name": "endDate",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true
+    },
+    {
+      "name": "runs",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "./Job",
+      "dimensions": "*"
+    }
+  ]
+}

--- a/example/app/data/WorkflowDS/Blueprints/Job.json
+++ b/example/app/data/WorkflowDS/Blueprints/Job.json
@@ -1,0 +1,93 @@
+{
+  "name": "Job",
+  "type": "CORE:Blueprint",
+  "attributes": [
+    {
+      "name": "type",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "uid",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true
+    },
+    {
+      "name": "name",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true
+    },
+    {
+      "name": "label",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true
+    },
+    {
+      "name": "triggeredBy",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true
+    },
+    {
+      "name": "status",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string",
+      "optional": false,
+      "default": "not started",
+      "enumType": "./JobStatus"
+    },
+    {
+      "name": "applicationInput",
+      "type": "CORE:BlueprintAttribute",
+      "description": "Input entity to a job",
+      "attributeType": "object",
+      "label": "Input",
+      "contained": false,
+      "optional": true
+    },
+    {
+      "name": "started",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true
+    },
+    {
+      "name": "ended",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true
+    },
+    {
+      "name": "outputTarget",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true
+    },
+    {
+      "name": "result",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "object",
+      "contained": false,
+      "optional": true
+    },
+    {
+      "name": "runner",
+      "type": "CORE:BlueprintAttribute",
+      "description": "JobRunner that will handle this job",
+      "attributeType": "JobHandler",
+      "label": "Runner",
+      "optional": true
+    },
+    {
+      "name": "referenceTarget",
+      "type": "CORE:BlueprintAttribute",
+      "description": "Dotted id to an analysis entity's job result. Should be on the format: entityId.jobs.*index*.result. Must be generated at run time since the index can vary.",
+      "attributeType": "string",
+      "label": "Reference target",
+      "optional": true
+    }
+  ]
+}

--- a/example/app/data/WorkflowDS/Blueprints/JobHandler.json
+++ b/example/app/data/WorkflowDS/Blueprints/JobHandler.json
@@ -1,0 +1,27 @@
+{
+  "name": "JobHandler",
+  "type": "CORE:Blueprint",
+  "description": "Base jobHandler type. Other jobHandlers should extend from this one",
+  "attributes": [
+    {
+      "name": "type",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string",
+      "optional": false
+    },
+    {
+      "name": "name",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true
+    },
+    {
+      "name": "environmentVariables",
+      "type": "CORE:BlueprintAttribute",
+      "description": "a list of strings on format 'myVar=myValue'",
+      "attributeType": "string",
+      "dimensions": "*",
+      "optional": true
+    }
+  ]
+}

--- a/example/app/data/WorkflowDS/Blueprints/JobStatus.json
+++ b/example/app/data/WorkflowDS/Blueprints/JobStatus.json
@@ -1,0 +1,25 @@
+{
+  "name": "JobStatus",
+  "type": "CORE:Enum",
+  "description": "String enum for valid job statuses",
+  "values": [
+    "registered",
+    "not started",
+    "starting",
+    "running",
+    "failed",
+    "completed",
+    "removed",
+    "unknown"
+  ],
+  "labels": [
+    "Registered",
+    "Not Started",
+    "Starting",
+    "Running",
+    "Failed",
+    "Completed",
+    "Removed",
+    "Unknown"
+  ]
+}

--- a/example/app/data/WorkflowDS/Blueprints/LocalContainer.json
+++ b/example/app/data/WorkflowDS/Blueprints/LocalContainer.json
@@ -1,0 +1,13 @@
+{
+  "name": "LocalContainer",
+  "type": "CORE:Blueprint",
+  "description": "Description of a executable job running as a Container in a local Docker network",
+  "extends": ["Container"],
+  "attributes": [
+    {
+      "name": "network",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string"
+    }
+  ]
+}

--- a/example/app/data/WorkflowDS/Blueprints/Radix.json
+++ b/example/app/data/WorkflowDS/Blueprints/Radix.json
@@ -1,0 +1,20 @@
+{
+  "name": "Radix",
+  "type": "CORE:Blueprint",
+  "description": "Description of a executable job running as an Radix job",
+  "extends": ["JobHandler"],
+  "attributes": [
+    {
+      "name": "jobName",
+      "type": "CORE:BlueprintAttribute",
+      "description": "The name defined in the radixconfig.yaml file",
+      "attributeType": "string"
+    },
+    {
+      "name": "schedulerPort",
+      "type": "CORE:BlueprintAttribute",
+      "description": "The schedulerPort defined in the radixconfig.yaml file",
+      "attributeType": "string"
+    }
+  ]
+}

--- a/example/app/data/WorkflowDS/Blueprints/RecurringJob.json
+++ b/example/app/data/WorkflowDS/Blueprints/RecurringJob.json
@@ -1,0 +1,23 @@
+{
+  "name": "RecurringJob",
+  "type": "CORE:Blueprint",
+  "extends": ["./Job"],
+  "attributes": [
+    {
+      "name": "applicationInput",
+      "type": "CORE:BlueprintAttribute",
+      "description": "Job entity to run on a schedule",
+      "attributeType": "./Job",
+      "label": "Job template",
+      "contained": true,
+      "optional": true
+    },
+    {
+      "name": "schedule",
+      "type": "CORE:BlueprintAttribute",
+      "description": "Schedule for a cronjob",
+      "attributeType": "CronJob",
+      "label": "Schedule"
+    }
+  ]
+}

--- a/example/app/data/WorkflowDS/Blueprints/RecurringJobHandler.json
+++ b/example/app/data/WorkflowDS/Blueprints/RecurringJobHandler.json
@@ -1,0 +1,6 @@
+{
+  "name": "RecurringJobHandler",
+  "type": "CORE:Blueprint",
+  "description": "",
+  "extends": ["JobHandler"]
+}

--- a/example/app/data/WorkflowDS/Blueprints/ReverseDescription.json
+++ b/example/app/data/WorkflowDS/Blueprints/ReverseDescription.json
@@ -1,0 +1,6 @@
+{
+  "name": "ReverseDescription",
+  "type": "CORE:Blueprint",
+  "description": "A job that takes an input of any type, and outputs a copy with the description reversed",
+  "extends": ["JobHandler"]
+}

--- a/example/app/data/WorkflowDS/Blueprints/Shell.json
+++ b/example/app/data/WorkflowDS/Blueprints/Shell.json
@@ -1,0 +1,13 @@
+{
+  "name": "Shell",
+  "type": "CORE:Blueprint",
+  "description": "Description of a shell-job. That is a job that will run in the shell. Only for testing.",
+  "extends": ["CORE:NamedEntity", "JobHandler"],
+  "attributes": [
+    {
+      "name": "script",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string"
+    }
+  ]
+}

--- a/example/app/data/WorkflowDS/Blueprints/package.json
+++ b/example/app/data/WorkflowDS/Blueprints/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "Blueprints",
+  "type": "CORE:Package",
+  "_meta_": {
+    "type": "CORE:Meta",
+    "version": "0.0.1",
+    "dependencies": [
+      {
+        "type": "CORE:Dependency",
+        "alias": "CORE",
+        "address": "system/SIMOS",
+        "version": "0.0.1",
+        "protocol": "dmss"
+      }
+    ]
+  }
+}

--- a/example/app/data/system/SIMOS/Application.json
+++ b/example/app/data/system/SIMOS/Application.json
@@ -1,0 +1,28 @@
+{
+  "name": "Application",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "description": "This describes an application",
+  "extends": ["dmss://system/SIMOS/NamedEntity"],
+  "attributes": [
+    {
+      "name": "label",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true
+    },
+    {
+      "name": "dataSources",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "dimensions": "*",
+      "optional": false
+    },
+    {
+      "name": "roles",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "dmss://system/SIMOS/Role",
+      "optional": true,
+      "dimensions": "*"
+    }
+  ]
+}

--- a/example/app/data/system/SIMOS/Blob.json
+++ b/example/app/data/system/SIMOS/Blob.json
@@ -1,0 +1,25 @@
+{
+  "name": "Blob",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "description": "Reference to a BLOB",
+  "extends": ["dmss://system/SIMOS/NamedEntity"],
+  "attributes": [
+    {
+      "name": "_blob_id",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "id for the raw blob",
+      "attributeType": "string",
+      "optional": true,
+      "contained": true
+    },
+    {
+      "name": "size",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "Size of the blob in bytes",
+      "attributeType": "integer",
+      "default": 0,
+      "optional": true,
+      "contained": true
+    }
+  ]
+}

--- a/example/app/data/system/SIMOS/Blueprint.json
+++ b/example/app/data/system/SIMOS/Blueprint.json
@@ -1,0 +1,70 @@
+{
+  "name": "Blueprint",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "description": "This describes a blueprint",
+  "_meta_": {
+    "type": "dmss://system/SIMOS/Meta",
+    "version": "0.0.1"
+  },
+  "attributes": [
+    {
+      "name": "_meta_",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "dmss://system/SIMOS/Meta",
+      "contained": true,
+      "optional": true
+    },
+    {
+      "name": "name",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "type",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "extends",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "default": [],
+      "optional": true,
+      "dimensions": "*"
+    },
+    {
+      "name": "description",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "default": "",
+      "optional": true
+    },
+    {
+      "name": "attributes",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "dmss://system/SIMOS/BlueprintAttribute",
+      "dimensions": "*",
+      "default": [
+        {
+          "name": "name",
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "attributeType": "string",
+          "optional": true
+        },
+        {
+          "name": "type",
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "attributeType": "string"
+        },
+        {
+          "name": "description",
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "attributeType": "string",
+          "optional": true
+        }
+      ],
+      "contained": true,
+      "optional": true
+    }
+  ]
+}

--- a/example/app/data/system/SIMOS/BlueprintAttribute.json
+++ b/example/app/data/system/SIMOS/BlueprintAttribute.json
@@ -1,0 +1,72 @@
+{
+  "name": "BlueprintAttribute",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "description": "This describes a blueprint attribute",
+  "extends": ["dmss://system/SIMOS/NamedEntity"],
+  "attributes": [
+    {
+      "name": "type",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "label": "Type",
+      "default": "dmss://system/SIMOS/BlueprintAttribute",
+      "optional": false
+    },
+    {
+      "name": "attributeType",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "optional": false,
+      "default": "string"
+    },
+    {
+      "name": "dimensions",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true,
+      "default": ""
+    },
+    {
+      "name": "ensureUID",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "If true, DMSS will ensure every complex child governed by this attribute, has a UUID",
+      "attributeType": "boolean",
+      "optional": true,
+      "default": false
+    },
+    {
+      "name": "label",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true,
+      "default": ""
+    },
+    {
+      "name": "default",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "any",
+      "optional": true
+    },
+    {
+      "name": "optional",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "boolean",
+      "default": false,
+      "optional": true
+    },
+    {
+      "name": "contained",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "boolean",
+      "default": true,
+      "optional": true
+    },
+    {
+      "name": "enumType",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true,
+      "default": ""
+    }
+  ]
+}

--- a/example/app/data/system/SIMOS/Dependency.json
+++ b/example/app/data/system/SIMOS/Dependency.json
@@ -1,0 +1,32 @@
+{
+  "name": "Dependency",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "description": "This describes a blueprint",
+  "attributes": [
+    {
+      "name": "type",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "version",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "alias",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "protocol",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "address",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    }
+  ]
+}

--- a/example/app/data/system/SIMOS/Entity.json
+++ b/example/app/data/system/SIMOS/Entity.json
@@ -1,0 +1,44 @@
+{
+  "name": "Entity",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "description": "Blueprint for an entity.",
+  "attributes": [
+    {
+      "name": "name",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "optional": true,
+      "attributeType": "string",
+      "label": "Name"
+    },
+    {
+      "name": "type",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "label": "Type",
+      "default": "",
+      "optional": false
+    },
+    {
+      "name": "description",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "default": "",
+      "optional": true,
+      "label": "Description"
+    },
+    {
+      "name": "label",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "default": "",
+      "optional": true,
+      "label": "Label"
+    },
+    {
+      "name": "_meta_",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "dmss://system/SIMOS/Meta",
+      "optional": true
+    }
+  ]
+}

--- a/example/app/data/system/SIMOS/Enum.json
+++ b/example/app/data/system/SIMOS/Enum.json
@@ -1,0 +1,35 @@
+{
+  "name": "Enum",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "description": "This describes an enum",
+  "attributes": [
+    {
+      "name": "name",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "type",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "description",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true
+    },
+    {
+      "name": "labels",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "dimensions": "*"
+    },
+    {
+      "name": "values",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "dimensions": "*"
+    }
+  ]
+}

--- a/example/app/data/system/SIMOS/File.json
+++ b/example/app/data/system/SIMOS/File.json
@@ -1,0 +1,44 @@
+{
+  "name": "File",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "description": "This describes a file",
+  "attributes": [
+    {
+      "name": "type",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "name",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "author",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true
+    },
+    {
+      "name": "date",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "size",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "integer"
+    },
+    {
+      "name": "filetype",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "content",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "binary",
+      "optional": true
+    }
+  ]
+}

--- a/example/app/data/system/SIMOS/InlineRecipeViewConfig.json
+++ b/example/app/data/system/SIMOS/InlineRecipeViewConfig.json
@@ -1,0 +1,12 @@
+{
+  "name": "InlineRecipeViewConfig",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "extends": ["dmss://system/SIMOS/ViewConfig"],
+  "attributes": [
+    {
+      "name": "recipe",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "dmss://system/SIMOS/UiRecipe"
+    }
+  ]
+}

--- a/example/app/data/system/SIMOS/Meta.json
+++ b/example/app/data/system/SIMOS/Meta.json
@@ -1,0 +1,54 @@
+{
+  "name": "Meta",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "description": "Meta information for the entity",
+  "attributes": [
+    {
+      "name": "dependencies",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "dmss://system/SIMOS/Dependency",
+      "dimensions": "*",
+      "optional": true
+    },
+    {
+      "name": "version",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "versionNote",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true
+    },
+    {
+      "name": "type",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "createdBy",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true
+    },
+    {
+      "name": "createdTimestamp",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true
+    },
+    {
+      "name": "lastModifiedBy",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true
+    },
+    {
+      "name": "lastModifiedTimestamp",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true
+    }
+  ]
+}

--- a/example/app/data/system/SIMOS/NamedEntity.json
+++ b/example/app/data/system/SIMOS/NamedEntity.json
@@ -1,0 +1,15 @@
+{
+  "name": "NamedEntity",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "description": "Blueprint for an entity which MUST have a name",
+  "extends": ["dmss://system/SIMOS/Entity"],
+  "attributes": [
+    {
+      "name": "name",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "optional": false,
+      "attributeType": "string",
+      "label": "Name"
+    }
+  ]
+}

--- a/example/app/data/system/SIMOS/PDF.json
+++ b/example/app/data/system/SIMOS/PDF.json
@@ -1,0 +1,42 @@
+{
+  "name": "PDF",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "description": "Contains metadata for a PDF, and a Blob type for the blob data",
+  "extends": ["dmss://system/SIMOS/NamedEntity"],
+  "attributes": [
+    {
+      "name": "blob",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "id for the data blob",
+      "attributeType": "dmss://system/SIMOS/Blob",
+      "contained": true
+    },
+    {
+      "name": "size",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "Size of the PDF in bytes",
+      "attributeType": "integer",
+      "default": 0,
+      "optional": true,
+      "contained": true
+    },
+    {
+      "name": "tags",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "List of tags used for indexing",
+      "attributeType": "string",
+      "dimensions": "*",
+      "optional": true,
+      "contained": true
+    },
+    {
+      "name": "author",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "Author of the PDF",
+      "attributeType": "string",
+      "default": "",
+      "contained": true,
+      "optional": true
+    }
+  ]
+}

--- a/example/app/data/system/SIMOS/Package.json
+++ b/example/app/data/system/SIMOS/Package.json
@@ -1,0 +1,21 @@
+{
+  "name": "Package",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "description": "This is a blueprint for a package that contains documents and other packages",
+  "extends": ["dmss://system/SIMOS/NamedEntity"],
+  "attributes": [
+    {
+      "name": "isRoot",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "boolean"
+    },
+    {
+      "name": "content",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "object",
+      "contained": true,
+      "dimensions": "*",
+      "optional": false
+    }
+  ]
+}

--- a/example/app/data/system/SIMOS/RecipeLink.json
+++ b/example/app/data/system/SIMOS/RecipeLink.json
@@ -1,0 +1,67 @@
+{
+  "name": "RecipeLink",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "description": "Blueprint for a RecipeLink. Used to associate types with a set of Storage- and UiRecipes",
+  "attributes": [
+    {
+      "name": "type",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "contained": true,
+      "optional": false
+    },
+    {
+      "name": "name",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "contained": true,
+      "optional": true
+    },
+    {
+      "name": "description",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "contained": true,
+      "optional": true
+    },
+    {
+      "name": "_blueprintPath_",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "contained": true,
+      "optional": false
+    },
+    {
+      "name": "extends",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "default": [],
+      "optional": true,
+      "dimensions": "*"
+    },
+    {
+      "name": "initialUiRecipe",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "dmss://system/SIMOS/UiRecipe",
+      "contained": true,
+      "optional": true,
+      "dimensions": ""
+    },
+    {
+      "name": "uiRecipes",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "dmss://system/SIMOS/UiRecipe",
+      "contained": true,
+      "optional": true,
+      "dimensions": "*"
+    },
+    {
+      "name": "storageRecipes",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "dmss://system/SIMOS/StorageRecipe",
+      "contained": true,
+      "optional": true,
+      "dimensions": "*"
+    }
+  ]
+}

--- a/example/app/data/system/SIMOS/Reference.json
+++ b/example/app/data/system/SIMOS/Reference.json
@@ -1,0 +1,25 @@
+{
+  "name": "Reference",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "description": "Can be of type link, pointer or storage.",
+  "attributes": [
+    {
+      "name": "type",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "referenceType",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "optional": false,
+      "default": "link"
+    },
+    {
+      "name": "address",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "optional": false
+    }
+  ]
+}

--- a/example/app/data/system/SIMOS/ReferenceViewConfig.json
+++ b/example/app/data/system/SIMOS/ReferenceViewConfig.json
@@ -1,0 +1,18 @@
+{
+  "name": "ReferenceViewConfig",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "extends": ["dmss://system/SIMOS/ViewConfig"],
+  "attributes": [
+    {
+      "name": "recipe",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "config",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "object",
+      "optional": true
+    }
+  ]
+}

--- a/example/app/data/system/SIMOS/Role.json
+++ b/example/app/data/system/SIMOS/Role.json
@@ -1,0 +1,26 @@
+{
+  "name": "Role",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "attributes": [
+    {
+      "name": "type",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "name",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "label",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "authServerRoleName",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    }
+  ]
+}

--- a/example/app/data/system/SIMOS/StorageAttribute.json
+++ b/example/app/data/system/SIMOS/StorageAttribute.json
@@ -1,0 +1,56 @@
+{
+  "name": "StorageAttribute",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "description": "This describes a storage recipe attribute",
+  "extends": ["dmss://system/SIMOS/NamedEntity"],
+  "attributes": [
+    {
+      "name": "name",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "Which attribute this StorageAttribute applies to.",
+      "attributeType": "string",
+      "default": "root"
+    },
+    {
+      "name": "contained",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "WARNING: Change how the entity is stored. Changing this value will make current entities unavailable. If True, storageTypeAffinity will have no effect",
+      "attributeType": "boolean",
+      "optional": true,
+      "default": true
+    },
+    {
+      "name": "storageAffinity",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "Will be used to decide how the data will be stored",
+      "attributeType": "string",
+      "default": "default",
+      "enumType": "dmss://system/SIMOS/enums/StorageTypes",
+      "optional": true
+    },
+    {
+      "name": "label",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "Friendly name visible to user",
+      "attributeType": "string",
+      "optional": true,
+      "default": ""
+    },
+    {
+      "name": "description",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "Description for the StoreAttribute",
+      "attributeType": "string",
+      "default": "",
+      "optional": true
+    },
+    {
+      "name": "dimensions",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "dimensions",
+      "attributeType": "string",
+      "default": "",
+      "optional": true
+    }
+  ]
+}

--- a/example/app/data/system/SIMOS/StorageRecipe.json
+++ b/example/app/data/system/SIMOS/StorageRecipe.json
@@ -1,0 +1,30 @@
+{
+  "name": "StorageRecipe",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "description": "This describes a storage recipe",
+  "extends": ["dmss://system/SIMOS/NamedEntity"],
+  "attributes": [
+    {
+      "name": "name",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "default": "default"
+    },
+    {
+      "name": "storageAffinity",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "Will be used to decide how the data will be stored",
+      "attributeType": "string",
+      "default": "default",
+      "enumType": "dmss://system/SIMOS/enums/StorageTypes",
+      "optional": true
+    },
+    {
+      "name": "attributes",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "dmss://system/SIMOS/StorageAttribute",
+      "dimensions": "*",
+      "contained": true
+    }
+  ]
+}

--- a/example/app/data/system/SIMOS/UiAttribute.json
+++ b/example/app/data/system/SIMOS/UiAttribute.json
@@ -1,0 +1,123 @@
+{
+  "name": "UiAttribute",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "description": "This describes an ui recipe attribute",
+  "extends": ["dmss://system/SIMOS/NamedEntity"],
+  "attributes": [
+    {
+      "name": "attributeType",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "default": "dmss://system/SIMOS/BlueprintAttribute",
+      "optional": true
+    },
+    {
+      "name": "label",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true,
+      "default": ""
+    },
+    {
+      "name": "uiRecipe",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "default": "",
+      "optional": true
+    },
+    {
+      "name": "dimensions",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true,
+      "default": ""
+    },
+    {
+      "name": "arrayField",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true,
+      "default": ""
+    },
+    {
+      "name": "enumType",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true,
+      "default": ""
+    },
+    {
+      "name": "field",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true,
+      "default": ""
+    },
+    {
+      "name": "widget",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "Widget for this property",
+      "attributeType": "string",
+      "optional": true,
+      "enumType": "DMT-Internal/DMT/plugins/ui/edit/WidgetEnum",
+      "default": ""
+    },
+    {
+      "name": "default",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true,
+      "default": ""
+    },
+    {
+      "name": "options",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "dmss://system/SIMOS/UiAttributeOption",
+      "dimensions": "*",
+      "contained": true,
+      "optional": true
+    },
+    {
+      "name": "optional",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "boolean",
+      "optional": true,
+      "default": false
+    },
+    {
+      "name": "contained",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "boolean",
+      "optional": true,
+      "default": true
+    },
+    {
+      "name": "disabled",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "boolean",
+      "default": false,
+      "optional": true
+    },
+    {
+      "name": "required",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "",
+      "attributeType": "boolean",
+      "default": false,
+      "optional": true
+    },
+    {
+      "name": "mapping",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true
+    },
+    {
+      "name": "collapsible",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "boolean",
+      "optional": true,
+      "default": false
+    }
+  ]
+}

--- a/example/app/data/system/SIMOS/UiAttributeOption.json
+++ b/example/app/data/system/SIMOS/UiAttributeOption.json
@@ -1,0 +1,13 @@
+{
+  "name": "UiAttributeOption",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "description": "This describes an ui recipe attribute option",
+  "extends": ["dmss://system/SIMOS/NamedEntity"],
+  "attributes": [
+    {
+      "name": "value",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    }
+  ]
+}

--- a/example/app/data/system/SIMOS/UiRecipe.json
+++ b/example/app/data/system/SIMOS/UiRecipe.json
@@ -1,0 +1,49 @@
+{
+  "name": "UiRecipe",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "description": "This describes uiRecipes",
+  "extends": ["dmss://system/SIMOS/NamedEntity"],
+  "attributes": [
+    {
+      "name": "plugin",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "optional": false
+    },
+    {
+      "name": "showRefreshButton",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "boolean",
+      "optional": true,
+      "default": false
+    },
+    {
+      "name": "category",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true,
+      "default": ""
+    },
+    {
+      "name": "roles",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true,
+      "dimensions": "*"
+    },
+    {
+      "name": "config",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "object",
+      "contained": true,
+      "optional": true
+    },
+    {
+      "name": "dimensions",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true,
+      "default": ""
+    }
+  ]
+}

--- a/example/app/data/system/SIMOS/Url.json
+++ b/example/app/data/system/SIMOS/Url.json
@@ -1,0 +1,20 @@
+{
+  "name": "Url",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "description": "This an object containing a url, ie. 'https://example.com'.",
+  "extends": ["dmss://system/SIMOS/Entity"],
+  "attributes": [
+    {
+      "name": "value",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "This is the url string, ie. 'https://example.com'.",
+      "attributeType": "string"
+    },
+    {
+      "name": "label",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "The label for the url, will often be what is seen by the user instead of the url string itself.",
+      "attributeType": "string"
+    }
+  ]
+}

--- a/example/app/data/system/SIMOS/ViewConfig.json
+++ b/example/app/data/system/SIMOS/ViewConfig.json
@@ -1,0 +1,50 @@
+{
+  "name": "ViewConfig",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "attributes": [
+    {
+      "name": "type",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "scope",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true,
+      "default": "self"
+    },
+    {
+      "name": "resolve",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "boolean",
+      "optional": true,
+      "default": true
+    },
+    {
+      "name": "label",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true
+    },
+    {
+      "name": "eds_icon",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true
+    },
+    {
+      "name": "roles",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "dimensions": "*",
+      "optional": true
+    },
+    {
+      "name": "showRefreshButton",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "boolean",
+      "optional": true
+    }
+  ]
+}

--- a/example/app/data/system/SIMOS/enums/ActionTypes.json
+++ b/example/app/data/system/SIMOS/enums/ActionTypes.json
@@ -1,0 +1,7 @@
+{
+  "name": "ActionTypes",
+  "type": "dmss://system/SIMOS/Enum",
+  "description": "Different valid action types",
+  "values": ["separateResultFile", "resultInEntity"],
+  "labels": ["Separate Result File", "Result In Entity"]
+}

--- a/example/app/data/system/SIMOS/enums/AttributeTypes.json
+++ b/example/app/data/system/SIMOS/enums/AttributeTypes.json
@@ -1,0 +1,7 @@
+{
+  "name": "AttributeTypes",
+  "type": "dmss://system/SIMOS/Enum",
+  "description": "This describes a list of attribute types",
+  "values": ["string", "integer", "number", "boolean", "blueprint"],
+  "labels": ["String", "Integer", "Number", "Boolean", "Blueprint"]
+}

--- a/example/app/data/system/SIMOS/enums/StatusEnum.json
+++ b/example/app/data/system/SIMOS/enums/StatusEnum.json
@@ -1,0 +1,21 @@
+{
+  "name": "StatusEnum",
+  "type": "dmss://system/SIMOS/Enum",
+  "description": "Valid Status values",
+  "labels": [
+    "Not Started",
+    "Running",
+    "Canceled",
+    "Exited with error(s)",
+    "Completed with errors(s)",
+    "Complete"
+  ],
+  "values": [
+    "notStarted",
+    "running",
+    "canceled",
+    "exitedWithErrors",
+    "completedWithErrors",
+    "complete"
+  ]
+}

--- a/example/app/data/system/SIMOS/enums/StorageTypes.json
+++ b/example/app/data/system/SIMOS/enums/StorageTypes.json
@@ -1,0 +1,7 @@
+{
+  "name": "StorageTypes",
+  "type": "dmss://system/SIMOS/Enum",
+  "description": "Will be used to decide in which repository the data will be stored",
+  "values": ["default", "blob", "video", "large", "veryLarge"],
+  "labels": ["Default", "Blob data", "Video", "Large", "Very Large"]
+}

--- a/example/app/data/system/SIMOS/recipe_links/blueprint.json
+++ b/example/app/data/system/SIMOS/recipe_links/blueprint.json
@@ -1,0 +1,49 @@
+{
+  "type": "dmss://system/SIMOS/RecipeLink",
+  "_blueprintPath_": "dmss://system/SIMOS/Blueprint",
+  "uiRecipes": [
+    {
+      "name": "Yaml",
+      "type": "dmss://system/SIMOS/UiRecipe",
+      "plugin": "@development-framework/dm-core-plugins/yaml"
+    },
+    {
+      "name": "Edit",
+      "type": "dmss://system/SIMOS/UiRecipe",
+      "description": "Default blueprint edit",
+      "plugin": "@development-framework/dm-core-plugins/blueprint"
+    },
+    {
+      "name": "Diagram",
+      "type": "dmss://system/SIMOS/UiRecipe",
+      "plugin": "blueprint-hierarchy"
+    }
+  ],
+  "storageRecipes": [
+    {
+      "name": "DefaultStorageRecipe",
+      "type": "dmss://system/SIMOS/StorageRecipe",
+      "description": "",
+      "attributes": [
+        {
+          "name": "attributes",
+          "type": "dmss://system/SIMOS/StorageAttribute",
+          "dimensions": "*",
+          "contained": true
+        },
+        {
+          "name": "storageRecipes",
+          "type": "dmss://system/SIMOS/StorageAttribute",
+          "dimensions": "*",
+          "contained": true
+        },
+        {
+          "name": "uiRecipes",
+          "type": "dmss://system/SIMOS/StorageAttribute",
+          "dimensions": "*",
+          "contained": true
+        }
+      ]
+    }
+  ]
+}

--- a/example/app/data/system/SIMOS/recipe_links/default.json
+++ b/example/app/data/system/SIMOS/recipe_links/default.json
@@ -1,0 +1,19 @@
+{
+  "type": "dmss://system/SIMOS/RecipeLink",
+  "_blueprintPath_": "_default_",
+  "uiRecipes": [
+    {
+      "name": "Yaml",
+      "type": "dmss://system/SIMOS/UiRecipe",
+      "plugin": "@development-framework/dm-core-plugins/yaml",
+      "roles": ["dmss-admin"],
+      "category": "view"
+    },
+    {
+      "name": "Edit",
+      "type": "dmss://system/SIMOS/UiRecipe",
+      "plugin": "@development-framework/dm-core-plugins/form",
+      "category": "edit"
+    }
+  ]
+}

--- a/example/app/data/system/SIMOS/recipe_links/entity.json
+++ b/example/app/data/system/SIMOS/recipe_links/entity.json
@@ -1,0 +1,12 @@
+{
+  "type": "dmss://system/SIMOS/RecipeLink",
+  "_blueprintPath_": "dmss://system/SIMOS/Entity",
+  "uiRecipes": [
+    {
+      "name": "DEFAULT_CREATE",
+      "type": "dmss://system/SIMOS/UiRecipe",
+      "description": "",
+      "plugin": "@development-framework/dm-core-plugins/form"
+    }
+  ]
+}

--- a/example/app/data/system/SIMOS/recipe_links/file.json
+++ b/example/app/data/system/SIMOS/recipe_links/file.json
@@ -1,0 +1,10 @@
+{
+  "type": "dmss://system/SIMOS/RecipeLink",
+  "_blueprintPath_": "dmss://system/SIMOS/File",
+  "initialUiRecipe": {
+    "name": "Edit",
+    "type": "dmss://system/SIMOS/UiRecipe",
+    "description": "",
+    "plugin": "@development-framework/dm-core-plugins/yaml"
+  }
+}

--- a/example/app/data/system/SIMOS/recipe_links/package_recipe.json
+++ b/example/app/data/system/SIMOS/recipe_links/package_recipe.json
@@ -1,0 +1,26 @@
+{
+  "type": "dmss://system/SIMOS/RecipeLink",
+  "_blueprintPath_": "dmss://system/SIMOS/Package",
+  "storageRecipes": [
+    {
+      "name": "DEFAULT",
+      "type": "dmss://system/SIMOS/StorageRecipe",
+      "description": "",
+      "attributes": [
+        {
+          "name": "content",
+          "type": "dmss://system/SIMOS/StorageAttribute",
+          "contained": false
+        }
+      ]
+    }
+  ],
+  "uiRecipes": [
+    {
+      "name": "DEFAULT_CREATE",
+      "type": "dmss://system/SIMOS/UiRecipe",
+      "description": "",
+      "plugin": "@development-framework/dm-core-plugins/form"
+    }
+  ]
+}

--- a/example/app/data/system/SIMOS/recipe_links/pdf.json
+++ b/example/app/data/system/SIMOS/recipe_links/pdf.json
@@ -1,0 +1,13 @@
+{
+  "type": "dmss://system/SIMOS/RecipeLink",
+  "_blueprintPath_": "dmss://system/SIMOS/PDF",
+  "extends": ["dmss://system/SIMOS/NamedEntity", "_default_"],
+  "uiRecipes": [
+    {
+      "name": "PDFView",
+      "type": "dmss://system/SIMOS/UiRecipe",
+      "description": "Embedded PDF View",
+      "plugin": "'@development-framework/dm-core-plugins/pdf"
+    }
+  ]
+}

--- a/example/app/data_sources/DemoDataSource.json
+++ b/example/app/data_sources/DemoDataSource.json
@@ -8,7 +8,7 @@
       "data_types": ["blob"],
       "database": "DemoDataSource",
       "host": "db",
-      "password": "xd7wCEhEx4kszsecYFfC",
+      "password": "maf",
       "port": 27017,
       "tls": false,
       "username": "maf"

--- a/example/app/data_sources/ExtraDataSource.json
+++ b/example/app/data_sources/ExtraDataSource.json
@@ -7,7 +7,7 @@
       "data_types": [],
       "database": "ExtraDataSource",
       "host": "db",
-      "password": "xd7wCEhEx4kszsecYFfC",
+      "password": "maf",
       "port": 27017,
       "tls": false,
       "username": "maf"

--- a/example/app/data_sources/WorkflowDS.json
+++ b/example/app/data_sources/WorkflowDS.json
@@ -1,0 +1,16 @@
+{
+  "name": "WorkflowDS",
+  "repositories": {
+    "forecastDB": {
+      "type": "mongo-db",
+      "host": "db",
+      "port": 27017,
+      "username": "maf",
+      "password": "maf",
+      "tls": false,
+      "database": "workflowDS",
+      "collection": "default",
+      "data_types": []
+    }
+  }
+}

--- a/example/app/data_sources/system_DS.json
+++ b/example/app/data_sources/system_DS.json
@@ -1,0 +1,15 @@
+{
+  "name": "system",
+  "repositories": {
+    "a": {
+      "type": "mongo-db",
+      "host": "db",
+      "port": 27017,
+      "username": "maf",
+      "password": "maf",
+      "tls": false,
+      "database": "DMSS-core",
+      "collection": "DMSS-core"
+    }
+  }
+}

--- a/example/docker-compose.yaml
+++ b/example/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.4'
-
 services:
   dmss:
     image: datamodelingtool.azurecr.io/dmss:${DMSS_TAG:-latest}
@@ -7,10 +5,10 @@ services:
     restart: unless-stopped
     environment:
       AUTH_ENABLED: 0
+      REDIS_PASSWORD: maf
+      MONGO_PASSWORD: maf
       ENVIRONMENT: ${ENVIRONMENT:-local}
 #      RESET_DATA_SOURCE: off
-      MONGO_USERNAME: maf
-      MONGO_PASSWORD: xd7wCEhEx4kszsecYFfC
       SECRET_KEY: sg9aeUM5i1JO4gNN8fQadokJa3_gXQMLBjSGGYcfscs= # Don't reuse this in production...
 #    volumes:
 #      - ../../data-modelling-storage-service/src:/code/src
@@ -18,12 +16,13 @@ services:
       - '5000:5000'
     depends_on:
       - db
+      - redis
 
   db:
     image: mongo:3.6
     environment:
       MONGO_INITDB_ROOT_USERNAME: maf
-      MONGO_INITDB_ROOT_PASSWORD: xd7wCEhEx4kszsecYFfC
+      MONGO_INITDB_ROOT_PASSWORD: maf
     volumes:
       - ./dmss-data/db:/data/db
 
@@ -33,11 +32,9 @@ services:
     restart: unless-stopped
     environment:
       SCHEDULER_ENVS_TO_EXPORT: 'PUBLIC_DMSS_API,SIMA_LICENSE'
-      SCHEDULER_REDIS_HOST: job-store
-      SCHEDULER_REDIS_PORT: 6379
-      SCHEDULER_REDIS_SSL: 'false'
+      SCHEDULER_REDIS_HOST: redis
+      SCHEDULER_REDIS_PASSWORD: maf
       DMSS_API: http://dmss:5000
-      API_DEBUG: 1
       AUTH_ENABLED: 0
       ENVIRONMENT: local
       AZURE_JOB_SUBSCRIPTION: 14d57366-b2ae-4da8-8b75-e273c6fdabe2
@@ -45,10 +42,10 @@ services:
       AZURE_SP_SECRET: ${AZURE_SP_SECRET}
       AZURE_JOB_TENANT_ID: 3aa4a235-b6e2-48d5-9195-7fcf05b459b0
       AZURE_JOB_CLIENT_ID: 97a6b5bd-63fb-42c6-bb75-7e5de2394ba0
-      MONGO_PASSWORD: xd7wCEhEx4kszsecYFfC
+      MONGO_PASSWORD: maf
       #SIMA_LICENSE: |
     depends_on:
-      - job-store
+      - redis
       - db
     volumes:
 #      - /var/run/docker.sock:/var/run/docker.sock # Needed for docker-in-docker jobs
@@ -69,8 +66,9 @@ services:
   #      ME_CONFIG_MONGODB_ADMINPASSWORD: xd7wCEhEx4kszsecYFfC
   #      ME_CONFIG_MONGODB_ENABLE_ADMIN: "true"
 
-  job-store:
-    image: redis:6.2.5-alpine
-    command: 'redis-server --save 30 1 --loglevel notice'
-    #    volumes:
-    #     - ./redis_data:/data
+  redis:
+    image: bitnami/redis:latest
+    environment:
+      REDIS_PASSWORD: maf
+      #    volumes:
+      #     - ./dmss-data/redis:/bitnami

--- a/example/docker-compose.yaml
+++ b/example/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
       REDIS_PASSWORD: maf
       MONGO_PASSWORD: maf
       ENVIRONMENT: ${ENVIRONMENT:-local}
-#      RESET_DATA_SOURCE: off
+      RESET_DATA_SOURCE: "off"
       SECRET_KEY: sg9aeUM5i1JO4gNN8fQadokJa3_gXQMLBjSGGYcfscs= # Don't reuse this in production...
 #    volumes:
 #      - ../../data-modelling-storage-service/src:/code/src

--- a/packages/dm-core-plugins/src/explorer/ExplorerPlugin.tsx
+++ b/packages/dm-core-plugins/src/explorer/ExplorerPlugin.tsx
@@ -1,21 +1,39 @@
 import {
   EBlueprint,
   EntityView,
+  TNodeWrapperProps,
   TreeNode,
   TreeView,
   useApplication,
 } from '@development-framework/dm-core'
 import { Progress } from '@equinor/eds-core-react'
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import Sidebar from './components/Sidebar'
 import NodeRightClickMenu from './components/context-menu/NodeRightClickMenu'
+import { default_raw_view_ui_recipe_config } from './constants'
 
 export default () => {
   const { treeNodes, loading } = useApplication()
   const [selectedType, setSelectedType] = useState<string>()
+  const [asRawView, setAsRawView] = useState<boolean>(false)
   const [selectedEntity, setSelectedEntity] = useState<string>()
   const [nodeDimensions, setNodeDimensions] = useState<string | undefined>(
     undefined
+  )
+  const setRawView = (type: string, id: string) => {
+    setSelectedEntity(id)
+    setSelectedType(type)
+    setAsRawView(true)
+  }
+  const nodeWrapper = useCallback(
+    (props: TNodeWrapperProps) =>
+      NodeRightClickMenu({ ...props, setRawView: setRawView }),
+    []
+  )
+
+  const { getUiPlugin } = useApplication()
+  const TabsPlugin = getUiPlugin(
+    '@development-framework/dm-core-plugins/view_selector/tabs'
   )
   return (
     <div className='flex-layout-container flex-row h-full'>
@@ -29,21 +47,30 @@ export default () => {
             nodes={treeNodes}
             onSelect={(node: TreeNode) => {
               if (node.type === EBlueprint.PACKAGE) return
+              setAsRawView(false)
               setSelectedType(node.type)
               setSelectedEntity(node.nodeId)
               setNodeDimensions(Array.isArray(node.entity) ? '*' : undefined)
             }}
-            NodeWrapper={NodeRightClickMenu}
+            NodeWrapper={nodeWrapper}
           />
         </Sidebar>
       )}
       {selectedType && selectedEntity && (
         <div className='flex-layout-container scroll'>
-          <EntityView
-            type={selectedType}
-            idReference={selectedEntity}
-            dimensions={nodeDimensions}
-          />
+          {asRawView ? (
+            <TabsPlugin
+              type={selectedType}
+              idReference={selectedEntity}
+              config={default_raw_view_ui_recipe_config}
+            />
+          ) : (
+            <EntityView
+              type={selectedType}
+              idReference={selectedEntity}
+              dimensions={nodeDimensions}
+            />
+          )}
         </div>
       )}
     </div>

--- a/packages/dm-core-plugins/src/explorer/components/context-menu/NodeRightClickMenu.tsx
+++ b/packages/dm-core-plugins/src/explorer/components/context-menu/NodeRightClickMenu.tsx
@@ -16,8 +16,10 @@ import { getMenuItems } from './getMenuItems'
 export const STANDARD_DIALOG_WIDTH = '100%'
 export const STANDARD_DIALOG_HEIGHT = '300px'
 
-const NodeRightClickMenu = (props: TNodeWrapperProps) => {
-  const { node, children, setNodeOpen } = props
+const NodeRightClickMenu = (
+  props: TNodeWrapperProps & { setRawView: (type: string, id: string) => void }
+) => {
+  const { node, children, setNodeOpen, setRawView } = props
   const [dialogId, setDialogId] = useState<EDialog | undefined>()
   const [showMenu, setShowMenu] = useState<boolean>(false)
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
@@ -42,7 +44,7 @@ const NodeRightClickMenu = (props: TNodeWrapperProps) => {
         placement='bottom-start'
         matchAnchorWidth={true}
       >
-        {getMenuItems(node, setDialogId)}
+        {getMenuItems(node, setDialogId, setRawView)}
       </Menu>
 
       {dialogId === EDialog.NewFolder && (

--- a/packages/dm-core-plugins/src/explorer/components/context-menu/getMenuItems.tsx
+++ b/packages/dm-core-plugins/src/explorer/components/context-menu/getMenuItems.tsx
@@ -8,7 +8,8 @@ import { EDialog } from '../../types'
 // See https://github.com/equinor/design-system/issues/2659
 export function getMenuItems(
   node: TreeNode,
-  setDialogId: (id: EDialog | undefined) => void
+  setDialogId: (id: EDialog | undefined) => void,
+  setRawView: (type: string, id: string) => void
 ): React.ReactElement[] {
   const menuItems = []
   const getMenuItem = (id: EDialog, text: string) => {
@@ -54,6 +55,14 @@ export function getMenuItems(
 
   // Everything besides dataSources can be deleted, copied, and edited AccessControl
   if (node.type !== 'dataSource') {
+    menuItems.push(
+      <Menu.Item
+        key={'viewRaw'}
+        onClick={() => setRawView(node.type, node.nodeId)}
+      >
+        View raw
+      </Menu.Item>
+    )
     menuItems.push(getMenuItem(EDialog.Delete, 'Delete'))
     menuItems.push(getMenuItem(EDialog.EditACL, 'Change permissions'))
     menuItems.push(getMenuItem(EDialog.CopyLink, 'Copy or link'))

--- a/packages/dm-core-plugins/src/explorer/constants.ts
+++ b/packages/dm-core-plugins/src/explorer/constants.ts
@@ -1,0 +1,35 @@
+export const default_raw_view_ui_recipe_config = {
+  type: 'dmss://system/Plugins/dm-core-plugins/view_selector/ViewSelectorConfig',
+  items: [
+    {
+      type: 'dmss://system/Plugins/dm-core-plugins/view_selector/ViewSelectorItem',
+      label: 'Yaml',
+      viewConfig: {
+        type: 'dmss://system/SIMOS/InlineRecipeViewConfig',
+        recipe: {
+          type: 'dmss://system/SIMOS/UiRecipe',
+          name: 'YAML',
+          description: 'YAML representation',
+          plugin: '@development-framework/dm-core-plugins/yaml',
+        },
+        scope: 'self',
+        eds_icon: 'code',
+      },
+    },
+    {
+      type: 'dmss://system/Plugins/dm-core-plugins/view_selector/ViewSelectorItem',
+      label: 'Edit',
+      viewConfig: {
+        type: 'dmss://system/SIMOS/InlineRecipeViewConfig',
+        recipe: {
+          type: 'dmss://system/SIMOS/UiRecipe',
+          name: 'Edit',
+          description: 'Default edit',
+          plugin: '@development-framework/dm-core-plugins/form',
+        },
+        scope: 'self',
+        eds_icon: 'edit',
+      },
+    },
+  ],
+}

--- a/packages/dm-core/src/components/Pickers/BlueprintPicker.tsx
+++ b/packages/dm-core/src/components/Pickers/BlueprintPicker.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react'
-import { toast } from 'react-toastify'
 import { EBlueprint } from '../../Enums'
 import {
   PATH_INPUT_FIELD_WIDTH,
@@ -123,10 +122,7 @@ export const BlueprintPicker = (props: TBlueprintPickerProps) => {
             <TreeView
               nodes={treeNodes}
               onSelect={(node: TreeNode) => {
-                if (node.type !== EBlueprint.BLUEPRINT) {
-                  toast.warning('You can only select a blueprint')
-                  return
-                } // Only allowed to select blueprints
+                if (node.type !== EBlueprint.BLUEPRINT) return // Only allowed to select blueprints
                 setShowModal(false)
                 onChange(node.getPath())
               }}


### PR DESCRIPTION
## What does this pull request change?
- Adds a new menuItem in ExplorerPlugin, "View raw"
   This forces explorer to render the "Tabs" plugin, with a constant config (similar to the default UiRecipe)

## Why is this pull request needed?
Should be possible to get a "raw/admin view" of entities in the explorer plugin

## Issues related to this change

closes #1412 