### PR TITLE
fix: add blueprint paths to recipe examples

### DIFF
--- a/packages/dm-core-plugins/docs/DataGridPlugin/Examples/1D_Primitive_Array.json
+++ b/packages/dm-core-plugins/docs/DataGridPlugin/Examples/1D_Primitive_Array.json
@@ -26,9 +26,10 @@
     "colors": ["red", "blue", "green", "yellow", "black"]
   },
   "recipe": {
-    "name": "cars",
+    "_blueprintPath_": "./ColorList",
+    "name": "colors",
     "type": "CORE:UiRecipe",
-    "description": "List of cars",
+    "description": "List of colors",
     "plugin": "@development-framework/dm-core-plugins/data_grid",
     "config": {
       "type": "PLUGINS:dm-core-plugins/data_grid/DataGridPluginConfig",

--- a/packages/dm-core-plugins/docs/DataGridPlugin/Examples/2D_Primitive_Array.json
+++ b/packages/dm-core-plugins/docs/DataGridPlugin/Examples/2D_Primitive_Array.json
@@ -30,6 +30,7 @@
     ]
   },
   "recipe": {
+    "_blueprintPath_": "./ColorList",
     "name": "colors",
     "type": "CORE:UiRecipe",
     "description": "List of colors",

--- a/packages/dm-core-plugins/docs/DataGridPlugin/Examples/Multiple_Primitive_Arrays.json
+++ b/packages/dm-core-plugins/docs/DataGridPlugin/Examples/Multiple_Primitive_Arrays.json
@@ -40,9 +40,10 @@
     "green": ["green", "#00FF00", "rgb(0, 255, 0)"]
   },
   "recipe": {
-    "name": "cars",
+    "_blueprintPath_": "./ColorList",
+    "name": "colors",
     "type": "CORE:UiRecipe",
-    "description": "List of cars",
+    "description": "List of colors",
     "plugin": "@development-framework/dm-core-plugins/data_grid",
     "config": {
       "type": "PLUGINS:dm-core-plugins/data_grid/DataGridPluginConfig",

--- a/packages/dm-core-plugins/docs/FormPlugin/Examples/Basic.json
+++ b/packages/dm-core-plugins/docs/FormPlugin/Examples/Basic.json
@@ -44,6 +44,7 @@
     "model": "XC40"
   },
   "recipe": {
+    "_blueprintPath_": "./Car",
     "name": "car",
     "type": "CORE:UiRecipe",
     "description": "Car form",

--- a/packages/dm-core-plugins/docs/FormPlugin/Examples/Nested.json
+++ b/packages/dm-core-plugins/docs/FormPlugin/Examples/Nested.json
@@ -47,6 +47,7 @@
     }
   },
   "recipe": {
+    "_blueprintPath_": "./Person",
     "name": "person",
     "type": "CORE:UiRecipe",
     "description": "Person form",

--- a/packages/dm-core-plugins/docs/FormPlugin/Examples/WidgetExample.json
+++ b/packages/dm-core-plugins/docs/FormPlugin/Examples/WidgetExample.json
@@ -41,6 +41,7 @@
     }
   },
   "recipe": {
+    "_blueprintPath_": "./Person",
     "name": "person",
     "type": "CORE:UiRecipe",
     "description": "Person form",

--- a/packages/dm-core-plugins/docs/ListPlugin/Examples/Basic.json
+++ b/packages/dm-core-plugins/docs/ListPlugin/Examples/Basic.json
@@ -53,6 +53,7 @@
     ]
   },
   "recipe": {
+    "_blueprintPath_": "./CarList",
     "name": "cars",
     "type": "CORE:UiRecipe",
     "description": "List of cars",

--- a/packages/dm-core-plugins/docs/MediaViewerPlugin/Examples/Basic.json
+++ b/packages/dm-core-plugins/docs/MediaViewerPlugin/Examples/Basic.json
@@ -36,6 +36,7 @@
     }
   },
   "recipe": {
+    "_blueprintPath_": "./MediaViewer",
     "name": "MediaExample",
     "type": "CORE:UiRecipe",
     "description": "Media example with basic config",

--- a/packages/dm-core-plugins/docs/MetaPlugin/Examples/Basic.json
+++ b/packages/dm-core-plugins/docs/MetaPlugin/Examples/Basic.json
@@ -21,6 +21,7 @@
     "_id": "1179c897-df62-445f-87e4-f393b4253936"
   },
   "recipe": {
+    "_blueprintPath_": "./Example",
     "type": "CORE:UiRecipe",
     "name": "Meta",
     "plugin": "@development-framework/dm-core-plugins/meta"

--- a/packages/dm-core-plugins/docs/ResponsiveGridPlugin/Examples/Basic.json
+++ b/packages/dm-core-plugins/docs/ResponsiveGridPlugin/Examples/Basic.json
@@ -22,6 +22,7 @@
     "_id": "1179c897-df62-445f-87e4-f393b4253936"
   },
   "recipe": {
+    "_blueprintPath_": "./Example",
     "type": "CORE:UiRecipe",
     "name": "grid_example",
     "description": "Person form",

--- a/packages/dm-core-plugins/docs/SidebarPlugin/Examples/Basic.json
+++ b/packages/dm-core-plugins/docs/SidebarPlugin/Examples/Basic.json
@@ -22,6 +22,7 @@
     "_id": "1179c897-df62-445f-87e4-f393b4253936"
   },
   "recipe": {
+    "_blueprintPath_": "./Section",
     "name": "UiRecipesSelector",
     "type": "CORE:UiRecipe",
     "plugin": "@development-framework/dm-core-plugins/view_selector/sidebar",

--- a/packages/dm-core-plugins/docs/StackPlugin/Examples/Basic.json
+++ b/packages/dm-core-plugins/docs/StackPlugin/Examples/Basic.json
@@ -22,6 +22,7 @@
     "_id": "1179c897-df62-445f-87e4-f393b4253936"
   },
   "recipe": {
+    "_blueprintPath_": "Section",
     "name": "section",
     "type": "CORE:UiRecipe",
     "description": "stack recipe",

--- a/packages/dm-core-plugins/docs/TablePlugin/Examples/Basic.json
+++ b/packages/dm-core-plugins/docs/TablePlugin/Examples/Basic.json
@@ -53,6 +53,7 @@
     ]
   },
   "recipe": {
+    "_blueprintPath_": "CarList",
     "name": "cars",
     "type": "CORE:UiRecipe",
     "description": "List of cars",

--- a/packages/dm-core-plugins/docs/TablePlugin/Examples/EditTable.json
+++ b/packages/dm-core-plugins/docs/TablePlugin/Examples/EditTable.json
@@ -53,6 +53,7 @@
     ]
   },
   "recipe": {
+    "_blueprintPath_": "EditTable",
     "name": "cars",
     "type": "CORE:UiRecipe",
     "description": "List of cars",

--- a/packages/dm-core-plugins/docs/TablePlugin/Examples/Nested.json
+++ b/packages/dm-core-plugins/docs/TablePlugin/Examples/Nested.json
@@ -68,6 +68,7 @@
     ]
   },
   "recipe": {
+    "_blueprintPath_": "CarList",
     "name": "cars",
     "type": "CORE:UiRecipe",
     "description": "List of cars",

--- a/packages/dm-core-plugins/docs/TabsPlugin/Examples/Basic.json
+++ b/packages/dm-core-plugins/docs/TabsPlugin/Examples/Basic.json
@@ -22,6 +22,7 @@
     "_id": "1179c897-df62-445f-87e4-f393b4253936"
   },
   "recipe": {
+    "_blueprintPath_": "./Section",
     "name": "UiRecipesSelector",
     "type": "CORE:UiRecipe",
     "plugin": "@development-framework/dm-core-plugins/view_selector/tabs",


### PR DESCRIPTION
## What does this pull request change?
Add blueprintPaths to example recipes

## Why is this pull request needed?
Missing paths should be included
