### PR TITLE
refactor: support label in uiRecipeList and cleanup header plugin

### DIFF
--- a/e2e/tests/plugin-explorer.spec.ts
+++ b/e2e/tests/plugin-explorer.spec.ts
@@ -77,7 +77,7 @@ test('Delete folder with content', async ({ page }) => {
 })
 
 test('Create entity with required name', async ({ page }) => {
-  await page.getByRole('button', { name: 'form' }).click()
+  await page.getByTestId('tree-button_form').click()
   await page.getByRole('button', { name: 'uncontained_object' }).click({
     button: 'right',
   })

--- a/e2e/tests/plugin-form-dimensional_scalar.spec.ts
+++ b/e2e/tests/plugin-form-dimensional_scalar.spec.ts
@@ -5,7 +5,7 @@ test('Dimensional scalar', async ({ page }) => {
     await page.goto('http://localhost:3000/')
     await page.getByRole('button', { name: 'DemoDataSource' }).click()
     await page.getByRole('button', { name: 'plugins' }).click()
-    await page.getByRole('button', { name: 'form' }).click()
+    await page.getByTestId('tree-button_form').click()
     await page.getByRole('button', { name: 'dimensional_scalar' }).click()
     await page.getByRole('button', { name: 'waveForm' }).click()
   }

--- a/e2e/tests/plugin-header-roles_header_example.spec.ts
+++ b/e2e/tests/plugin-header-roles_header_example.spec.ts
@@ -67,10 +67,9 @@ test('Change to operator role and back', async ({ page }) => {
 
   await test.step('Change back to admin', async () => {
     await page.getByLabel('AppSelector').nth(1).click()
-
     await page.getByRole('menuitem', { name: 'Yaml' }).first().click()
     await page.getByRole('button', { name: 'User' }).click()
-    await page.getByLabel('admin').check()
+    await page.getByTestId('impersonate-role-dmss-admin').check()
     await page.getByRole('button', { name: 'Save' }).click()
     await page.getByLabel('AppSelector').nth(1).click()
     await expect(page.getByRole('menuitem', { name: 'Edit' })).toBeVisible()

--- a/e2e/tests/plugin-header.spec.ts
+++ b/e2e/tests/plugin-header.spec.ts
@@ -10,13 +10,13 @@ test.beforeEach(async ({ page }) => {
 
 test('Load header', async ({ page }) => {
   await expect(page.getByLabel('AppSelector')).toBeVisible()
-  await expect(page.getByLabel('main-heading')).toBeVisible()
-  await expect(page.getByRole('button', { name: 'User' })).toBeVisible()
-  await expect(page.getByRole('button', { name: 'About' })).toBeVisible()
+  await expect(page.getByTestId('application-label')).toBeVisible()
+  await expect(page.getByTestId('header-user-info-button')).toBeVisible()
+  await expect(page.getByTestId('header-about-button')).toBeVisible()
 })
 
 test('User info', async ({ page }) => {
-  await page.getByRole('button', { name: 'User' }).click()
+  await page.getByTestId('header-user-info-button').click()
   await expect(page.getByRole('dialog')).toBeVisible()
   await expect(
     page.getByRole('dialog').getByText('User info', { exact: true })
@@ -24,12 +24,12 @@ test('User info', async ({ page }) => {
   await expect(
     page
       .getByRole('dialog')
-      .getByText('Name:Not authenticated', { exact: true })
+      .getByText('Name: Not authenticated', { exact: true })
   ).toBeVisible()
 })
 
 test('About', async ({ page }) => {
-  await page.getByRole('button', { name: 'About' }).click()
+  await page.getByTestId('header-about-button').click()
   await expect(page.getByRole('dialog')).toBeVisible()
   await expect(
     page
@@ -39,12 +39,17 @@ test('About', async ({ page }) => {
         { exact: true }
       )
   ).toBeVisible()
-  await page.getByRole('dialog').getByRole('button', { name: 'Ok' }).click()
+  await page
+    .getByRole('dialog')
+    .getByTestId('about-dialog-close-button')
+    .click()
   await expect(page.getByRole('dialog')).not.toBeVisible()
 })
 
 test('Recipe list', async ({ page }) => {
-  await page.getByLabel('AppSelector').click()
+  await page.getByTestId('application-selector-button').click()
+  await expect(page.getByRole('menu')).toBeVisible()
+  await expect(page.getByRole('menuitem', { name: 'Edit' })).toBeVisible()
   await page.getByRole('menuitem', { name: 'Edit' }).click()
   await expect(page.getByTestId('form-text-widget-Name')).toHaveValue('example')
 })

--- a/e2e/tests/plugin-view_selector-roles_school_example.spec.ts
+++ b/e2e/tests/plugin-view_selector-roles_school_example.spec.ts
@@ -36,7 +36,7 @@ test('Change role to operator and back', async ({ page }) => {
   ).not.toBeVisible()
   await expect(page.getByTestId('form-text-widget-Name')).not.toBeEditable()
   await page.getByRole('button', { name: 'User' }).click()
-  await page.getByLabel('admin').check()
+  await page.getByTestId('impersonate-role-dmss-admin').check()
   await page.getByRole('button', { name: 'Save', exact: true }).click()
   await page.getByRole('tab', { name: 'Hogwarts Admin', exact: true }).click()
   await expect(page.getByTestId('form-text-widget-Name')).toBeEditable()

--- a/example/app/data/DemoDataSource/recipes/apps/ExampleApplication/ExampleApplication.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/apps/ExampleApplication/ExampleApplication.recipe.json
@@ -8,7 +8,17 @@
       "type": "PLUGINS:dm-core-plugins/header/HeaderPluginConfig",
       "hideAbout": false,
       "hideUserInfo": false,
-      "uiRecipesList": ["Explorer", "Yaml"]
+      "uiRecipesList": [
+        {
+          "type": "PLUGINS:dm-core-plugins/header/HeaderUIRecipeItem",
+          "recipeName": "Explorer"
+        },
+        {
+          "type": "PLUGINS:dm-core-plugins/header/HeaderUIRecipeItem",
+          "recipeName": "Yaml",
+          "label": "YAML"
+        }
+      ]
     },
     "plugin": "@development-framework/dm-core-plugins/header"
   },

--- a/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/signalApp.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/apps/signal_app/recipe_links/signalApp.recipe.json
@@ -8,7 +8,21 @@
       "type": "PLUGINS:dm-core-plugins/header/HeaderPluginConfig",
       "hideAbout": false,
       "hideUserInfo": true,
-      "uiRecipesList": ["View study", "Explorer", "Yaml"]
+      "uiRecipesList": [
+        {
+          "type": "PLUGINS:dm-core-plugins/header/HeaderUIRecipeItem",
+          "recipeName": "View study"
+        },
+        {
+          "type": "PLUGINS:dm-core-plugins/header/HeaderUIRecipeItem",
+          "recipeName": "Explorer"
+        },
+        {
+          "type": "PLUGINS:dm-core-plugins/header/HeaderUIRecipeItem",
+          "recipeName": "Yaml",
+          "label": "YAML"
+        }
+      ]
     },
     "plugin": "@development-framework/dm-core-plugins/header"
   },

--- a/example/app/data/DemoDataSource/recipes/plugins/header/example_app/exampleApplication.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/header/example_app/exampleApplication.recipe.json
@@ -8,7 +8,21 @@
       "type": "PLUGINS:dm-core-plugins/header/HeaderPluginConfig",
       "hideAbout": false,
       "hideUserInfo": false,
-      "uiRecipesList": ["Yaml", "Edit", "Explorer"]
+      "uiRecipesList": [
+        {
+          "type": "PLUGINS:dm-core-plugins/header/HeaderUIRecipeItem",
+          "recipeName": "Yaml",
+          "label": "YAML"
+        },
+        {
+          "type": "PLUGINS:dm-core-plugins/header/HeaderUIRecipeItem",
+          "recipeName": "Edit"
+        },
+        {
+          "type": "PLUGINS:dm-core-plugins/header/HeaderUIRecipeItem",
+          "recipeName": "Explorer"
+        }
+      ]
     },
     "plugin": "@development-framework/dm-core-plugins/header"
   },

--- a/example/app/data/DemoDataSource/recipes/plugins/header/roles_header_example/person.recipe.json
+++ b/example/app/data/DemoDataSource/recipes/plugins/header/roles_header_example/person.recipe.json
@@ -33,7 +33,21 @@
         "type": "PLUGINS:dm-core-plugins/header/HeaderPluginConfig",
         "hideAbout": false,
         "hideUserInfo": true,
-        "uiRecipesList": ["Yaml", "Edit", "Explorer"]
+        "uiRecipesList": [
+          {
+            "type": "PLUGINS:dm-core-plugins/header/HeaderUIRecipeItem",
+            "recipeName": "Yaml",
+            "label": "YAML"
+          },
+          {
+            "type": "PLUGINS:dm-core-plugins/header/HeaderUIRecipeItem",
+            "recipeName": "Edit"
+          },
+          {
+            "type": "PLUGINS:dm-core-plugins/header/HeaderUIRecipeItem",
+            "recipeName": "Explorer"
+          }
+        ]
       },
       "plugin": "@development-framework/dm-core-plugins/header"
     },
@@ -44,7 +58,16 @@
         "type": "PLUGINS:dm-core-plugins/header/HeaderPluginConfig",
         "hideAbout": false,
         "hideUserInfo": true,
-        "uiRecipesList": ["Yaml", "Explorer"]
+        "uiRecipesList": [
+          {
+            "type": "PLUGINS:dm-core-plugins/header/HeaderUIRecipeItem",
+            "recipeName": "Yaml"
+          },
+          {
+            "type": "PLUGINS:dm-core-plugins/header/HeaderUIRecipeItem",
+            "recipeName": "Explorer"
+          }
+        ]
       },
       "plugin": "@development-framework/dm-core-plugins/header"
     },

--- a/packages/dm-core-plugins/blueprints/header/HeaderPluginConfig.json
+++ b/packages/dm-core-plugins/blueprints/header/HeaderPluginConfig.json
@@ -1,36 +1,36 @@
 {
   "name": "HeaderPluginConfig",
-  "type": "dmss://system/SIMOS/Blueprint",
+  "type": "CORE:Blueprint",
   "attributes": [
     {
       "name": "type",
-      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "type": "CORE:BlueprintAttribute",
       "attributeType": "string"
     },
     {
       "name": "hideAbout",
-      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "type": "CORE:BlueprintAttribute",
       "attributeType": "boolean",
       "description": "Hide the about link in the header",
       "default": false
     },
     {
       "name": "hideUserInfo",
-      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "type": "CORE:BlueprintAttribute",
       "attributeType": "boolean",
       "description": "Hide the user info in the header",
       "default": false
     },
     {
       "name": "uiRecipesList",
-      "type": "dmss://system/SIMOS/BlueprintAttribute",
-      "attributeType": "string",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "PLUGINS:dm-core-plugins/header/HeaderUIRecipeItem",
       "dimensions": "*",
       "description": "Can be used to specify a list of UI recipes the user can select. By default, the fist UI recipe in\n  the list is displayed. If the list is empty, all UI recipes will be included."
     },
     {
       "name": "adminRole",
-      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "type": "CORE:BlueprintAttribute",
       "attributeType": "string",
       "default": "dmss-admin",
       "description": "The role that is considered an admin role. If the user has this role, the user will see the 'admin menu' in the header.",

--- a/packages/dm-core-plugins/blueprints/header/HeaderUIRecipeItem.json
+++ b/packages/dm-core-plugins/blueprints/header/HeaderUIRecipeItem.json
@@ -1,0 +1,24 @@
+{
+  "name": "HeaderUIRecipeItem",
+  "type": "CORE:Blueprint",
+  "attributes": [
+    {
+      "name": "type",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "label",
+      "type": "CORE:BlueprintAttribute",
+      "description": "Label for item in dropdown selection",
+      "optional": true,
+      "attributeType": "string"
+    },
+    {
+      "name": "recipeName",
+      "type": "CORE:BlueprintAttribute",
+      "description": "Name of recipe to select",
+      "attributeType": "string"
+    }
+  ]
+}

--- a/packages/dm-core-plugins/src/header/HeaderPlugin.styles.ts
+++ b/packages/dm-core-plugins/src/header/HeaderPlugin.styles.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components'
+
+export const Logo = styled.span`
+  color: #007079;
+  font-weight: 500;
+  margin-right: 1rem;
+  margin-left: 0.5rem;
+  font-size: 18px;
+`

--- a/packages/dm-core-plugins/src/header/HeaderPlugin.tsx
+++ b/packages/dm-core-plugins/src/header/HeaderPlugin.tsx
@@ -78,7 +78,7 @@ export default (props: IUIPlugin): React.ReactElement => {
     <Stack fullWidth grow={1} minHeight={0}>
       <TopBar style={{ width: '100%', flexShrink: 0 }}>
         <TopBar.Header>
-          <S.Logo>{entity.label}</S.Logo>
+          <S.Logo data-testid='application-label'>{entity.label}</S.Logo>
           <AppSelector
             isLoading={isBlueprintLoading}
             items={recipes}

--- a/packages/dm-core-plugins/src/header/HeaderPlugin.tsx
+++ b/packages/dm-core-plugins/src/header/HeaderPlugin.tsx
@@ -2,70 +2,26 @@ import {
   type IUIPlugin,
   Loading,
   type TApplication,
-  type TGenericObject,
   type TUiRecipe,
   useApplication,
   useBlueprint,
   useDocument,
 } from '@development-framework/dm-core'
-import { Icon, Menu, TopBar, Typography } from '@equinor/eds-core-react'
-import { account_circle, info_circle, menu, refresh } from '@equinor/eds-icons'
-import { useEffect, useState } from 'react'
-import { toast } from 'react-toastify'
-import styled from 'styled-components'
-
+import { TopBar } from '@equinor/eds-core-react'
+import { useEffect, useMemo, useState } from 'react'
 import { Stack } from '../common'
 import { AboutDialog } from './components/AboutDialog'
+import { AdminMenu } from './components/AdminMenu'
 import { AppSelector } from './components/AppSelector'
 import { UserInfoDialog } from './components/UserInfoDialog'
-
-const Icons = styled.div`
-  display: flex;
-  align-items: center;
-  flex-direction: row;
-
-  > * {
-    margin-left: 40px;
-  }
-`
-const Logo = styled.span`
-  color: #007079;
-  font-weight: 500;
-  margin-right: 1rem;
-  margin-left: 0.5rem;
-  font-size: 18px;
-`
-
-const ClickableIcon = styled.button`
-  appearance: none;
-  border: none;
-  background-color: transparent;
-
-  &:hover {
-    color: gray;
-    cursor: pointer;
-  }
-`
-
-type THeaderPluginConfig = {
-  uiRecipesList: string[]
-  hideUserInfo: boolean
-  hideAbout: boolean
-  adminRole?: string
-}
-
-const defaultHeaderPluginConfig = {
-  uiRecipesList: [],
-  hideUserInfo: false,
-  hideAbout: false,
-  adminRole: 'dmss-admin',
-}
-
-type TRecipeConfigAndPlugin = {
-  config?: TGenericObject
-  component: (props: IUIPlugin) => React.ReactElement
-  name: string
-}
+import * as S from './HeaderPlugin.styles'
+import {
+  defaultHeaderPluginConfig,
+  type THeaderPluginConfig,
+  type TRecipeConfigAndPlugin,
+  type UIRecipeItem,
+} from './HeaderPlugin.types'
+import { getRecipeConfigAndPlugin } from './HeaderPlugin.utils'
 
 /**
  * Component which renders a header.
@@ -78,142 +34,78 @@ type TRecipeConfigAndPlugin = {
 
 export default (props: IUIPlugin): React.ReactElement => {
   const { idReference, config: passedConfig, type } = props
-  const config: THeaderPluginConfig & { adminRole: string } = {
+  const config: THeaderPluginConfig = {
     ...defaultHeaderPluginConfig,
     ...passedConfig,
   }
-  const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false)
-  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
+
   const { document: entity, isLoading } = useDocument<TApplication>(idReference)
   const { uiRecipes, isLoading: isBlueprintLoading } = useBlueprint(type)
-  const { roles, role, dmssAPI, name } = useApplication()
-  const [aboutOpen, setAboutOpen] = useState(false)
-  const [visibleUserInfo, setVisibleUserInfo] = useState<boolean>(false)
-  const { getUiPlugin } = useApplication()
+  const { getUiPlugin, roles } = useApplication()
   const [selectedRecipe, setSelectedRecipe] = useState<TRecipeConfigAndPlugin>({
     component: () => <div />,
     config: {},
     name: '',
   })
 
-  function getRecipeConfigAndPlugin(
-    recipeName: string
-  ): TRecipeConfigAndPlugin {
-    const recipe = uiRecipes.find(
-      (recipe: TUiRecipe) => recipe.name === recipeName
-    )
-    if (!recipe) throw new Error(`Failed to find recipe named '${recipeName}'`)
-    return {
-      component: getUiPlugin(recipe.plugin),
-      config: recipe?.config ?? {},
-      name: recipeName,
-    }
-  }
-
   useEffect(() => {
     if (!isBlueprintLoading) {
       const defaultRecipe: TUiRecipe = config.uiRecipesList.length
         ? uiRecipes.find(
-            (recipe: TUiRecipe) => recipe.name === config.uiRecipesList[0]
+            (recipe: TUiRecipe) =>
+              recipe.name === config.uiRecipesList[0]?.recipeName
           )
         : uiRecipes[0]
-      setSelectedRecipe(getRecipeConfigAndPlugin(defaultRecipe.name))
+      setSelectedRecipe(
+        getRecipeConfigAndPlugin(defaultRecipe?.name, uiRecipes, getUiPlugin)
+      )
     }
-  }, [isBlueprintLoading])
+  }, [isBlueprintLoading, config.uiRecipesList, uiRecipes])
 
   const UIPlugin: (props: IUIPlugin) => React.ReactElement =
     selectedRecipe.component
+
+  const recipes: UIRecipeItem[] | TUiRecipe[] = useMemo(
+    () => (config.uiRecipesList.length > 0 ? config.uiRecipesList : uiRecipes),
+    [config.uiRecipesList, uiRecipes]
+  )
 
   if (isLoading || !entity || isBlueprintLoading) {
     return <Loading />
   }
 
-  const recipeNames: string[] =
-    config.uiRecipesList.length > 0
-      ? config.uiRecipesList
-      : uiRecipes.map((recipe: TUiRecipe) => recipe.name)
   return (
     <Stack fullWidth grow={1} minHeight={0}>
       <TopBar style={{ width: '100%', flexShrink: 0 }}>
         <TopBar.Header>
-          <Logo aria-label='main-heading'>{entity.label}</Logo>
+          <S.Logo>{entity.label}</S.Logo>
           <AppSelector
-            items={recipeNames}
-            onSelectItem={(item) =>
-              setSelectedRecipe(getRecipeConfigAndPlugin(item))
-            }
+            isLoading={isBlueprintLoading}
+            items={recipes}
+            onSelectItem={(item) => {
+              const newSelectedRecipe = getRecipeConfigAndPlugin(
+                item,
+                uiRecipes,
+                getUiPlugin
+              )
+              setSelectedRecipe(newSelectedRecipe)
+            }}
             currentItem={selectedRecipe.name}
           />
         </TopBar.Header>
         <TopBar.Actions>
-          <Icons>
-            <ClickableIcon
-              onClick={() => setVisibleUserInfo(true)}
-              hidden={config.hideUserInfo}
-            >
-              <Icon data={account_circle} size={24} title='User' />
-            </ClickableIcon>
-            <ClickableIcon
-              onClick={() => setAboutOpen(true)}
-              hidden={config.hideAbout}
-            >
-              <Icon data={info_circle} size={24} title='About' />
-            </ClickableIcon>
-            {roles.map((r) => r.name).includes(config.adminRole) && (
-              <ClickableIcon
-                onClick={() => setIsMenuOpen(!isMenuOpen)}
-                ref={setAnchorEl}
-              >
-                <Icon data={menu} />
-              </ClickableIcon>
+          <Stack direction='row' alignItems='center' spacing={2}>
+            {!config.hideUserInfo && (
+              <UserInfoDialog applicationEntity={entity} />
             )}
-          </Icons>
-          <Menu
-            open={isMenuOpen}
-            id='menu-default'
-            aria-labelledby='anchor-default'
-            onClose={() => setIsMenuOpen(false)}
-            anchorEl={anchorEl}
-          >
-            <Menu.Item>
-              <Icon data={refresh} title='refresh_app' />
-              <Typography
-                group='navigation'
-                variant='menu_title'
-                as='span'
-                onClick={() => {
-                  dmssAPI
-                    .refreshLookup({ application: name })
-                    .then(() => {
-                      Object.keys(window.sessionStorage).forEach((key) => {
-                        if (key.startsWith('BLUEPRINT::'))
-                          window.sessionStorage.removeItem(key)
-                      })
-                      toast.success(`RecipeLookup for app '${name}' updated`)
-                    })
-                    .catch((error: any) => {
-                      console.error(error)
-                      toast.error(`Failed to refresh application '${name}'`)
-                    })
-                  setIsMenuOpen(false)
-                }}
-              >
-                Refresh application recipes
-              </Typography>
-            </Menu.Item>
-          </Menu>
+            {!config.hideAbout && <AboutDialog applicationEntity={entity} />}
+            {config.adminRole &&
+              roles.map((r) => r.name).includes(config.adminRole) && (
+                <AdminMenu />
+              )}
+          </Stack>
         </TopBar.Actions>
       </TopBar>
-      <AboutDialog
-        isOpen={aboutOpen}
-        setIsOpen={setAboutOpen}
-        applicationEntity={entity}
-      />
-      <UserInfoDialog
-        isOpen={visibleUserInfo}
-        setIsOpen={setVisibleUserInfo}
-        applicationEntity={entity}
-      />
       <Stack fullWidth grow={1} minHeight={0}>
         <UIPlugin
           key={idReference + selectedRecipe.name}

--- a/packages/dm-core-plugins/src/header/HeaderPlugin.types.ts
+++ b/packages/dm-core-plugins/src/header/HeaderPlugin.types.ts
@@ -1,0 +1,26 @@
+import type { IUIPlugin } from '@development-framework/dm-core'
+
+export type UIRecipeItem = {
+  label?: string
+  recipeName: string
+}
+
+export type THeaderPluginConfig = {
+  uiRecipesList: UIRecipeItem[]
+  hideUserInfo: boolean
+  hideAbout: boolean
+  adminRole?: string
+}
+
+export const defaultHeaderPluginConfig: THeaderPluginConfig = {
+  uiRecipesList: [],
+  hideUserInfo: false,
+  hideAbout: false,
+  adminRole: 'dmss-admin',
+}
+
+export type TRecipeConfigAndPlugin = {
+  config?: Record<string, any>
+  component: (props: IUIPlugin) => React.ReactElement
+  name: string
+}

--- a/packages/dm-core-plugins/src/header/HeaderPlugin.utils.ts
+++ b/packages/dm-core-plugins/src/header/HeaderPlugin.utils.ts
@@ -1,0 +1,18 @@
+import type { IUIPlugin, TUiRecipe } from '@development-framework/dm-core'
+import type { TRecipeConfigAndPlugin } from './HeaderPlugin.types'
+
+export function getRecipeConfigAndPlugin(
+  recipeName: string,
+  uiRecipes: TUiRecipe[],
+  getUiPlugin: (pluginName: string) => (props: IUIPlugin) => React.ReactElement
+): TRecipeConfigAndPlugin {
+  const recipe = uiRecipes.find(
+    (recipe: TUiRecipe) => recipe.name === recipeName
+  )
+  if (!recipe) throw new Error(`Failed to find recipe named '${recipeName}'`)
+  return {
+    component: getUiPlugin(recipe.plugin),
+    config: recipe?.config ?? {},
+    name: recipeName,
+  }
+}

--- a/packages/dm-core-plugins/src/header/components/AboutDialog.tsx
+++ b/packages/dm-core-plugins/src/header/components/AboutDialog.tsx
@@ -17,6 +17,7 @@ export const AboutDialog = (props: AboutDialogProps) => {
         aria-haspopup='dialog'
         aria-label='Open application information dialog'
         variant='ghost_icon'
+        data-testid='header-about-button'
         onClick={() => setIsInfoDialogOpen(true)}
       >
         <Icon data={info_circle} size={24} />
@@ -32,6 +33,7 @@ export const AboutDialog = (props: AboutDialogProps) => {
             aria-label='Close application information dialog'
             variant='ghost_icon'
             onClick={() => setIsInfoDialogOpen(false)}
+            data-testid='about-dialog-close-button'
           >
             <Icon data={close} size={16} />
           </Button>

--- a/packages/dm-core-plugins/src/header/components/AboutDialog.tsx
+++ b/packages/dm-core-plugins/src/header/components/AboutDialog.tsx
@@ -1,42 +1,46 @@
 import { Dialog, type TApplication } from '@development-framework/dm-core'
 import { Button, Icon } from '@equinor/eds-core-react'
-import { close } from '@equinor/eds-icons'
+import { close, info_circle } from '@equinor/eds-icons'
+import { useState } from 'react'
 
 type AboutDialogProps = {
-  isOpen: boolean
-  setIsOpen: (newValue: boolean) => void
   applicationEntity: TApplication
 }
 
 export const AboutDialog = (props: AboutDialogProps) => {
-  const { isOpen, setIsOpen, applicationEntity } = props
+  const { applicationEntity } = props
+  const [isInfoDialogOpen, setIsInfoDialogOpen] = useState(false)
 
   return (
-    <Dialog isDismissable open={isOpen} onClose={() => setIsOpen(false)}>
-      <div
-        style={{
-          minWidth: '291px',
-          maxWidth: '400px',
-        }}
+    <>
+      <Button
+        aria-haspopup='dialog'
+        aria-label='Open application information dialog'
+        variant='ghost_icon'
+        onClick={() => setIsInfoDialogOpen(true)}
+      >
+        <Icon data={info_circle} size={24} />
+      </Button>
+      <Dialog
+        isDismissable
+        open={isInfoDialogOpen}
+        onClose={() => setIsInfoDialogOpen(false)}
       >
         <Dialog.Header>
           <Dialog.Title>About {applicationEntity.label}</Dialog.Title>
           <Button
-            variant='ghost'
-            onClick={() => {
-              setIsOpen(false)
-            }}
+            aria-label='Close application information dialog'
+            variant='ghost_icon'
+            onClick={() => setIsInfoDialogOpen(false)}
           >
-            <Icon data={close} size={16} title='Close' />
+            <Icon data={close} size={16} />
           </Button>
         </Dialog.Header>
         <Dialog.CustomContent>
-          {applicationEntity.description}
+          {applicationEntity.description ||
+            'No description provided for this application.'}
         </Dialog.CustomContent>
-        <Dialog.Actions>
-          <Button onClick={() => setIsOpen(false)}>Ok</Button>
-        </Dialog.Actions>
-      </div>
-    </Dialog>
+      </Dialog>
+    </>
   )
 }

--- a/packages/dm-core-plugins/src/header/components/AdminMenu.tsx
+++ b/packages/dm-core-plugins/src/header/components/AdminMenu.tsx
@@ -1,0 +1,57 @@
+import { useApplication } from '@development-framework/dm-core'
+import { Button, Icon, Menu } from '@equinor/eds-core-react'
+import { menu, refresh } from '@equinor/eds-icons'
+import { useId, useRef, useState } from 'react'
+import { toast } from 'react-toastify'
+
+export function AdminMenu() {
+  const { dmssAPI, name } = useApplication()
+  const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false)
+  const menuButtonRef = useRef<HTMLButtonElement | null>(null)
+  const menuButtonId = useId()
+
+  function handleRefreshRecipes() {
+    dmssAPI
+      .refreshLookup({ application: name })
+      .then(() => {
+        Object.keys(window.sessionStorage).forEach((key) => {
+          if (key.startsWith('BLUEPRINT::'))
+            window.sessionStorage.removeItem(key)
+        })
+        toast.success(`RecipeLookup for app '${name}' updated`)
+      })
+      .catch((error: any) => {
+        console.error(error)
+        toast.error(`Failed to refresh application '${name}'`)
+      })
+    setIsMenuOpen(false)
+  }
+
+  return (
+    <>
+      <Button
+        aria-label='Open application menu'
+        aria-haspopup='menu'
+        aria-controls={`${menuButtonId}-menu`}
+        variant='ghost_icon'
+        id={menuButtonId}
+        onClick={() => setIsMenuOpen(!isMenuOpen)}
+        ref={menuButtonRef}
+      >
+        <Icon data={menu} size={24} />
+      </Button>
+      <Menu
+        anchorEl={menuButtonRef.current}
+        placement='bottom-end'
+        id={`${menuButtonId}-menu`}
+        open={isMenuOpen}
+        onClose={() => setIsMenuOpen(false)}
+      >
+        <Menu.Item onClick={handleRefreshRecipes}>
+          <Icon data={refresh} />
+          Refresh application recipes
+        </Menu.Item>
+      </Menu>
+    </>
+  )
+}

--- a/packages/dm-core-plugins/src/header/components/AdminMenu.tsx
+++ b/packages/dm-core-plugins/src/header/components/AdminMenu.tsx
@@ -30,7 +30,7 @@ export function AdminMenu() {
   return (
     <>
       <Button
-        aria-label='Open application menu'
+        aria-label='Open admin menu'
         aria-haspopup='menu'
         aria-controls={`${menuButtonId}-menu`}
         variant='ghost_icon'

--- a/packages/dm-core-plugins/src/header/components/AppSelector.tsx
+++ b/packages/dm-core-plugins/src/header/components/AppSelector.tsx
@@ -1,50 +1,71 @@
+import type { TUiRecipe } from '@development-framework/dm-core'
 import { Button, Icon, Menu } from '@equinor/eds-core-react'
 import { chevron_down, chevron_up } from '@equinor/eds-icons'
-import { useRef, useState } from 'react'
+import { useId, useRef, useState } from 'react'
+import type { UIRecipeItem } from '../HeaderPlugin.types'
 
 interface AppSelectorProps {
-  items: string[]
+  items: UIRecipeItem[] | TUiRecipe[]
   currentItem: string
   onSelectItem: (item: string) => void
+  isLoading?: boolean
 }
 
 export const AppSelector = ({
   onSelectItem,
   currentItem,
   items,
+  isLoading,
 }: AppSelectorProps) => {
   const [appSelectorOpen, setAppSelectorOpen] = useState<boolean>(false)
-  const referenceElement = useRef<HTMLDivElement | null>(null)
+  const appSelectorButtonRef = useRef<HTMLButtonElement | null>(null)
+  const appSelectorId = useId()
+
+  const listType =
+    items.length > 0 && 'recipeName' in items[0] ? 'UIRecipeItem' : 'TUiRecipe'
+
+  const normalizedList =
+    listType === 'UIRecipeItem'
+      ? (items as UIRecipeItem[]).map((item) => ({
+          name: item.recipeName,
+          label: item.label,
+        }))
+      : (items as TUiRecipe[]).map((item) => ({
+          name: item.name,
+          label: item.name,
+        }))
 
   return (
-    <div ref={referenceElement}>
+    <>
       <Button
         variant='ghost'
         onClick={() => setAppSelectorOpen(!appSelectorOpen)}
         aria-label='AppSelector'
+        aria-haspopup='menu'
+        aria-controls={`${appSelectorId}-menu`}
+        disabled={isLoading}
+        ref={appSelectorButtonRef}
+        id={appSelectorId}
       >
         {currentItem}
         <Icon data={appSelectorOpen ? chevron_up : chevron_down}></Icon>
       </Button>
       <Menu
         open={appSelectorOpen}
-        anchorEl={referenceElement.current}
+        anchorEl={appSelectorButtonRef.current}
         onClose={() => setAppSelectorOpen(false)}
+        id={`${appSelectorId}-menu`}
       >
-        {items.map((recipe: string, index: number) => (
+        {normalizedList.map((item, index: number) => (
           <Menu.Item
             key={index}
-            active={currentItem === recipe}
-            onClick={() => {
-              onSelectItem(recipe)
-              setAppSelectorOpen(false)
-            }}
-            aria-label={recipe}
+            active={currentItem === item.name}
+            onClick={() => onSelectItem(item.name)}
           >
-            {recipe}
+            {item.label || item.name}
           </Menu.Item>
         ))}
       </Menu>
-    </div>
+    </>
   )
 }

--- a/packages/dm-core-plugins/src/header/components/AppSelector.tsx
+++ b/packages/dm-core-plugins/src/header/components/AppSelector.tsx
@@ -43,6 +43,7 @@ export const AppSelector = ({
         aria-label='AppSelector'
         aria-haspopup='menu'
         aria-controls={`${appSelectorId}-menu`}
+        data-testid='application-selector-button'
         disabled={isLoading}
         ref={appSelectorButtonRef}
         id={appSelectorId}

--- a/packages/dm-core-plugins/src/header/components/UserInfoDialog.tsx
+++ b/packages/dm-core-plugins/src/header/components/UserInfoDialog.tsx
@@ -5,166 +5,143 @@ import {
   useApplication,
 } from '@development-framework/dm-core'
 import { Button, Icon, Radio, Typography } from '@equinor/eds-core-react'
-import { close } from '@equinor/eds-icons'
+import { account_circle, close } from '@equinor/eds-icons'
 import type { AxiosResponse } from 'axios'
-import { useContext, useState } from 'react'
+import { useContext, useId, useState } from 'react'
 import { AuthContext } from 'react-oauth2-code-pkce'
 import { toast } from 'react-toastify'
-import styled from 'styled-components'
-
-const UnstyledList = styled.ul`
-  margin: 0;
-  padding: 0;
-  list-style-type: none;
-  display: inline-flex;
-`
-
-const Row = styled.div`
-  display: flex;
-  flex-direction: row;
-  margin: 5px;
-
-  > * {
-    margin-left: 10px;
-  }
-`
-
-const UserInfoLabel = styled.b`
-  margin-left: 5px;
-`
-
-const FlexRow = styled.div`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: 0.5rem;
-`
+import { Stack } from '../../common'
 
 type UserInfoDialogProps = {
-  isOpen: boolean
-  setIsOpen: (newValue: boolean) => void
   applicationEntity: TApplication
 }
 
 export const UserInfoDialog = (props: UserInfoDialogProps) => {
-  const { isOpen, setIsOpen } = props
+  const [isUserInfoDialogOpen, setIsUserInfoDialogOpen] = useState(false)
   const [apiKey, setAPIKey] = useState<string | null>(null)
   const { tokenData, token, logOut } = useContext(AuthContext)
-  const { dmssAPI, role, setRole, roles, name } = useApplication()
+  const { dmssAPI, role, setRole, roles } = useApplication()
   const [selectedRole, setSelectedRole] = useState<TRole>(role)
+  const uiRoleRadioGroupId = useId()
 
   return (
-    <Dialog
-      isDismissable
-      open={isOpen}
-      onClose={() => {
-        setSelectedRole(role)
-        setIsOpen(false)
-      }}
-    >
-      <div
-        style={{
-          minWidth: '720px',
-          width: 'fit-content',
+    <>
+      <Button
+        aria-haspopup='dialog'
+        aria-label='Open user information dialog'
+        variant='ghost_icon'
+        onClick={() => setIsUserInfoDialogOpen(true)}
+      >
+        <Icon data={account_circle} size={24} title='User' />
+      </Button>
+      <Dialog
+        isDismissable
+        open={isUserInfoDialogOpen}
+        onClose={() => {
+          setSelectedRole(role)
+          setIsUserInfoDialogOpen(false)
         }}
       >
         <Dialog.Header>
           <Dialog.Title>User info</Dialog.Title>
           <Button
-            variant='ghost'
+            aria-label='Close user information dialog'
+            variant='ghost_icon'
             onClick={() => {
               setSelectedRole(role)
-              setIsOpen(false)
+              setIsUserInfoDialogOpen(false)
             }}
           >
-            <Icon data={close} size={16} title='Close' />
+            <Icon data={close} size={16} />
           </Button>
         </Dialog.Header>
-        <Dialog.CustomContent>
-          <Row>
-            Name:
-            <UserInfoLabel>
-              {tokenData?.name || 'Not authenticated'}
-            </UserInfoLabel>
-          </Row>
-          <Row>
-            Username:
-            <UserInfoLabel>
-              {tokenData?.preferred_username || 'Not authenticated'}
-            </UserInfoLabel>
-          </Row>
-          {apiKey && (
-            <Row>
-              API Key:
-              <pre>{apiKey}</pre>
-            </Row>
-          )}
-
-          {roles.length > 1 && (
-            <>
-              <Typography variant='h6'>Chose role (UI only)</Typography>
-              <UnstyledList>
-                {roles.map((role: TRole) => (
-                  <li key={role.name}>
+        <Dialog.Content>
+          <Stack spacing={1}>
+            <Stack spacing={0.25}>
+              <Typography variant='body_short'>
+                Name: <b>{tokenData?.name || 'Not authenticated'}</b>
+              </Typography>
+              <Typography variant='body_short'>
+                Username:{' '}
+                <b>{tokenData?.preferred_username || 'Not authenticated'}</b>
+              </Typography>
+              {apiKey && (
+                <Typography variant='body_short'>
+                  API Key:{' '}
+                  <pre
+                    style={{ display: 'inline-block', padding: 0, margin: 0 }}
+                  >
+                    {apiKey}
+                  </pre>
+                </Typography>
+              )}
+            </Stack>
+            {roles.length > 1 && (
+              <div>
+                <Typography variant='h6' id={`${uiRoleRadioGroupId}_label`}>
+                  Chose role (UI only)
+                </Typography>
+                <Stack
+                  role='radiogroup'
+                  aria-labelledby={`${uiRoleRadioGroupId}_label`}
+                  direction='row'
+                  spacing={0.75}
+                >
+                  {roles.map((role: TRole) => (
                     <Radio
+                      key={role.name}
                       label={role.label}
                       name='impersonate-role'
                       value={role.name}
                       checked={role.name === selectedRole.name}
                       onChange={() => setSelectedRole(role)}
                     />
-                  </li>
-                ))}
-              </UnstyledList>
-            </>
-          )}
-        </Dialog.CustomContent>
+                  ))}
+                </Stack>
+              </div>
+            )}
+          </Stack>
+        </Dialog.Content>
         <Dialog.Actions>
-          <FlexRow style={{ justifyContent: 'space-between', width: '100%' }}>
-            <FlexRow>
-              <Button
-                variant='ghost'
-                onClick={() => {
-                  navigator.clipboard.writeText(token)
-                  toast.success('Copied token to clipboard')
-                }}
-              >
-                Copy token to clipboard
-              </Button>
-              <Button
-                variant='ghost'
-                onClick={() =>
-                  dmssAPI
-                    .tokenCreate()
-                    .then((response: AxiosResponse<string>) =>
-                      setAPIKey(response.data)
-                    )
-                    .catch((error: any) => {
-                      console.error(error)
-                      toast.error('Failed to create personal access token')
-                    })
-                }
-              >
-                Create API-Key
-              </Button>
-            </FlexRow>
-            <FlexRow>
-              <Button variant='ghost' color='danger' onClick={() => logOut()}>
-                Log out
-              </Button>
-              <Button
-                onClick={() => {
-                  setRole(selectedRole)
-                  setIsOpen(false)
-                }}
-                disabled={role === selectedRole}
-              >
-                Save
-              </Button>
-            </FlexRow>
-          </FlexRow>
+          <Button
+            variant='ghost'
+            onClick={() => {
+              navigator.clipboard.writeText(token)
+              toast.success('Copied token to clipboard')
+            }}
+          >
+            Copy token to clipboard
+          </Button>
+          <Button
+            variant='ghost'
+            onClick={() =>
+              dmssAPI
+                .tokenCreate()
+                .then((response: AxiosResponse<string>) =>
+                  setAPIKey(response.data)
+                )
+                .catch((error: any) => {
+                  console.error(error)
+                  toast.error('Failed to create personal access token')
+                })
+            }
+          >
+            Create API-Key
+          </Button>
+          <Button variant='ghost' color='danger' onClick={() => logOut()}>
+            Log out
+          </Button>
+          <Button
+            onClick={() => {
+              setRole(selectedRole)
+              setIsUserInfoDialogOpen(false)
+            }}
+            disabled={role === selectedRole}
+          >
+            Save
+          </Button>
         </Dialog.Actions>
-      </div>
-    </Dialog>
+      </Dialog>
+    </>
   )
 }

--- a/packages/dm-core-plugins/src/header/components/UserInfoDialog.tsx
+++ b/packages/dm-core-plugins/src/header/components/UserInfoDialog.tsx
@@ -29,10 +29,11 @@ export const UserInfoDialog = (props: UserInfoDialogProps) => {
       <Button
         aria-haspopup='dialog'
         aria-label='Open user information dialog'
+        data-testid='header-user-info-button'
         variant='ghost_icon'
         onClick={() => setIsUserInfoDialogOpen(true)}
       >
-        <Icon data={account_circle} size={24} title='User' />
+        <Icon data={account_circle} size={24} />
       </Button>
       <Dialog
         isDismissable

--- a/packages/dm-core-plugins/src/header/components/UserInfoDialog.tsx
+++ b/packages/dm-core-plugins/src/header/components/UserInfoDialog.tsx
@@ -93,6 +93,7 @@ export const UserInfoDialog = (props: UserInfoDialogProps) => {
                       key={role.name}
                       label={role.label}
                       name='impersonate-role'
+                      data-testid={`impersonate-role-${role.name}`}
                       value={role.name}
                       checked={role.name === selectedRole.name}
                       onChange={() => setSelectedRole(role)}

--- a/packages/dm-core/src/layout/Stack/styles.ts
+++ b/packages/dm-core/src/layout/Stack/styles.ts
@@ -5,7 +5,7 @@ import type { StackProps } from './types'
 const props_to_pass: string[] = [
   'children',
   'style',
-  'date-testid',
+  'data-testid',
   'id',
   'className',
 ]


### PR DESCRIPTION
## What does this pull request change?
- refactor! uiRecipesList in HeaderPluginConfig now expects list of objects (label, recipeName) instead of string (recipeName)
- refactor: general cleanup of HeaderPlugin
  - minimise use of custom components
  - split code into multiple files
  - cleanup incorrect use of titles and aria-attributes + add missing aria-attributes and form connections

## Why is this pull request needed?
User and PO requested the ability to configure labels for the appselector list of recipes
https://equinor.slack.com/archives/C050WG4NYGM/p1760600697075809

## Issues related to this change
#1536 
