### PR TITLE
Fix/media viewer

### DIFF
--- a/e2e/tests/plugin-form-Media_viewer.spec.ts
+++ b/e2e/tests/plugin-form-Media_viewer.spec.ts
@@ -29,7 +29,7 @@ test('Media viewer', async ({ page }) => {
 
   await test.step('pdf', async () => {
     await page.getByRole('button', { name: 'engine_compartment' }).click()
-    await expect(page.getByTestId('embeded-document')).toBeVisible()
+    await expect(page.getByTestId('embedded-document')).toBeVisible()
   })
 
   await test.step('bin', async () => {

--- a/example/app/data/DemoDataSource/plugins/media_viewer/mediaViewerPDF.entity.json
+++ b/example/app/data/DemoDataSource/plugins/media_viewer/mediaViewerPDF.entity.json
@@ -1,0 +1,9 @@
+{
+  "name": "mediaViewerPDF",
+  "type": "./MediaViewer",
+  "file": {
+    "type": "dmss://system/SIMOS/Reference",
+    "address": "./assets/engine_compartment",
+    "referenceType": "link"
+  }
+}

--- a/packages/dm-core-plugins/blueprints/media_viewer/MediaViewerConfig.json
+++ b/packages/dm-core-plugins/blueprints/media_viewer/MediaViewerConfig.json
@@ -20,6 +20,13 @@
       "optional": true
     },
     {
+      "name": "fill",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string",
+      "description": "Choose between 'width', 'height' or 'both'",
+      "optional": true
+    },
+    {
       "name": "showMeta",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "boolean",

--- a/packages/dm-core-plugins/src/mediaViewer/MediaContent/MediaContentPopover/MediaContentPopover.tsx
+++ b/packages/dm-core-plugins/src/mediaViewer/MediaContent/MediaContentPopover/MediaContentPopover.tsx
@@ -1,0 +1,78 @@
+import { Button, Icon, Popover } from '@equinor/eds-core-react'
+import { download, external_link } from '@equinor/eds-icons'
+import { DateTime } from 'luxon'
+import type { RefObject } from 'react'
+import { Stack } from '../../../common'
+import { formatBytes } from '../../../utils'
+import { MetaItem } from '../MetaItem/MetaItem'
+import type { MediaContentProps } from '../types'
+import { isViewableInBrowser } from '../utils'
+
+type MediaContentPopoverProps = {
+  isOpen: boolean
+  onClose: () => void
+  popoverButtonRef: RefObject<HTMLButtonElement | null>
+} & Omit<MediaContentProps, 'fetchBlob' | 'downloadFile'>
+
+export const MediaContentPopover = (props: MediaContentPopoverProps) => {
+  const { isOpen, onClose, config, meta, blobUrl, popoverButtonRef } = props
+  return (
+    <Popover
+      open={isOpen}
+      anchorEl={popoverButtonRef?.current}
+      onClose={onClose}
+    >
+      <Popover.Header>
+        <Popover.Title>{config.caption ?? meta?.title}</Popover.Title>
+      </Popover.Header>
+      <Popover.Content>
+        <Stack spacing={0.5} fullWidth style={{ minWidth: 280 }}>
+          {config.showDescription && config.description && (
+            <p style={{ maxWidth: '320px' }}>{config.description}</p>
+          )}
+          {config.showMeta && (
+            <Stack spacing={0.25} fullWidth>
+              <MetaItem
+                title='File name'
+                value={`${meta.title}.${meta.filetype}`}
+              />
+              <MetaItem title='Author' value={meta.author} />
+              <MetaItem title='Filetype' value={meta.filetype} />
+              <MetaItem title='File size' value={formatBytes(meta.fileSize)} />
+              <MetaItem
+                title='Date'
+                value={DateTime.fromISO(meta.date.replace(' ', 'T')).toFormat(
+                  'dd/MM/yyyy HH:mm'
+                )}
+              />
+            </Stack>
+          )}
+        </Stack>
+      </Popover.Content>
+      <Popover.Actions>
+        <Stack direction='row' spacing={0.25} fullWidth justifyContent='center'>
+          {isViewableInBrowser(meta.contentType) && (
+            <Button
+              variant='ghost'
+              as='a'
+              href={blobUrl}
+              target='_blank'
+              rel='noopener noreferrer'
+            >
+              <Icon size={16} data={external_link} />
+              New tab
+            </Button>
+          )}
+          <Button
+            download={`${meta.title}.${meta.filetype}`}
+            href={blobUrl}
+            variant='ghost'
+          >
+            <Icon size={16} data={download} />
+            Download
+          </Button>
+        </Stack>
+      </Popover.Actions>
+    </Popover>
+  )
+}

--- a/packages/dm-core-plugins/src/mediaViewer/MediaContent/styles.ts
+++ b/packages/dm-core-plugins/src/mediaViewer/MediaContent/styles.ts
@@ -1,10 +1,55 @@
 import { Button } from '@equinor/eds-core-react'
-import styled from 'styled-components'
+import { tokens } from '@equinor/eds-tokens'
+import styled, { css } from 'styled-components'
+import { Stack } from '../../common'
+import type { FillVariant } from '../MediaViewerPlugin.types'
 
-export const MediaWrapper = styled.div<{ $height?: number; $width?: number }>`
-  height: fit-content;
-  width: fit-content;
+export const NoPreviewMessage = styled(Stack)`
+  border: 1px solid ${tokens.colors.interactive.primary__resting.rgba};
+  background: ${tokens.colors.interactive.primary__hover_alt.rgba};
+`
+
+type MediaWrapperStyleProps = {
+  $height?: number
+  $width?: number
+  $fill?: FillVariant
+}
+
+export const MediaPluginWrapper = styled.div<MediaWrapperStyleProps>`
+  ${({ $fill }) =>
+    $fill === 'height' || $fill === 'both'
+      ? css`
+          min-height: 0;
+          flex-grow: 1;
+        `
+      : css`
+          height: fit-content;
+        `};
+  width: ${({ $fill }) => ($fill === 'width' || $fill === 'both' ? '100%' : 'fit-content')};
+`
+
+export const MediaWrapper = styled.div<{
+  $height?: number
+  $width?: number
+  $fill?: FillVariant
+}>`
   position: relative;
+  ${({ $fill, $height }) =>
+    $fill === 'height' || $fill === 'both'
+      ? css`
+          height: 100%;
+        `
+      : css`
+          height: ${$height ? `${$height}px` : 'fit-content'};
+        `};
+  ${({ $fill, $width }) =>
+    $fill === 'width' || $fill === 'both'
+      ? css`
+          width: 100%;
+        `
+      : css`
+          width: ${$width ? `${$width}px` : 'fit-content'};
+        `};
 `
 
 export const MetaPopoverButton = styled(Button)`

--- a/packages/dm-core-plugins/src/mediaViewer/MediaContent/types.ts
+++ b/packages/dm-core-plugins/src/mediaViewer/MediaContent/types.ts
@@ -1,16 +1,9 @@
-export interface MediaContentConfig {
-  height?: number
-  width?: number
-  showMeta?: boolean
-  showDescription?: boolean
-  caption?: string
-  description?: string
-}
+import type { MediaViewerPluginConfig } from '../MediaViewerPlugin.types'
 
 export interface MediaContentProps {
   blobUrl: string | undefined
-  getBlobUrl: () => Promise<string>
-  config: MediaContentConfig
+  downloadFile: () => void
+  config: MediaViewerPluginConfig
   meta: {
     author: string
     fileSize: number

--- a/packages/dm-core-plugins/src/mediaViewer/MediaViewerPlugin.tsx
+++ b/packages/dm-core-plugins/src/mediaViewer/MediaViewerPlugin.tsx
@@ -7,100 +7,89 @@ import {
   useDocument,
 } from '@development-framework/dm-core'
 import type { AxiosRequestConfig } from 'axios'
-import { Suspense, useCallback, useEffect, useState } from 'react'
+import { Suspense, useCallback, useEffect, useMemo, useState } from 'react'
+import { Stack } from '../common'
+import { createSyntheticFileDownload } from '../utils'
 import { MediaContent } from './MediaContent/MediaContent'
+import { MediaPluginWrapper } from './MediaContent/styles'
+import type {
+  MediaObject,
+  MediaViewerPluginConfig,
+} from './MediaViewerPlugin.types'
 import { mimeTypes } from './mime-types'
 
-interface MediaObject {
-  type: string
-  _id: string
-  name: string
-  author: string
-  date: string
-  size: number
-  filetype: string
-  contentType?: string
-  content: {
-    type: string
-    referenceType: string
-    address: string
-  }
-}
-
-interface MediaViewerConfig {
-  type: string
-  width?: number
-  height?: number
-}
-
 export const MediaViewerPlugin = (
-  props: Omit<IUIPlugin, 'config'> & { config: MediaViewerConfig }
-): React.ReactElement => {
+  props: Omit<IUIPlugin, 'config'> & { config: MediaViewerPluginConfig }
+) => {
   const { idReference, config } = props
   const [blobUrl, setBlobUrl] = useState<string>()
-  const [contentType, setContentType] = useState<string>('')
   const { dmssAPI } = useApplication()
-  const {
-    document,
-    isLoading,
-    error: documentError,
-  } = useDocument<MediaObject>(idReference, 1)
-  const { dataSource } = splitAddress(idReference)
-  const options: AxiosRequestConfig = { responseType: 'blob' }
-
-  const getBlobUrl = useCallback(
-    async (passedContentType?: string) => {
-      if (document?.content?.address) {
-        try {
-          const response = await dmssAPI.blobGetById(
-            {
-              dataSourceId: dataSource,
-              blobId: document?.content?.address.slice(1),
-            },
-            options
-          )
-          const blob = new Blob([response.data], {
-            type: passedContentType || contentType,
-          })
-          const url = window.URL.createObjectURL(blob)
-          setBlobUrl(url)
-          return url
-        } catch (error) {
-          console.error(error)
-        }
-      }
-      return ''
-    },
-    [document?.content]
+  const { document, isLoading, error } = useDocument<MediaObject>(
+    idReference,
+    1
   )
-
-  useEffect(() => {
-    if (document) {
-      const contentType =
-        document?.contentType ||
-        mimeTypes[document.filetype] ||
-        'application/octet-stream'
-      setContentType(contentType)
-      // Only fetch file types we have previews for
-      if (
-        contentType.includes('image') ||
-        contentType.includes('video') ||
-        contentType === 'application/pdf'
-      ) {
-        getBlobUrl(contentType)
-      }
-    }
+  const { dataSource } = useMemo(() => splitAddress(idReference), [idReference])
+  const [contentType, canPreview] = useMemo(() => {
+    const contentType =
+      document?.contentType || document?.filetype
+        ? mimeTypes[document.filetype]
+        : 'application/octet-stream'
+    const canPreview =
+      contentType.includes('image') ||
+      contentType.includes('video') ||
+      contentType === 'application/pdf'
+    return [contentType, canPreview]
   }, [document])
 
-  if (documentError) throw new Error(JSON.stringify(documentError, null, 2))
+  const fetchBlob = useCallback(async () => {
+    if (document?.content?.address) {
+      try {
+        const response = await dmssAPI.blobGetById(
+          {
+            dataSourceId: dataSource,
+            blobId: document?.content?.address.slice(1),
+          },
+          { responseType: 'blob' }
+        )
+        const blobFile = new Blob([response.data], {
+          type: contentType,
+        })
+        const syntheticBlobUrl = window.URL.createObjectURL(blobFile)
+        setBlobUrl(syntheticBlobUrl)
+        return syntheticBlobUrl
+      } catch (error) {
+        console.error(error)
+      }
+    }
+    return ''
+  }, [document])
+
+  useEffect(() => {
+    if (canPreview) {
+      fetchBlob()
+    }
+  }, [canPreview])
+
+  async function downloadFile() {
+    const url = blobUrl || (await fetchBlob())
+    createSyntheticFileDownload(url, `${document?.name}.${document?.filetype}`)
+  }
+
+  if (error) throw new Error(JSON.stringify(error, null, 2))
   if (isLoading || document === null) return <Loading />
   if (document.type !== EBlueprint.FILE) throw new Error('This is not a file')
+
   return (
-    <div className='dm-plugin-padding'>
+    <MediaPluginWrapper
+      className='dm-plugin-padding'
+      $fill={config.fill}
+      $height={config.height}
+      $width={config.width}
+    >
       <Suspense fallback={<Loading />}>
         <MediaContent
           blobUrl={blobUrl}
-          getBlobUrl={getBlobUrl}
+          downloadFile={downloadFile}
           config={config}
           meta={{
             author: document.author,
@@ -112,6 +101,6 @@ export const MediaViewerPlugin = (
           }}
         />
       </Suspense>
-    </div>
+    </MediaPluginWrapper>
   )
 }

--- a/packages/dm-core-plugins/src/mediaViewer/MediaViewerPlugin.types.ts
+++ b/packages/dm-core-plugins/src/mediaViewer/MediaViewerPlugin.types.ts
@@ -1,0 +1,27 @@
+export interface MediaObject {
+  type: string
+  _id: string
+  name: string
+  author: string
+  date: string
+  size: number
+  filetype: string
+  contentType?: string
+  content: {
+    type: string
+    referenceType: string
+    address: string
+  }
+}
+
+export type FillVariant = 'height' | 'width' | 'both'
+
+export interface MediaViewerPluginConfig {
+  height?: number
+  width?: number
+  fill?: FillVariant
+  showMeta?: boolean
+  showDescription?: boolean
+  caption?: string
+  description?: string
+}


### PR DESCRIPTION
## What does this pull request change?
- refactor: clean up code, split components
- fix: image tag loading before image blob is fetched - meaning that depending on internet speed you see a broken image tag before image is loaded
- fix: all previews support height and width config
  - width and height now working properly on pdf preview
  - added "fill" config that allows you to fill width, height or both

## Why is this pull request needed?
- Previews not loading correctly
- Previews not supporting width and height config properly
- Hard to configure preview size with progressive sizing (like in use of grid and stack)

## Issues related to this change
#1482 
