### PR TITLE
fix: include application context in Tree

### DIFF
--- a/packages/dm-core/src/ApplicationContext.tsx
+++ b/packages/dm-core/src/ApplicationContext.tsx
@@ -81,7 +81,11 @@ export const DMApplicationProvider = (props: {
 
   const dmssAPIOriginal = new DmssAPI(token, props.dmssBasePath)
   const dmssAPI = new DmssAPI(token, props.dmssBasePath)
-  const tree: Tree = new Tree(dmssAPI, (t: Tree) => setTreeNodes([...t]))
+  const tree: Tree = new Tree(
+    dmssAPI,
+    (t: Tree) => setTreeNodes([...t]),
+    props.application.name
+  )
 
   // @ts-ignore
   dmssAPI.blueprintGet = async (requestParameters, options) => {

--- a/packages/dm-core/src/domain/Tree.ts
+++ b/packages/dm-core/src/domain/Tree.ts
@@ -175,6 +175,7 @@ export class TreeNode {
           const parentBlueprint: TBlueprint = await this.tree.dmssApi
             .blueprintGet({
               typeRef: this.type,
+              context: this.tree.context,
             })
             .then((response: any) => response.data.blueprint)
           this.tree.dmssApi
@@ -273,10 +274,16 @@ export class Tree {
   index: TTreeMap = {}
   dmssApi: DmssAPI
   updateCallback: (t: Tree) => void
+  context: string | undefined
 
-  constructor(dmssAPI: DmssAPI, updateCallback: (t: Tree) => void) {
+  constructor(
+    dmssAPI: DmssAPI,
+    updateCallback: (t: Tree) => void,
+    context?: string
+  ) {
     this.dmssApi = dmssAPI
     this.updateCallback = updateCallback
+    this.context = context
   }
 
   async init(path?: string[]) {


### PR DESCRIPTION

## Why is this pull request needed?
 - Blueprint fetches in Tree did not use "context", resulting in double the amount of blueprint calls

