### PR TITLE
feat: add itemMaxWidths attribute

### DIFF
--- a/packages/dm-core-plugins/blueprints/stack/StackPluginConfig.json
+++ b/packages/dm-core-plugins/blueprints/stack/StackPluginConfig.json
@@ -15,6 +15,14 @@
       "dimensions": "*"
     },
     {
+      "name": "itemMaxWidths",
+      "type": "CORE:BlueprintAttribute",
+      "description": "Pass array maxWidths of child items. Matches based on index. Use 'none' for empty slots.",
+      "attributeType": "string",
+      "dimensions": "*",
+      "optional": true
+    },
+    {
       "name": "direction",
       "type": "CORE:BlueprintAttribute",
       "description": "horizontal or vertical",

--- a/packages/dm-core-plugins/src/stack/StackPlugin.tsx
+++ b/packages/dm-core-plugins/src/stack/StackPlugin.tsx
@@ -7,7 +7,7 @@ export const StackPlugin = (props: IUIPlugin) => {
   const config: StackPluginConfig = { ...defaultConfig, ...props.config }
 
   // map plugin language to stack props/css language
-  const configMap: { [name: string]: string } = {
+  const configMap: Record<string, string> = {
     vertical: 'column',
     horizontal: 'row',
     horizontalPlacement:
@@ -38,13 +38,20 @@ export const StackPlugin = (props: IUIPlugin) => {
       className={`dm-plugin-padding dm-parent-plugin ${config.classNames}`}
     >
       {config.items?.map((item, index) => (
-        <ViewCreator
+        <Stack
           key={`${item.recipe}_${index}`}
-          idReference={idReference}
-          viewConfig={item}
-          onSubmit={props.onSubmit}
-          onChange={props.onChange}
-        />
+          grow={1}
+          minHeight={0}
+          fullWidth
+          style={{ maxWidth: config.itemMaxWidths?.[index] || 'none' }}
+        >
+          <ViewCreator
+            idReference={idReference}
+            viewConfig={item}
+            onSubmit={props.onSubmit}
+            onChange={props.onChange}
+          />
+        </Stack>
       ))}
     </Stack>
   )

--- a/packages/dm-core-plugins/src/stack/types.ts
+++ b/packages/dm-core-plugins/src/stack/types.ts
@@ -9,6 +9,7 @@ export type StackPluginConfig = {
   maxWidth: string
   wrap: boolean
   classNames: string[]
+  itemMaxWidths: string[]
 }
 
 export const defaultConfig: StackPluginConfig = {
@@ -20,4 +21,5 @@ export const defaultConfig: StackPluginConfig = {
   maxWidth: 'none',
   wrap: false,
   classNames: [],
+  itemMaxWidths: [],
 }


### PR DESCRIPTION
## What does this pull request change?
- feat: add itemMaxWidths attribute to set maxWidths for child views of StackPlugin

## Why is this pull request needed?
If stack child has maxWidth, the parent wrapper should follow that width, but there doesn't seem to be a way around using full width in EntityView so it will always span full width and there's no way of knowing the maxWidth of child elements either. Best solution seems to be giving opportunity to set maxWidths of children in the actual StackPlugin config.

## Issues related to this change
#1466 
