### PR TITLE
fix: move dnd packages to correct project

### DIFF
--- a/packages/dm-core-plugins/package.json
+++ b/packages/dm-core-plugins/package.json
@@ -4,6 +4,9 @@
   "version": "1.55.1",
   "main": "dist/index.js",
   "dependencies": {
+    "@dnd-kit/core": "^6.0.8",
+    "@dnd-kit/modifiers": "^6.0.1",
+    "@dnd-kit/sortable": "^7.0.2",
     "@development-framework/dm-core": "^1.45.1",
     "@equinor/eds-core-react": ">0.33.0",
     "@equinor/eds-icons": ">0.19.3",

--- a/packages/dm-core/package.json
+++ b/packages/dm-core/package.json
@@ -10,9 +10,6 @@
     "styled-components": "^5.2.3"
   },
   "dependencies": {
-    "@dnd-kit/core": "^6.0.8",
-    "@dnd-kit/modifiers": "^6.0.1",
-    "@dnd-kit/sortable": "^7.0.2",
     "@equinor/eds-core-react": ">0.33.0",
     "@equinor/eds-icons": ">0.19.3",
     "@equinor/eds-tokens": ">0.9.0",


### PR DESCRIPTION
## What does this pull request change?
Move dnd packages from dm-core to dm-core-plugins

## Why is this pull request needed?
Sortable was moved to plugins from core, but packages were left behind

