### PR TITLE
ci: use github app for getting token

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -4,8 +4,7 @@ on:
   workflow_dispatch:
   workflow_call:
     secrets:
-      RELEASE_PLEASE_TOKEN:
-        description: "PAT for release-please to create releases and PRs"
+      APP_PRIVATE_KEY:
         required: true
     outputs:
       releases_created:
@@ -15,17 +14,27 @@ on:
         description: "The release tag. Ex v1.4.0"
         value: ${{ jobs.release-please.outputs.tag_name }}
 
+permissions:
+  issues: write
+  contents: write
+  pull-requests: write
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
-      - uses: googleapis/release-please-action@v4
-        id: release
+      - name: Generate Token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: release-please
+        id: release
+        uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}

--- a/.github/workflows/on-main-push.yaml
+++ b/.github/workflows/on-main-push.yaml
@@ -31,11 +31,12 @@ jobs:
   release-please:
     needs: [tests, integration-tests]
     permissions:
+      issues: write
       contents: write
       pull-requests: write
     uses: ./.github/workflows/create-release-pr.yaml
     secrets:
-      RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 
   publish-packages:
     needs: release-please


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to improve how release PRs are created. The main change is migrating from using a personal access token (PAT) for authentication to using a GitHub App token, which enhances security and maintainability. Additionally, workflow permissions are updated to explicitly grant the necessary access.

Key changes:

**Authentication and Secrets Management:**

* Replaced the `RELEASE_PLEASE_TOKEN` secret (PAT) with `APP_PRIVATE_KEY` for GitHub App authentication in `.github/workflows/create-release-pr.yaml` and `.github/workflows/on-main-push.yaml`. [[1]](diffhunk://#diff-f6e4477bac850a142b0ce6bdaf13584662928227fee90487af19603f091d5e2fL7-R7) [[2]](diffhunk://#diff-4b2416f4a9c143743278c551b09283f1098b5c74434c80972c590d8db0bb00caR34-R39)
* Added a new step to generate a GitHub App token using `actions/create-github-app-token@v2` and updated the `release-please` step to use this token.

**Workflow Permissions:**

* Explicitly set `issues: write`, `contents: write`, and `pull-requests: write` permissions for the release workflow to ensure the GitHub App has the required access. [[1]](diffhunk://#diff-f6e4477bac850a142b0ce6bdaf13584662928227fee90487af19603f091d5e2fL18-R37) [[2]](diffhunk://#diff-4b2416f4a9c143743278c551b09283f1098b5c74434c80972c590d8db0bb00caR34-R39)