### PR TITLE
refactor: remove deprecated react defaultProps

### DIFF
--- a/packages/dm-core-plugins/src/common/Stack/Stack.tsx
+++ b/packages/dm-core-plugins/src/common/Stack/Stack.tsx
@@ -1,8 +1,9 @@
 import { StyledStack } from './styles'
-import { StackProps } from './types'
+import { StackProps, defaultProps } from './types'
 
 export const Stack = (props: StackProps) => {
-  const { grow, shrink, direction, wrap, ...restProps } = props
+  const mergedProps = { ...defaultProps, ...props }
+  const { grow, shrink, direction, wrap, ...restProps } = mergedProps
   return (
     <StyledStack
       flexDirection={direction}
@@ -12,16 +13,4 @@ export const Stack = (props: StackProps) => {
       {...restProps}
     />
   )
-}
-
-Stack.defaultProps = {
-  direction: 'column',
-  alignContent: 'initial',
-  alignItems: 'initial',
-  alignSelf: 'initial',
-  justifyContent: 'initial',
-  wrap: 'initial',
-  padding: 0,
-  grow: 0,
-  shrink: 0,
 }

--- a/packages/dm-core-plugins/src/common/Stack/types.ts
+++ b/packages/dm-core-plugins/src/common/Stack/types.ts
@@ -64,3 +64,15 @@ export interface StyledStackProps {
   spacing?: number
   flexWrap?: 'initial' | 'no-wrap' | 'wrap' | 'wrap-reverse'
 }
+
+export const defaultProps: StackProps = {
+  direction: 'column',
+  alignContent: 'initial',
+  alignItems: 'initial',
+  alignSelf: 'initial',
+  justifyContent: 'initial',
+  wrap: 'initial',
+  padding: 0,
+  grow: 0,
+  shrink: 0,
+}


### PR DESCRIPTION
## What does this pull request change?
Removed use of React defaultProps, switch to merging configs

## Why is this pull request needed?
React defaultProps is being deprecated and it's causing warnings in the developer console