### PR TITLE
chore: bundle dependabot pull requests by version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,19 +10,10 @@ updates:
     labels:
       - "dependencies"
     groups:
-      equinor-eds:
-        patterns:
-          - "@equinor/eds-*"
-      testing:
-        patterns:
-          - "@testing-library/*"
-          - "jest*"
-          - "@types/jest"
-      types:
-        patterns:
-          - "@types/*"
-        exclude-patterns:
-          - "@types/jest"
+      web:
+        update-types:
+          - "minor"
+          - "patch"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## What does this pull request change?
This update consolidates the handling of dependabot pull requests by version, specifically focusing on minor and patch updates for web dependencies.

## Why is this pull request needed?
This change simplifies dependency management and ensures that updates are grouped effectively, improving the overall maintenance process.

## Issues related to this change
None.

