### PR TITLE
feat: expanded config for hyperlinkwidget

### DIFF
--- a/example/app/data/DemoDataSource/recipes/plugins/form/hyperlinks/LinkForm.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/form/hyperlinks/LinkForm.recipe.json
@@ -11,7 +11,11 @@
         {
           "name": "stringLink1",
           "type": "PLUGINS:dm-core-plugins/form/fields/StringField",
-          "widget": "HyperlinkWidget"
+          "widget": "HyperlinkWidget",
+          "config": {
+            "type": "PLUGINS:dm-core-plugins/form/widgets/HyperlinkWidgetConfig",
+            "target": "_blank"
+          }
         },
         {
           "name": "stringLink2",

--- a/packages/dm-core-plugins/blueprints/form/widgets/HyperlinkWidgetConfig.json
+++ b/packages/dm-core-plugins/blueprints/form/widgets/HyperlinkWidgetConfig.json
@@ -6,6 +6,28 @@
     {
       "name": "label",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "If label is not submitted, text will default to url",
+      "attributeType": "string",
+      "optional": true
+    },
+    {
+      "name": "target",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "Default html syntax. Choose between '_blank' (new tab/window), '_self' (default), '_parent', '_top' or name of iframe.",
+      "attributeType": "string",
+      "optional": true
+    },
+    {
+      "name": "download",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "Pass 'true' to make file download on link click",
+      "attributeType": "boolean",
+      "optional": true
+    },
+    {
+      "name": "customDownloadFilename",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "Custom filename for when file downloads. Assumes download attribute is set to 'true'",
       "attributeType": "string",
       "optional": true
     }

--- a/packages/dm-core-plugins/src/form/widgets/HyperlinkWidget.tsx
+++ b/packages/dm-core-plugins/src/form/widgets/HyperlinkWidget.tsx
@@ -1,56 +1,46 @@
 import { Tooltip, Typography } from '@equinor/eds-core-react'
+import { type HTMLAttributeAnchorTarget, useMemo } from 'react'
 import type { TWidget } from '../types'
 
-function ensureProtocol(url: string): string {
-  if (!url.includes('://')) {
-    return 'https://' + url
-  }
-  return url
-}
-
-function isComplex(value: string | object) {
-  if (typeof value === 'object') return true
-  if (typeof value === 'string') return false
-  throw new Error('Invalid data type of value')
-}
-
-function isUrl(value: any): value is Url {
-  return (
-    value &&
-    typeof (value.value === 'string') &&
-    (typeof (value.label === 'string') || typeof value.label === 'undefined')
-  )
-}
-
-type Url = {
-  value: string
+type HyperlinkWidgetConfig = {
   label?: string
+  target?: HTMLAttributeAnchorTarget
+  download?: boolean
+  customDownloadFilename?: string
+}
+
+const defaultConfig = {
+  label: undefined,
+  target: '_self',
+  download: false,
+  customDownloadFilename: undefined,
 }
 
 const HyperlinkWidget = (props: TWidget) => {
   const { value, config } = props
+  const widgetConfig: HyperlinkWidgetConfig = { ...defaultConfig, ...config }
 
-  let url: string
-  let label: string
-  if (isComplex(value) && isUrl(value)) {
-    url = value.value
-    label = config?.label || value.label
-  } else {
-    url = value
-    label = config?.label
-  }
-  url = ensureProtocol(url)
+  const [url, label, rel] = useMemo(() => {
+    const url = typeof value === 'object' ? value?.value : value
+    const label = widgetConfig?.label || value.label || url
+    const rel = url.includes('http') ? 'noopener noreferrer' : ''
+    return [url, label, rel]
+  }, [value, widgetConfig])
 
   return (
     <Tooltip title={url}>
-      <a href={url} style={{ display: 'inline-block' }}>
-        <Typography
-          color='primary'
-          token={{ textDecoration: 'underline', fontWeight: 500 }}
-        >
-          {label ?? url}
-        </Typography>
-      </a>
+      <Typography
+        as='a'
+        variant='body_short_link'
+        style={{ display: 'inline-block', cursor: 'pointer' }}
+        token={{ textDecoration: 'underline', fontWeight: 500 }}
+        href={url}
+        target={widgetConfig.target}
+        rel={rel}
+        download={widgetConfig.customDownloadFilename || widgetConfig.download}
+      >
+        {label ?? url}
+      </Typography>
     </Tooltip>
   )
 }


### PR DESCRIPTION
## What does this pull request change?
- Expands config for HyperLinkWidget
  - add attribute target (follows html syntax)
  - add attribute download
  - add attribute customDownloadFilename (same as download, but with custom file name. HTML attribute accepts both bool and string, but we don't support that)
- General refactoring of HyperlinkWidget code

## Why is this pull request needed?
- By request

## Issues related to this change
#1484 
