### PR TITLE
fix: parse integers as numbers on edit cell

### DIFF
--- a/packages/dm-core-plugins/src/table/Table/TableRow/TableRow.tsx
+++ b/packages/dm-core-plugins/src/table/Table/TableRow/TableRow.tsx
@@ -74,7 +74,9 @@ export function TableRow(props: TableRowProps) {
     newValue: string | number | boolean,
     attributeType: string
   ) {
-    if (attributeType === 'number') newValue = Number(newValue)
+    if (attributeType === 'number' || attributeType === 'integer') {
+      newValue = Number(newValue)
+    }
     setItems(utils.updateItemAttribute(items, item.key, attribute, newValue))
     setDirtyState(true)
   }


### PR DESCRIPTION
## What does this pull request change?
- fix: support integers in table edit

## Why is this pull request needed?
Integers not parsed as numbers ini table edit

## Issues related to this change
#1474 
