### PR TITLE
Feat/yaml plugin

### DIFF
--- a/e2e/tests/plugin-form-Nested.spec.ts
+++ b/e2e/tests/plugin-form-Nested.spec.ts
@@ -85,9 +85,6 @@ test('View accountant yaml', async () => {
   await expect(
     page.getByTestId('accountant').getByRole('button', { name: 'Copy as YAML' })
   ).toBeVisible()
-  await expect(
-    page.getByTestId('accountant').getByRole('button', { name: 'Copy as JSON' })
-  ).toBeVisible()
   await expect(page.getByTestId('accountant').getByRole('code')).toBeVisible()
 })
 

--- a/packages/dm-core-plugins/blueprints/yaml/YamlPluginConfig.json
+++ b/packages/dm-core-plugins/blueprints/yaml/YamlPluginConfig.json
@@ -1,0 +1,28 @@
+{
+  "name": "YamlPluginConfig",
+  "type": "CORE:Blueprint",
+  "attributes": [
+    {
+      "name": "type",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "languages",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string",
+      "description": "What languages should be available. Expects a list of language names. Only yaml and json is supported. Initial language is based on order its passed and only passing 1 language will disable toggling between languages.",
+      "dimensions": "*",
+      "optional": true,
+      "default": ["yaml", "json"]
+    },
+    {
+      "name": "editable",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "boolean",
+      "description": "Should raw code be editable.",
+      "optional": true,
+      "default": true
+    }
+  ]
+}

--- a/packages/dm-core-plugins/blueprints/yaml/package.json
+++ b/packages/dm-core-plugins/blueprints/yaml/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "yaml",
+  "type": "CORE:Package",
+  "isRoot": false,
+  "_meta_": {
+    "type": "CORE:Meta",
+    "version": "0.0.1",
+    "dependencies": [
+      {
+        "type": "CORE:Dependency",
+        "alias": "CORE",
+        "address": "system/SIMOS",
+        "version": "0.0.1",
+        "protocol": "dmss"
+      },
+      {
+        "type": "CORE:Dependency",
+        "alias": "PLUGINS",
+        "address": "system/Plugins",
+        "version": "0.0.1",
+        "protocol": "dmss"
+      }
+    ]
+  }
+}

--- a/packages/dm-core-plugins/src/yaml/YamlPlugin.tsx
+++ b/packages/dm-core-plugins/src/yaml/YamlPlugin.tsx
@@ -8,7 +8,7 @@ import { Icon, Popover, TextField, Tooltip } from '@equinor/eds-core-react'
 import { close, copy, edit, filter_alt, save } from '@equinor/eds-icons'
 import DOMPurify from 'dompurify'
 import hljs from 'highlight.js'
-import { ChangeEvent, useEffect, useRef, useState } from 'react'
+import { ChangeEvent, useMemo, useRef, useState } from 'react'
 import { toast } from 'react-toastify'
 import YAML from 'yaml'
 import { ActionButton, ActionsWrapper, CodeContainer } from './styles'
@@ -18,8 +18,6 @@ export const YamlPlugin = (props: YamlPluginProps) => {
   const { idReference, config: userConfig } = props
   const config = { ...defaultConfig, ...userConfig }
   const [depth, setDepth] = useState(0)
-  const [asYAML, setAsYAML] = useState<string>('')
-  const [asJSON, setAsJSON] = useState<string>('')
   const [isEditMode, setIsEditMode] = useState<boolean>(false)
   const [showAsJSON, setShowAsJSON] = useState<boolean>(
     config?.languages[0] === 'json'
@@ -32,12 +30,8 @@ export const YamlPlugin = (props: YamlPluginProps) => {
   const { document, isLoading, error, setError, updateDocument } =
     useDocument<TGenericObject>(idReference, depth, false, true)
 
-  useEffect(() => {
-    if (document) {
-      setAsYAML(YAML.stringify(document))
-      setAsJSON(JSON.stringify(document, null, 2))
-    }
-  }, [document])
+  const asYAML = useMemo(() => YAML.stringify(document), [document])
+  const asJSON = useMemo(() => JSON.stringify(document, null, 2), [document])
 
   const copyToClipboard = () => {
     try {
@@ -60,8 +54,6 @@ export const YamlPlugin = (props: YamlPluginProps) => {
       const clean = DOMPurify.sanitize(textEditor.current?.innerText || '{}')
       const parsedJSON = showAsJSON ? JSON.parse(clean) : YAML.parse(clean)
       updateDocument(parsedJSON, true).then(() => {
-        setAsYAML(YAML.stringify(parsedJSON))
-        setAsJSON(JSON.stringify(parsedJSON, null, 2))
         setIsEditMode(false)
       })
     } catch (e) {

--- a/packages/dm-core-plugins/src/yaml/YamlPlugin.tsx
+++ b/packages/dm-core-plugins/src/yaml/YamlPlugin.tsx
@@ -28,7 +28,7 @@ export const YamlPlugin = (props: YamlPluginProps) => {
   const depthPopoverTrigger = useRef<HTMLButtonElement>(null)
 
   const { document, isLoading, error, setError, updateDocument } =
-    useDocument<TGenericObject>(idReference, depth, false, true)
+    useDocument<TGenericObject>(idReference, depth, false)
 
   const asYAML = useMemo(() => YAML.stringify(document), [document])
   const asJSON = useMemo(() => JSON.stringify(document, null, 2), [document])
@@ -53,7 +53,7 @@ export const YamlPlugin = (props: YamlPluginProps) => {
     try {
       const clean = DOMPurify.sanitize(textEditor.current?.innerText || '{}')
       const parsedJSON = showAsJSON ? JSON.parse(clean) : YAML.parse(clean)
-      updateDocument(parsedJSON, true).then(() => {
+      updateDocument(parsedJSON, true, false, true).then(() => {
         setIsEditMode(false)
       })
     } catch (e) {

--- a/packages/dm-core-plugins/src/yaml/YamlPlugin.tsx
+++ b/packages/dm-core-plugins/src/yaml/YamlPlugin.tsx
@@ -161,7 +161,10 @@ export const YamlPlugin = (props: YamlPluginProps) => {
               </Tooltip>
             )}
             <Tooltip title='Copy'>
-              <ActionButton onClick={copyToClipboard}>
+              <ActionButton
+                title={`Copy as ${showAsJSON ? 'JSON' : 'YAML'}`}
+                onClick={copyToClipboard}
+              >
                 <Icon data={copy} />
               </ActionButton>
             </Tooltip>

--- a/packages/dm-core-plugins/src/yaml/YamlPlugin.tsx
+++ b/packages/dm-core-plugins/src/yaml/YamlPlugin.tsx
@@ -161,11 +161,13 @@ export const YamlPlugin = (props: YamlPluginProps) => {
                 </ActionButton>
               </Tooltip>
             )}
-            <Tooltip title={`Switch to ${showAsJSON ? 'YAML' : 'JSON'}`}>
-              <ActionButton onClick={() => setShowAsJSON(!showAsJSON)}>
-                {showAsJSON ? 'YAML' : 'JSON'}
-              </ActionButton>
-            </Tooltip>
+            {config.languages?.length > 1 && (
+              <Tooltip title={`Switch to ${showAsJSON ? 'YAML' : 'JSON'}`}>
+                <ActionButton onClick={() => setShowAsJSON(!showAsJSON)}>
+                  {showAsJSON ? 'YAML' : 'JSON'}
+                </ActionButton>
+              </Tooltip>
+            )}
             <Tooltip title='Copy'>
               <ActionButton onClick={copyToClipboard}>
                 <Icon data={copy} />

--- a/packages/dm-core-plugins/src/yaml/YamlPlugin.tsx
+++ b/packages/dm-core-plugins/src/yaml/YamlPlugin.tsx
@@ -80,7 +80,7 @@ export const YamlPlugin = (props: YamlPluginProps) => {
           <ErrorGroup>{error.message}</ErrorGroup>
         </div>
       )}
-      <div className='flex min-h-0 grow bg-[#132634]'>
+      <div className='flex min-h-0 grow bg-[#132634] overflow-auto relative'>
         <div className='flex flex-col min-h-0 grow w-full'>
           <CodeContainer
             ref={textEditor}

--- a/packages/dm-core-plugins/src/yaml/styles.ts
+++ b/packages/dm-core-plugins/src/yaml/styles.ts
@@ -1,0 +1,80 @@
+import styled, { css } from 'styled-components'
+
+export const ActionsWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    padding: 1rem;
+    gap: 0.5rem;
+    min-height: 0;
+    flex-grow: 1;
+`
+
+export const ActionButton = styled.button<{ bg?: 'green' | 'yellow' }>`
+    position: relative;
+    width: 3rem;
+    height: 3rem;
+    color: white;
+    padding: 0.5rem;
+    background: rgba(173, 226, 230, 0.1);
+    border-radius: 50px;
+    font-weight: 900;
+    font-size:0.875rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    ${({ bg }) =>
+      bg === 'green' &&
+      css`
+        background: rgba(193, 231, 193, 1);
+        color: rgba(19, 38, 52, 1);
+    `}
+    ${({ bg }) =>
+      bg === 'yellow' &&
+      css`
+        background: rgba(255, 218, 168, 1);
+        color: rgba(19, 38, 52, 1);
+    `}
+
+    .depth-indicator {
+        position: absolute;
+        top: -0.5rem;
+        right: -0.5rem;
+        background: rgb(46, 63, 77);
+        color: white;
+        min-width: 1.5rem;
+        height: 1.5rem;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+`
+
+export const CodeContainer = styled.pre`
+  background-color: rgba(19, 38, 52, 1);
+  margin: 0;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  width: 100%;
+  overflow-y: auto;
+  min-height: 0;
+  flex-grow: 1;
+  color: white;
+  display: flex;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+
+  & .hljs-string {
+    color: #a5ff90;
+  }
+
+  & .hljs-literal,
+  & .hljs-number {
+    color: #f53b6e;
+  }
+
+  & .hljs-attr,
+  & .hljs-bullet {
+    color: #99ffff;
+  }
+`

--- a/packages/dm-core-plugins/src/yaml/styles.ts
+++ b/packages/dm-core-plugins/src/yaml/styles.ts
@@ -1,12 +1,13 @@
 import styled, { css } from 'styled-components'
 
 export const ActionsWrapper = styled.div`
+    position: sticky;
     display: flex;
     flex-direction: column;
     padding: 1rem;
     gap: 0.5rem;
-    min-height: 0;
-    flex-grow: 1;
+    top: 0;
+    right: 0;
 `
 
 export const ActionButton = styled.button<{ bg?: 'green' | 'yellow' }>`
@@ -56,7 +57,6 @@ export const CodeContainer = styled.pre`
   padding: 1rem;
   border-radius: 0.5rem;
   width: 100%;
-  overflow-y: auto;
   min-height: 0;
   flex-grow: 1;
   color: white;

--- a/packages/dm-core-plugins/src/yaml/types.ts
+++ b/packages/dm-core-plugins/src/yaml/types.ts
@@ -1,0 +1,17 @@
+import { IUIPlugin } from '@development-framework/dm-core'
+
+export type TLanguages = 'json' | 'yaml'
+
+export type TYamlPluginConfig = {
+  languages: TLanguages[]
+  editable: boolean
+}
+
+export type YamlPluginProps = {
+  config: TYamlPluginConfig
+} & IUIPlugin
+
+export const defaultConfig: TYamlPluginConfig = {
+  languages: ['yaml', 'json'],
+  editable: true,
+}

--- a/packages/dm-core/src/hooks/useDocument.tsx
+++ b/packages/dm-core/src/hooks/useDocument.tsx
@@ -1,5 +1,5 @@
 import { AxiosError } from 'axios'
-import { useEffect, useState } from 'react'
+import { Dispatch, SetStateAction, useEffect, useState } from 'react'
 import { ErrorResponse } from '../services'
 
 import { toast } from 'react-toastify'
@@ -14,6 +14,7 @@ interface IUseDocumentReturnType<T> {
     partialUpdate?: boolean
   ) => Promise<void>
   error: ErrorResponse | null
+  setError: Dispatch<SetStateAction<ErrorResponse | null>>
 }
 
 /**
@@ -51,7 +52,8 @@ interface IUseDocumentReturnType<T> {
 export function useDocument<T>(
   idReference: string,
   depth?: number | undefined,
-  notify: boolean = true
+  notify: boolean = true,
+  throwError: boolean = false
 ): IUseDocumentReturnType<T> {
   const [document, setDocument] = useState<T | null>(null)
   const [isLoading, setLoading] = useState<boolean>(true)
@@ -108,9 +110,12 @@ export function useDocument<T>(
         console.error(error)
         if (notify) toast.error(error.response?.data.message ?? error.message)
         setError(error.response?.data || { message: error.name, data: error })
+        if (throwError) {
+          throw new Error(JSON.stringify(error, null, 2))
+        }
       })
       .finally(() => setLoading(false))
   }
 
-  return { document, isLoading, updateDocument, error }
+  return { document, isLoading, updateDocument, error, setError }
 }

--- a/packages/dm-core/src/hooks/useDocument.tsx
+++ b/packages/dm-core/src/hooks/useDocument.tsx
@@ -52,8 +52,7 @@ interface IUseDocumentReturnType<T> {
 export function useDocument<T>(
   idReference: string,
   depth?: number | undefined,
-  notify: boolean = true,
-  throwError: boolean = false
+  notify: boolean = true
 ): IUseDocumentReturnType<T> {
   const [document, setDocument] = useState<T | null>(null)
   const [isLoading, setLoading] = useState<boolean>(true)
@@ -91,7 +90,8 @@ export function useDocument<T>(
   async function updateDocument(
     newDocument: T,
     notify: boolean = true,
-    partialUpdate: boolean = false
+    partialUpdate: boolean = false,
+    throwError: boolean = false
   ): Promise<void> {
     setLoading(true)
     return dmssAPI

--- a/packages/dm-core/src/hooks/useDocument.tsx
+++ b/packages/dm-core/src/hooks/useDocument.tsx
@@ -11,7 +11,8 @@ interface IUseDocumentReturnType<T> {
   updateDocument: (
     newDocument: T,
     notify: boolean,
-    partialUpdate?: boolean
+    partialUpdate?: boolean,
+    throwError?: boolean
   ) => Promise<void>
   error: ErrorResponse | null
   setError: Dispatch<SetStateAction<ErrorResponse | null>>


### PR DESCRIPTION
## What does this pull request change?

**useDocument**
- Export setError function so that error can be reset from plugin
- Add parameter `throwError` to updateDocument function that decides if error should be actually thrown in updateDocument so that it's easier to handle errors in plugins  when needed

**YamlPlugin**
- Add language config. Expects a list of languages (json, yaml) so that user can decide both order and enabled languages in one go
- Add editable config. Default to true, but should be able to disable edit functionality.

- Can now both view, edit and copy code  in yaml and json respectively
- Sticky sidebar with buttons on side, scroll in code wrapper
- Some error handling

## Why is this pull request needed?
- Want to combine YAML plugin and JSON plugin to one + expand editor functionality
- Tried to reduce the feeling of floating buttons
- View was only available in YAML, edit was only available in JSON

![Skjermbilde 2024-05-27 kl  15 20 24](https://github.com/equinor/dm-core-packages/assets/25383299/5b173cda-8a76-4685-8e71-fb7cab2372ad)


NOTE: In the future we have a plan to rename plugin to something like InspectPlugin
