### PR TITLE
Feat/markdown plugin

### DIFF
--- a/example/app/data/DemoDataSource/plugins/markdown/assets/content.md
+++ b/example/app/data/DemoDataSource/plugins/markdown/assets/content.md
@@ -1,0 +1,152 @@
+# Markdown Example
+
+## Headings 
+
+# h1 Heading
+## h2 Heading
+### h3 Heading
+#### h4 Heading
+##### h5 Heading
+###### h6 Heading
+
+## Text Emphasis 
+
+**This is bold text**
+
+__This is also bold text__
+
+*This is italic text*
+
+_This is also italic text_
+
+~~Strikethrough~~
+
+
+## Blockquotes 
+
+
+> Blockquotes can also be nested...
+>> ...by using additional greater-than signs right next to each other...
+> > > ...or with spaces between arrows.
+
+
+## Lists 
+
+### Unordered
+
++ Create a list by starting a line with `+`, `-`, or `*`
++ Sub-lists are made by indenting 2 spaces:
+  - Lists can also be nested
+    - Ac tristique libero volutpat at
+    - Facilisis in pretium nisl aliquet
+    - Nulla volutpat aliquam velit
+
+### Ordered
+
+1. The first item in a ordered list
+2. The second item in a ordered list
+3. The third item in a ordered list
+    1. Ordered lists can also be nested
+    1. Starting marker can stay the same
+
+You can also start list numbering with offset:
+
+57. foo
+1. bar
+
+
+## Code 
+
+### Inline code
+
+This sentence has `inline-code`
+
+
+### Block code
+
+```
+Sample text here...
+```
+
+### Code with syntax highlighting
+
+
+#### Javascript example
+``` js
+var foo = function (bar) {
+  return bar++;
+};
+
+console.log(foo(5));
+```
+
+#### JSON example
+``` json
+{
+    "attribute": "value",
+    "array": [
+        "string", "string2", true, 1039
+    ]
+}
+```
+
+
+## Tables 
+
+### Default table
+
+| App Name   | App Version | Domain Name     |
+| ---------- | ------------| --------------- |
+| Bigtax     | 9.5         | telegraph.co.uk |
+| Fix San    | 1.25        | deviantart.com  |
+| Trippledex | 0.50        | seesaa.net      |
+| Flexidy    | 5.23        | people.com.cn   |
+
+
+### Table with right aligned columns
+
+| App Name   | App Version | Domain Name     |
+| ---------: | -----------:| --------------: |
+| Bigtax     | 9.5         | telegraph.co.uk |
+| Fix San    | 1.25        | deviantart.com  |
+| Trippledex | 0.50        | seesaa.net      |
+| Flexidy    | 5.23        | people.com.cn   |
+
+
+## Links
+
+- [This is a link](http://dev.nodeca.com)
+
+- [Hover me to see title](http://nodeca.github.io/pica/demo/ "This is the title text!")
+
+- Autoconverted link https://github.com/nodeca/pica 
+
+
+## Images 
+
+![Minion](https://octodex.github.com/images/minion.png)
+![Stormtroopocat](https://octodex.github.com/images/stormtroopocat.jpg "The Stormtroopocat")
+
+
+## Referencing Footnotes
+
+Footnote 1 link[^first].
+
+Footnote 2 link[^second].
+
+Inline footnote^[Text of inline footnote] definition.
+
+Footnotes can be references twice reference[^second].
+
+[^first]: Footnote **can have markup**
+
+    and multiple paragraphs.
+
+[^second]: Footnote text.
+
+
+## Tasklist
+
+* [ ] to do
+* [x] done
+    * [x] task lists can also be nested

--- a/example/app/data/DemoDataSource/plugins/markdown/markdown.blueprint.json
+++ b/example/app/data/DemoDataSource/plugins/markdown/markdown.blueprint.json
@@ -1,0 +1,22 @@
+{
+  "name": "Markdown",
+  "type": "CORE:Blueprint",
+  "attributes": [
+    {
+      "name": "type",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "name",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "file",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "CORE:File",
+      "contained": false
+    }
+  ]
+}

--- a/example/app/data/DemoDataSource/plugins/markdown/markdown.entity.json
+++ b/example/app/data/DemoDataSource/plugins/markdown/markdown.entity.json
@@ -1,0 +1,9 @@
+{
+  "name": "MarkdownExample",
+  "type": "./Markdown",
+  "file": {
+    "type": "dmss://system/SIMOS/Reference",
+    "address": "./assets/content",
+    "referenceType": "link"
+  }
+}

--- a/example/app/data/DemoDataSource/recipes/plugins/markdown/markdown.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/markdown/markdown.recipe.json
@@ -1,0 +1,22 @@
+{
+  "type": "CORE:RecipeLink",
+  "_blueprintPath_": "/plugins/markdown/Markdown",
+  "initialUiRecipe": {
+    "name": "SingleView",
+    "type": "CORE:UiRecipe",
+    "config": {
+      "type": "CORE:InlineRecipeViewConfig",
+      "recipe": {
+        "name": "Markdown",
+        "type": "CORE:UiRecipe",
+        "description": "Markdown example",
+        "config": {
+          "type": "PLUGINS:dm-core-plugins/markdown/MarkdownConfig"
+        },
+        "plugin": "@development-framework/dm-core-plugins/markdown"
+      },
+      "scope": "file"
+    },
+    "plugin": "@development-framework/dm-core-plugins/single_view"
+  }
+}

--- a/packages/dm-core-plugins/blueprints/markdown/MarkdownConfig.json
+++ b/packages/dm-core-plugins/blueprints/markdown/MarkdownConfig.json
@@ -1,0 +1,11 @@
+{
+  "name": "MarkdownConfig",
+  "type": "CORE:Blueprint",
+  "attributes": [
+    {
+      "name": "type",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string"
+    }
+  ]
+}

--- a/packages/dm-core-plugins/blueprints/markdown/package.json
+++ b/packages/dm-core-plugins/blueprints/markdown/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "markdown",
+  "type": "CORE:Package",
+  "isRoot": false,
+  "_meta_": {
+    "type": "CORE:Meta",
+    "version": "0.0.1",
+    "dependencies": [
+      {
+        "type": "CORE:Dependency",
+        "alias": "CORE",
+        "address": "system/SIMOS",
+        "version": "0.0.1",
+        "protocol": "dmss"
+      },
+      {
+        "type": "CORE:Dependency",
+        "alias": "PLUGINS",
+        "address": "system/Plugins",
+        "version": "0.0.1",
+        "protocol": "dmss"
+      }
+    ]
+  }
+}

--- a/packages/dm-core-plugins/package.json
+++ b/packages/dm-core-plugins/package.json
@@ -18,7 +18,9 @@
     "luxon": "^3.5.0",
     "mermaid": "^11.4.1",
     "react-hook-form": "^7.54.0",
+    "react-markdown": "^10.1.0",
     "react-toastify": "^10.0.6",
+    "remark-gfm": "^4.0.1",
     "ts-node": "^10.9.2",
     "yaml": "^2.6.1"
   },
@@ -50,10 +52,7 @@
     "react-dom": "^18.2.0",
     "styled-components": "^6.1.13"
   },
-  "files": [
-    "blueprints",
-    "dist"
-  ],
+  "files": ["blueprints", "dist"],
   "types": "dist/index.d.ts",
   "scripts": {
     "prebuild": "shx rm -rf dist",

--- a/packages/dm-core-plugins/src/index.tsx
+++ b/packages/dm-core-plugins/src/index.tsx
@@ -143,6 +143,13 @@ export default {
       }))
     ),
   },
+  '@development-framework/dm-core-plugins/markdown': {
+    component: lazy(() =>
+      import('./markdown/MarkdownPlugin').then((module) => ({
+        default: module.MarkdownPlugin,
+      }))
+    ),
+  },
   '@development-framework/dm-core-plugins/meta': {
     component: lazy(() =>
       import('./meta/MetaPlugin').then((module) => ({

--- a/packages/dm-core-plugins/src/markdown/MarkdownPlugin.styles.tsx
+++ b/packages/dm-core-plugins/src/markdown/MarkdownPlugin.styles.tsx
@@ -1,0 +1,108 @@
+import { tokens } from '@equinor/eds-tokens'
+import styled from 'styled-components'
+
+const headingStyles = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].map(
+  (heading) => `
+    ${heading} {
+      font-size: ${
+        tokens.typography.heading[
+          heading as keyof typeof tokens.typography.heading
+        ].fontSize
+      };
+      font-weight: ${
+        tokens.typography.heading[
+          heading as keyof typeof tokens.typography.heading
+        ].fontWeight
+      };
+      line-height: ${
+        tokens.typography.heading[
+          heading as keyof typeof tokens.typography.heading
+        ].lineHeight
+      };
+      margin: 0;
+    }
+  `
+)
+
+export const StyledMarkdownWrapper = styled.div`
+  ${headingStyles};
+
+  h1 {
+    margin: 1rem 0;
+  }
+  h2 {
+    margin: 0.5rem 0;
+  }
+  h3,
+  h4 {
+    margin-bottom: 0.375rem;
+  }
+  h5,
+  h6 {
+    margin-bottom: 0.25rem;
+  }
+
+  p {
+    margin: 0 0 1rem;
+  }
+
+  ul,
+  ol {
+    margin-block-start: 0;
+  }
+
+  font-size: ${tokens.typography.paragraph.body_short.fontSize};
+  line-height: ${tokens.typography.paragraph.body_short.lineHeight};
+
+  blockquote {
+    border-left: 4px solid ${tokens.colors.ui.background__medium.hex};
+    margin: 0;
+    padding-left: 1rem;
+  }
+
+  a {
+    color: ${tokens.colors.interactive.primary__resting.hex};
+    text-transform: underline;
+  }
+
+  pre {
+    color: white;
+    background-color: rgba(19, 38, 52, 1);
+    margin: 0;
+    padding: 1rem;
+    border-radius: 0.5rem;
+    width: 100%;
+    margin-bottom: 1rem;
+  }
+  pre,
+  code {
+    font-size: 0.875rem;
+    font-family: ui-monospace, "Cascadia Mono", "Segoe UI Mono",
+      "Liberation Mono", Menlo, Monaco, Consolas, monospace;
+  }
+
+  table {
+    min-width: min-content;
+    margin-bottom: 1.25rem;
+    th {
+      text-align: left;
+    }
+    th,
+    td {
+      padding: 0.25rem;
+      border-bottom: 1px solid ${tokens.colors.ui.background__medium.hex};
+      border-right: 1px solid ${tokens.colors.ui.background__medium.hex};
+    }
+  }
+
+  img {
+    max-width: 100%;
+  }
+
+  .task-list-item {
+    svg {
+        margin-bottom: -7px;
+        fill: ${tokens.colors.interactive.primary__resting.hex};
+    }
+  }
+`

--- a/packages/dm-core-plugins/src/markdown/MarkdownPlugin.tsx
+++ b/packages/dm-core-plugins/src/markdown/MarkdownPlugin.tsx
@@ -1,0 +1,93 @@
+import {
+  type IUIPlugin,
+  Loading,
+  splitAddress,
+  useApplication,
+  useDocument,
+} from '@development-framework/dm-core'
+import axios from 'axios'
+import hljs from 'highlight.js'
+import { useMemo, useState } from 'react'
+import Markdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import type { MediaObject } from '../mediaViewer/MediaViewerPlugin.types'
+import { StyledMarkdownWrapper } from './MarkdownPlugin.styles'
+import 'highlight.js/styles/github-dark.css'
+import { Icon } from '@equinor/eds-core-react'
+import { checkbox, checkbox_outline } from '@equinor/eds-icons'
+
+export const MarkdownPlugin = (props: IUIPlugin) => {
+  const { idReference, config } = props
+  const { dmssAPI } = useApplication()
+  const [markdownString, setMarkdownString] = useState<string>()
+  const { document, isLoading, error } = useDocument<MediaObject>(
+    idReference,
+    1
+  )
+
+  useMemo(async () => {
+    if (document) {
+      const { dataSource } = splitAddress(idReference)
+      const response = await dmssAPI.blobGetById(
+        {
+          dataSourceId: dataSource,
+          blobId: document?.content?.address.slice(1),
+        },
+        { responseType: 'blob' }
+      )
+      const blobFile = new Blob([response.data], {
+        type: 'text/markdown',
+      })
+      const syntheticBlobUrl = window.URL.createObjectURL(blobFile)
+      const file = await axios.get(syntheticBlobUrl)
+      setMarkdownString(file.data)
+    }
+  }, [document])
+
+  if (error) throw new Error(JSON.stringify(error, null, 2))
+  if (isLoading || document === null) return <Loading />
+
+  return (
+    <StyledMarkdownWrapper className='dm-plugin-padding'>
+      <Markdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          input(props: any) {
+            if (props.type === 'checkbox') {
+              return (
+                <Icon
+                  role='checkbox'
+                  aria-checked={props.checked}
+                  aria-disabled
+                  data={props.checked ? checkbox : checkbox_outline}
+                  {...props}
+                />
+              )
+            }
+            return <input {...props} />
+          },
+          code({ node, inline, className, children, ...props }: any) {
+            const definedLanguage = /language-(\w+)/.exec(className || '')
+            return !inline && definedLanguage ? (
+              <pre
+                language={definedLanguage[1]}
+                {...props}
+                dangerouslySetInnerHTML={{
+                  __html: hljs.highlight(String(children).replace(/\n$/, ''), {
+                    language: definedLanguage[1],
+                  }).value,
+                }}
+              ></pre>
+            ) : (
+              <code className={className} {...props}>
+                {children}
+              </code>
+            )
+          },
+        }}
+      >
+        {markdownString}
+      </Markdown>
+    </StyledMarkdownWrapper>
+  )
+}

--- a/packages/dm-core/package.json
+++ b/packages/dm-core/package.json
@@ -42,11 +42,7 @@
     "ts-loader": "^9.5.1",
     "typescript": "^5.7.2"
   },
-  "files": [
-    "dist",
-    "src",
-    "tsconfig.json"
-  ],
+  "files": ["dist", "src", "tsconfig.json"],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
## What does this pull request change?
feat: add markdown plugin to dm-core-plugins
chore: add markdown example in example application

## Why is this pull request needed?
Requested plugin for printing markdown files. Might also be a better/easier than solution than creating a text plugin which has been discussed earlier.

## Screenshots
<img width="694" alt="Screenshot 2025-03-18 at 12 01 24" src="https://github.com/user-attachments/assets/09d8539b-4c79-4611-a976-b1e8510b510a" />
<img width="596" alt="Screenshot 2025-03-18 at 12 01 30" src="https://github.com/user-attachments/assets/0bc216b5-6c33-4475-b2f8-b15e4dfe1864" />
<img width="521" alt="Screenshot 2025-03-18 at 12 01 36" src="https://github.com/user-attachments/assets/698de8b1-0986-478a-b076-724a6c6e251e" />
<img width="566" alt="Screenshot 2025-03-18 at 12 01 39" src="https://github.com/user-attachments/assets/abcec289-9ab8-4a46-a671-5c932eb67e91" />
<img width="449" alt="Screenshot 2025-03-18 at 12 01 44" src="https://github.com/user-attachments/assets/afdd36d2-7e51-44c3-9780-2ebad55fdde4" />


## Issues related to this change
#1488 
